### PR TITLE
ci: deploy Pages only when landing-page content changes

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,56 @@
+name: Deploy Pages
+
+# Replaces the legacy Jekyll-on-every-push behavior. Only runs when the
+# landing-page content actually changes, when a release is published, or
+# when manually triggered. Dependabot / API / docs / CI churn no longer
+# produces a Pages deployment.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "index.html"
+      - "CNAME"
+      - "robots.txt"
+      - "sitemap.xml"
+      - ".github/workflows/pages.yml"
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy landing page
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Stage static site
+        run: |
+          mkdir -p _site
+          cp index.html CNAME robots.txt sitemap.xml _site/
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Replace the legacy Jekyll \"deploy on every main push\" behavior with a dedicated GitHub Actions workflow.
- Trigger only when landing-page assets change (\`index.html\`, \`CNAME\`, \`robots.txt\`, \`sitemap.xml\`), on \`release: published\`, or via \`workflow_dispatch\`.
- Dependabot, CodeQL, API/worker, and docs changes will no longer produce a Pages deployment.

## Why
We have 24 \`github-pages\` deployments on the repo, but only ~3-5 commits actually changed the landing page. Every dependency bump and security PR was creating a Pages deployment too. Path-filtering keeps the deployment list aligned with what actually shipped.

## Post-merge steps (out of band)
1. Switch repo Pages source from "Deploy from a branch" to **"GitHub Actions"** (\`build_type=workflow\`).
2. Manually trigger the workflow once to confirm the new pipeline deploys correctly.
3. Clean up the historical 24 deployments via the API once the new flow is verified.

## Labels
\`ci\`, \`enhancement\`

## Test plan
- [ ] Workflow YAML parses cleanly (syntax check on push).
- [ ] After merging and switching the source, \`workflow_dispatch\` produces a successful deployment.
- [ ] Modifying a non-landing file (e.g. a docs README) on \`main\` does NOT enqueue a Pages deployment.
- [ ] Modifying \`index.html\` does enqueue a deployment.