### PR TITLE
docs: sync roadmap and README after ADR-003 Phase 3 close

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Self-hosted webhook delivery platform with reliable at-least-once delivery, expo
 - **Circuit breaker** -- per-endpoint, auto-opens after 5 consecutive failures, 5-minute cooldown
 - **HMAC-SHA256 signing** -- Standard Webhooks spec (`webhook-id`, `webhook-timestamp`, `webhook-signature`)
 - **Idempotency** -- optional `idempotencyKey` prevents duplicate deliveries
+- **Payload transformation** -- per-endpoint JMESPath expression reshapes the body before signing; fail-open with timeout and output-size guards (ADR-003); live editor in the dashboard
 - **Real-time dashboard** -- React SPA with live delivery feed via SignalR
 - **Single process** -- API + background workers + dashboard served from one ASP.NET Core host
 - **Data retention** -- automatic cleanup (delivered: 30 days, dead-letter: 90 days)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,10 +1,10 @@
 # Roadmap
 # WebhookEngine — Strategic Roadmap
 
-**Last Updated:** 2026-05-04
+**Last Updated:** 2026-05-05
 **Status:** Active — Phase 2 (Traction & Feedback)
 
-> **Note:** Phase 1 is complete (launch posts and the engineering blog post remain deferred). Phase 2 core tasks (2.2, 2.3, 2.4) are done. Remaining Phase 2 items (payload transformation, TypeScript SDK, application layer cleanup) are planned.
+> **Note:** Phase 1 is complete (launch posts and the engineering blog post remain deferred). Phase 2 core tasks (2.2, 2.3, 2.4, **2.5 payload transformation across all three rollout phases**, 2.7 application layer cleanup) are done. Remaining Phase 2 items (TypeScript SDK gated on demand signal, comparison/best-practice blog posts) are planned.
 
 ---
 
@@ -90,9 +90,9 @@ Patch release focused on project discoverability and packaging hygiene. No new e
 | 2.2 | Event replay (re-deliver events in a time range) | P1 | Almost certain user request | done |
 | 2.3 | Batch message sending (multiple events in one API call) | P1 | API power users | done |
 | 2.4 | Rate limiting per endpoint | P1 | Large-scale users | done |
-| 2.5 | Webhook payload transformation (modify before delivery) | P2 | Integration use cases | planned |
+| 2.5 | Webhook payload transformation (JMESPath, ADR-003 — schema, delivery integration, dashboard editor) | P2 | Integration use cases | done |
 | 2.6 | TypeScript SDK (npm) | P1 | If demand signal exists | planned |
-| 2.7 | Application layer cleanup (implement CQRS or remove scaffold) | P1 | Tech debt | planned |
+| 2.7 | Application layer cleanup (implement CQRS or remove scaffold) | P1 | Tech debt | done |
 | 2.8 | Blog: "Webhook Delivery Best Practices" | P1 | SEO + authority | planned |
 | 2.9 | Blog: "WebhookEngine vs Svix vs Convoy" | P1 | SEO + positioning | planned |
 | 2.10 | Integration guide: ABP Framework + WebhookEngine | P2 | .NET ecosystem reach | planned |


### PR DESCRIPTION
## Summary
- \`docs/ROADMAP.md\`: 2.5 (Webhook payload transformation) marked **done** — all three rollout phases shipped (schema + API, delivery integration, dashboard editor). 2.7 (Application layer cleanup) marked **done**. Status note updated.
- \`README.md\`: payload transformation listed under Features.

## Why
Phase 3 dashboard editor merged in #16 yesterday but ROADMAP and README still showed both items as planned. Bringing the public-facing docs in sync.

## Labels
\`documentation\`

## Test plan
- [ ] Markdown renders correctly on GitHub
- [ ] Roadmap status notes match the actual state of the repo