### PR TITLE
feat(dashboard): adopt landing-page logo across the SPA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -514,6 +514,7 @@ src/dashboard/dist/
 # Dashboard build output bundled into API host (generated)
 src/WebhookEngine.API/wwwroot/index.html
 src/WebhookEngine.API/wwwroot/assets/
+src/WebhookEngine.API/wwwroot/favicon.svg
 
 # Environment files
 .env

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="theme-color" content="#0C1018" />
     <title>WebhookEngine</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/src/dashboard/public/favicon.svg
+++ b/src/dashboard/public/favicon.svg
@@ -1,0 +1,10 @@
+<svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="1" y="1" width="28" height="28" rx="7" fill="#0C1018" stroke="#1C2535"/>
+  <path d="M8 15 L13 10 L18 15 L13 20 Z" fill="none" stroke="#3EFFA0" stroke-width="1.5" stroke-linejoin="round"/>
+  <circle cx="21" cy="10" r="2" fill="#3EFFA0" opacity="0.6"/>
+  <circle cx="21" cy="15" r="2" fill="#3EFFA0"/>
+  <circle cx="21" cy="20" r="2" fill="#3EFFA0" opacity="0.4"/>
+  <line x1="18" y1="15" x2="19" y2="15" stroke="#3EFFA0" stroke-width="1.5"/>
+  <line x1="18" y1="10.5" x2="19" y2="10.2" stroke="#3EFFA0" stroke-width="1" opacity="0.5"/>
+  <line x1="18" y1="19.5" x2="19" y2="19.8" stroke="#3EFFA0" stroke-width="1" opacity="0.3"/>
+</svg>

--- a/src/dashboard/src/components/Logo.tsx
+++ b/src/dashboard/src/components/Logo.tsx
@@ -1,0 +1,64 @@
+interface LogoProps {
+  /** Pixel size of the square logo. Defaults to 30 to match the landing page. */
+  size?: number;
+  className?: string;
+  /** Render only the icon, no surrounding rounded background. */
+  bare?: boolean;
+}
+
+/**
+ * The WebhookEngine mark — a fan-out from a diamond into three accent dots,
+ * shared with the landing page so the brand reads consistently across surfaces.
+ */
+export function Logo({ size = 30, className, bare = false }: LogoProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 30 30"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label="WebhookEngine"
+      className={className}
+    >
+      {!bare && (
+        <rect x="1" y="1" width="28" height="28" rx="7" fill="#0C1018" stroke="#1C2535" />
+      )}
+      <path
+        d="M8 15 L13 10 L18 15 L13 20 Z"
+        fill="none"
+        stroke="#3EFFA0"
+        strokeWidth="1.5"
+        strokeLinejoin="round"
+      />
+      <circle cx="21" cy="10" r="2" fill="#3EFFA0" opacity="0.6" />
+      <circle cx="21" cy="15" r="2" fill="#3EFFA0" />
+      <circle cx="21" cy="20" r="2" fill="#3EFFA0" opacity="0.4" />
+      <line x1="18" y1="15" x2="19" y2="15" stroke="#3EFFA0" strokeWidth="1.5" />
+      <line x1="18" y1="10.5" x2="19" y2="10.2" stroke="#3EFFA0" strokeWidth="1" opacity="0.5" />
+      <line x1="18" y1="19.5" x2="19" y2="19.8" stroke="#3EFFA0" strokeWidth="1" opacity="0.3" />
+    </svg>
+  );
+}
+
+interface LogoWordmarkProps {
+  size?: number;
+  className?: string;
+}
+
+/**
+ * The full lockup: icon + "WebhookEngine" wordmark with the accent split
+ * (Webhook in the body color, Engine in the accent color), matching the
+ * landing-page header.
+ */
+export function LogoWordmark({ size = 24, className }: LogoWordmarkProps) {
+  return (
+    <span className={`inline-flex items-center gap-2 ${className ?? ""}`}>
+      <Logo size={size} />
+      <span className="text-sm font-semibold tracking-tight">
+        Webhook<span className="text-accent">Engine</span>
+      </span>
+    </span>
+  );
+}

--- a/src/dashboard/src/layout/AppShell.tsx
+++ b/src/dashboard/src/layout/AppShell.tsx
@@ -1,5 +1,6 @@
 import { NavLink, Outlet, useNavigate } from "react-router";
 import { useAuth } from "../auth/AuthContext";
+import { Logo } from "../components/Logo";
 import {
   LayoutDashboard,
   Box,
@@ -7,7 +8,6 @@ import {
   Waypoints,
   Mail,
   LogOut,
-  Webhook,
   ChevronRight
 } from "lucide-react";
 
@@ -35,14 +35,10 @@ export function AppShell() {
         {/* Brand */}
         <div className="px-4 pt-5 pb-4 border-b border-border-subtle">
           <div className="flex items-center gap-2">
-            <div className="w-7 h-7 rounded-md bg-accent/10 flex items-center justify-center">
-              <Webhook className="w-4 h-4 text-accent" />
-            </div>
-            <div>
-              <span className="text-sm font-semibold text-text-primary tracking-tight">
-                WebhookEngine
-              </span>
-            </div>
+            <Logo size={28} />
+            <span className="text-sm font-semibold text-text-primary tracking-tight">
+              Webhook<span className="text-accent">Engine</span>
+            </span>
           </div>
         </div>
 

--- a/src/dashboard/src/pages/LoginPage.tsx
+++ b/src/dashboard/src/pages/LoginPage.tsx
@@ -1,7 +1,8 @@
 import { FormEvent, useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
 import { useAuth } from "../auth/AuthContext";
-import { Webhook, ArrowRight, AlertCircle, Loader2 } from "lucide-react";
+import { Logo } from "../components/Logo";
+import { ArrowRight, AlertCircle, Loader2 } from "lucide-react";
 
 interface LocationState {
   from?: string;
@@ -51,10 +52,10 @@ export function LoginPage() {
       <div className="relative w-full max-w-sm animate-fade-in-up">
         {/* Brand */}
         <div className="flex items-center gap-2.5 mb-8">
-          <div className="w-8 h-8 rounded-lg bg-accent/10 flex items-center justify-center">
-            <Webhook className="w-5 h-5 text-accent" />
-          </div>
-          <span className="text-lg font-semibold tracking-tight">WebhookEngine</span>
+          <Logo size={32} />
+          <span className="text-lg font-semibold tracking-tight">
+            Webhook<span className="text-accent">Engine</span>
+          </span>
         </div>
 
         {/* Card */}


### PR DESCRIPTION
## Why

The dashboard sidebar and login screen rendered a generic Lucide \`Webhook\` glyph; the landing page already ships a custom mark (diamond fanning out to three accent dots). Brand consistency.

## What changed

- New \`Logo\` + \`LogoWordmark\` components in \`src/dashboard/src/components/Logo.tsx\` (size prop + optional bare mode)
- Sidebar brand area in \`AppShell.tsx\` uses \`<Logo size={28} />\` + the split wordmark (\`Webhook\` + accent \`Engine\`)
- \`LoginPage\` header uses \`<Logo size={32} />\` with the same wordmark
- Browser tab gets \`/favicon.svg\` (Vite \`public/\` asset bundled into \`wwwroot\`)
- \`<meta name=\"theme-color\" content=\"#0C1018\">\` in \`index.html\` matches the logo backplate
- \`.gitignore\` allowlist extended for the generated \`wwwroot/favicon.svg\`

## Test plan

- [x] \`bun run typecheck\` — passes
- [x] \`bun run lint\` — passes
- [x] \`bun run build\` — passes
- [ ] CI green on PR
- [ ] Visual check: sidebar logo + login logo + browser-tab favicon all show the diamond+dots mark