### PR TITLE
test(worker): end-to-end DeliveryWorker coverage with Testcontainers

### DIFF
--- a/tests/WebhookEngine.Infrastructure.Tests/EndToEnd/DeliveryFlowEndToEndTests.cs
+++ b/tests/WebhookEngine.Infrastructure.Tests/EndToEnd/DeliveryFlowEndToEndTests.cs
@@ -1,0 +1,303 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using WebhookEngine.Core.Entities;
+using WebhookEngine.Core.Enums;
+using WebhookEngine.Core.Interfaces;
+using WebhookEngine.Core.Models;
+using WebhookEngine.Core.Options;
+using WebhookEngine.Core.StateMachine;
+using WebhookEngine.Infrastructure.Data;
+using WebhookEngine.Infrastructure.Queue;
+using WebhookEngine.Infrastructure.Repositories;
+using WebhookEngine.Infrastructure.Services;
+using WebhookEngine.Worker;
+using ApplicationEntity = WebhookEngine.Core.Entities.Application;
+
+namespace WebhookEngine.Infrastructure.Tests.EndToEnd;
+
+/// <summary>
+/// End-to-end coverage for <see cref="DeliveryWorker"/> against a real
+/// PostgreSQL database. The outbound HTTP call is the only mocked piece —
+/// queue, repositories, state machine, signing, and circuit-breaker tracking
+/// all run their production code paths so the assertions reflect what would
+/// actually happen on a live system.
+///
+/// Each test boots a fresh service provider and a fresh worker so the
+/// scenarios cannot interfere with each other.
+/// </summary>
+public class DeliveryFlowEndToEndTests : IClassFixture<PostgresFixture>
+{
+    private readonly PostgresFixture _fixture;
+
+    public DeliveryFlowEndToEndTests(PostgresFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task Successful_Delivery_Marks_Message_As_Delivered()
+    {
+        await _fixture.ResetAsync();
+
+        var deliveryService = Substitute.For<IDeliveryService>();
+        deliveryService
+            .DeliverAsync(Arg.Any<DeliveryRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new DeliveryResult { Success = true, StatusCode = 200, LatencyMs = 42 });
+
+        await using var sp = BuildServiceProvider(deliveryService);
+        var seed = await SeedAsync(sp);
+        await EnqueueMessageAsync(sp, seed);
+
+        await RunWorkerOnceAsync(sp);
+
+        var message = await GetMessageAsync(sp, seed.MessageId);
+        message.Status.Should().Be(MessageStatus.Delivered);
+        message.AttemptCount.Should().Be(1);
+        message.DeliveredAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Failed_Delivery_Increments_Attempt_And_Schedules_Retry()
+    {
+        await _fixture.ResetAsync();
+
+        var deliveryService = Substitute.For<IDeliveryService>();
+        deliveryService
+            .DeliverAsync(Arg.Any<DeliveryRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new DeliveryResult { Success = false, StatusCode = 500, Error = "Server error", LatencyMs = 30 });
+
+        await using var sp = BuildServiceProvider(deliveryService);
+        var seed = await SeedAsync(sp);
+        await EnqueueMessageAsync(sp, seed);
+
+        await RunWorkerOnceAsync(sp);
+
+        var message = await GetMessageAsync(sp, seed.MessageId);
+        message.Status.Should().Be(MessageStatus.Failed);
+        message.AttemptCount.Should().Be(1);
+        message.DeliveredAt.Should().BeNull();
+        // RetryScheduler will move it back to Pending later; for now the row
+        // sits as Failed with a future ScheduledAt set by the worker.
+        message.ScheduledAt.Should().BeAfter(DateTime.UtcNow.AddSeconds(-5));
+
+        // The error landed on the attempt row (one-to-many), not the message
+        // itself; verify it survived the round-trip.
+        using var scope = sp.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+        var attempt = await db.MessageAttempts.AsNoTracking()
+            .Where(a => a.MessageId == seed.MessageId)
+            .OrderByDescending(a => a.CreatedAt)
+            .FirstAsync();
+        attempt.Status.Should().Be(AttemptStatus.Failed);
+    }
+
+    [Fact]
+    public async Task Exhausted_Retries_Move_Message_To_DeadLetter()
+    {
+        await _fixture.ResetAsync();
+
+        var deliveryService = Substitute.For<IDeliveryService>();
+        deliveryService
+            .DeliverAsync(Arg.Any<DeliveryRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new DeliveryResult { Success = false, StatusCode = 500, Error = "Server error", LatencyMs = 30 });
+
+        await using var sp = BuildServiceProvider(deliveryService);
+        var seed = await SeedAsync(sp);
+        // Pre-set the message to its last allowed attempt so the next failure
+        // pushes it across the dead-letter threshold without us needing to
+        // wait for seven real retry cycles.
+        await EnqueueMessageAsync(sp, seed, attemptCount: 6, maxRetries: 7);
+
+        await RunWorkerOnceAsync(sp);
+
+        var message = await GetMessageAsync(sp, seed.MessageId);
+        message.Status.Should().Be(MessageStatus.DeadLetter);
+        message.AttemptCount.Should().Be(7);
+    }
+
+    [Fact]
+    public async Task Repeated_Failures_Open_Endpoint_Circuit()
+    {
+        await _fixture.ResetAsync();
+
+        var deliveryService = Substitute.For<IDeliveryService>();
+        deliveryService
+            .DeliverAsync(Arg.Any<DeliveryRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new DeliveryResult { Success = false, StatusCode = 500, Error = "Server error", LatencyMs = 30 });
+
+        await using var sp = BuildServiceProvider(deliveryService);
+        var seed = await SeedAsync(sp);
+
+        // Default circuit-breaker threshold is 5 consecutive failures, so
+        // we enqueue and process six independent messages back-to-back to
+        // make sure the circuit moves to Open.
+        for (var i = 0; i < 6; i++)
+        {
+            await EnqueueMessageAsync(sp, seed, suffix: i.ToString());
+            await RunWorkerOnceAsync(sp);
+        }
+
+        using var scope = sp.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+        var health = await db.EndpointHealths.AsNoTracking()
+            .FirstAsync(h => h.EndpointId == seed.EndpointId);
+
+        health.CircuitState.Should().Be(CircuitState.Open);
+        health.ConsecutiveFailures.Should().BeGreaterThanOrEqualTo(5);
+    }
+
+    // ── Plumbing ───────────────────────────────────────
+
+    private ServiceProvider BuildServiceProvider(IDeliveryService deliveryServiceMock)
+    {
+        var services = new ServiceCollection();
+
+        services.AddLogging(b => b.SetMinimumLevel(LogLevel.Warning));
+
+        services.AddDbContext<WebhookDbContext>(o => o.UseNpgsql(_fixture.ConnectionString));
+
+        services.AddScoped<ApplicationRepository>();
+        services.AddScoped<EndpointRepository>();
+        services.AddScoped<MessageRepository>();
+        services.AddScoped<EventTypeRepository>();
+
+        services.AddScoped<IMessageQueue, PostgresMessageQueue>();
+        services.AddSingleton<ISigningService, HmacSigningService>();
+        services.AddScoped<IEndpointHealthTracker, EndpointHealthTracker>();
+        services.AddSingleton<IEndpointRateLimiter, EndpointRateLimiter>();
+        services.AddSingleton<IMessageStateMachine, MessageStateMachine>();
+
+        services.AddSingleton<IDeliveryService>(deliveryServiceMock);
+
+        services.Configure<DeliveryOptions>(o =>
+        {
+            o.PollIntervalMs = 50;
+            o.BatchSize = 10;
+        });
+        services.Configure<RetryPolicyOptions>(_ => { });
+        services.Configure<CircuitBreakerOptions>(_ => { });
+        services.Configure<TransformationOptions>(_ => { });
+
+        services.AddSingleton<IPayloadTransformer, JmesPathPayloadTransformer>();
+
+        services.AddSingleton<DeliveryWorker>();
+
+        return services.BuildServiceProvider();
+    }
+
+    /// <summary>
+    /// Spins the worker up just long enough to drain the queue once. The 50 ms
+    /// poll interval combined with a 1.2 s wait gives ~20 polling chances —
+    /// far more than the single iteration each scenario needs.
+    /// </summary>
+    private static async Task RunWorkerOnceAsync(IServiceProvider sp)
+    {
+        var worker = sp.GetRequiredService<DeliveryWorker>();
+        using var cts = new CancellationTokenSource();
+
+        await worker.StartAsync(cts.Token);
+        await Task.Delay(1200);
+        await cts.CancelAsync();
+        await worker.StopAsync(CancellationToken.None);
+    }
+
+    private static async Task<SeedIds> SeedAsync(IServiceProvider sp)
+    {
+        using var scope = sp.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+
+        var app = new ApplicationEntity
+        {
+            Id = Guid.NewGuid(),
+            Name = "E2E App",
+            ApiKeyPrefix = "whe_e2e_",
+            ApiKeyHash = "hash",
+            SigningSecret = "whsec_e2e_secret_for_signing_messages_in_tests"
+        };
+
+        var endpoint = new Endpoint
+        {
+            Id = Guid.NewGuid(),
+            AppId = app.Id,
+            Url = "https://example.invalid/webhook",
+            Status = EndpointStatus.Active
+        };
+
+        var eventType = new EventType
+        {
+            Id = Guid.NewGuid(),
+            AppId = app.Id,
+            Name = "test.event"
+        };
+
+        db.Applications.Add(app);
+        db.Endpoints.Add(endpoint);
+        db.EventTypes.Add(eventType);
+        await db.SaveChangesAsync();
+
+        return new SeedIds(app.Id, endpoint.Id, eventType.Id, Guid.Empty);
+    }
+
+    private static async Task EnqueueMessageAsync(
+        IServiceProvider sp,
+        SeedIds seed,
+        string suffix = "",
+        int attemptCount = 0,
+        int maxRetries = 7)
+    {
+        using var scope = sp.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+
+        var message = new Message
+        {
+            Id = Guid.NewGuid(),
+            AppId = seed.AppId,
+            EndpointId = seed.EndpointId,
+            EventTypeId = seed.EventTypeId,
+            EventId = $"evt_{suffix}_{Guid.NewGuid():N}"[..32],
+            Payload = """{"hello":"world"}""",
+            Status = MessageStatus.Pending,
+            AttemptCount = attemptCount,
+            MaxRetries = maxRetries,
+            ScheduledAt = DateTime.UtcNow.AddSeconds(-1)
+        };
+
+        db.Messages.Add(message);
+        await db.SaveChangesAsync();
+
+        // Seed the message id back into the seed record for the caller to read.
+        seed.LastMessageIdSetter(message.Id);
+    }
+
+    private static async Task<Message> GetMessageAsync(IServiceProvider sp, Guid messageId)
+    {
+        using var scope = sp.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+        return await db.Messages.AsNoTracking().FirstAsync(m => m.Id == messageId);
+    }
+
+    private sealed class SeedIds
+    {
+        public SeedIds(Guid appId, Guid endpointId, Guid eventTypeId, Guid messageId)
+        {
+            AppId = appId;
+            EndpointId = endpointId;
+            EventTypeId = eventTypeId;
+            MessageId = messageId;
+        }
+
+        public Guid AppId { get; }
+        public Guid EndpointId { get; }
+        public Guid EventTypeId { get; }
+        public Guid MessageId { get; private set; }
+
+        // Stored as a delegate so the immutable-ish record can still be
+        // updated by the helper that creates the message row.
+        public Action<Guid> LastMessageIdSetter => id => MessageId = id;
+    }
+}

--- a/tests/WebhookEngine.Infrastructure.Tests/EndToEnd/PostgresFixture.cs
+++ b/tests/WebhookEngine.Infrastructure.Tests/EndToEnd/PostgresFixture.cs
@@ -1,0 +1,69 @@
+using Microsoft.EntityFrameworkCore;
+using Testcontainers.PostgreSql;
+using WebhookEngine.Infrastructure.Data;
+
+namespace WebhookEngine.Infrastructure.Tests.EndToEnd;
+
+/// <summary>
+/// Spins up a real PostgreSQL container once per test class and runs the
+/// production EF Core migrations against it. Tests share the same container
+/// for speed, and reset their data via <see cref="ResetAsync"/> before each
+/// scenario so they cannot bleed into one another.
+/// </summary>
+public sealed class PostgresFixture : IAsyncLifetime
+{
+#pragma warning disable CS0618 // PostgreSqlBuilder() constructor is marked obsolete in 4.11; tracked upstream — chained .WithImage(...) keeps the call equivalent.
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder()
+        .WithImage("postgres:17-alpine")
+        .WithDatabase("webhookengine_e2e")
+        .WithUsername("test")
+        .WithPassword("test")
+        .Build();
+#pragma warning restore CS0618
+
+    public string ConnectionString => _container.GetConnectionString();
+
+    public async Task InitializeAsync()
+    {
+        await _container.StartAsync();
+
+        // Apply the production migrations exactly the way the API host would
+        // on startup, so the schema under test matches what runs in prod.
+        var options = new DbContextOptionsBuilder<WebhookDbContext>()
+            .UseNpgsql(ConnectionString)
+            .Options;
+
+        await using var db = new WebhookDbContext(options);
+        await db.Database.MigrateAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _container.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Truncates every test-managed table and resets identity sequences. Cheap
+    /// enough to call from every test; faster than DROP/CREATE database.
+    /// </summary>
+    public async Task ResetAsync()
+    {
+        var options = new DbContextOptionsBuilder<WebhookDbContext>()
+            .UseNpgsql(ConnectionString)
+            .Options;
+
+        await using var db = new WebhookDbContext(options);
+        await db.Database.ExecuteSqlRawAsync("""
+            TRUNCATE TABLE
+                message_attempts,
+                messages,
+                endpoint_event_types,
+                endpoint_health,
+                endpoints,
+                event_types,
+                applications,
+                dashboard_users
+            RESTART IDENTITY CASCADE;
+        """);
+    }
+}

--- a/tests/WebhookEngine.Infrastructure.Tests/WebhookEngine.Infrastructure.Tests.csproj
+++ b/tests/WebhookEngine.Infrastructure.Tests/WebhookEngine.Infrastructure.Tests.csproj
@@ -14,7 +14,9 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="8.9.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
@@ -25,6 +27,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\WebhookEngine.Infrastructure\WebhookEngine.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\src\WebhookEngine.Worker\WebhookEngine.Worker.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Adds the first true end-to-end test for the delivery pipeline (real Postgres, real queue, real repositories, real state machine).
- New \`PostgresFixture\` (xUnit \`IAsyncLifetime\`) spins up \`postgres:17-alpine\` once per test class and runs the production EF migrations.
- Only mocked piece is \`IDeliveryService\` (NSubstitute) so each scenario can deterministically choose success or failure.

## Coverage (4 scenarios)
| Scenario | Outcome verified |
|---|---|
| Successful delivery | message Pending → Delivered, AttemptCount=1, DeliveredAt set |
| Failed delivery | message Failed, attempt row recorded with status Failed, ScheduledAt advanced |
| Retry exhaustion | message starting at attempt 6/7 → one more failure → DeadLetter |
| Circuit breaker | 6 back-to-back failures → endpoint health CircuitState=Open, ConsecutiveFailures≥5 |

## Project changes
- \`Infrastructure.Tests.csproj\`: adds \`NSubstitute\`, \`Microsoft.Extensions.Hosting\`, and a project reference to \`WebhookEngine.Worker\` so the worker can be hosted directly via \`StartAsync\`/\`StopAsync\`.
- \`DeliveryOptions.PollIntervalMs=50\` in tests so each scenario only needs a ~1.2s wait window.

## Why this matters
DeliveryWorker had unit-level coverage on backoff math + header building, but no test ever exercised the actual state transitions (Pending → Sending → Delivered/Failed/DeadLetter) or the circuit-breaker integration. These are the most regression-prone parts of the system; this PR puts them under a regression net.

## Trade-offs accepted
- Tests require Docker on the runner. GitHub Actions Ubuntu images already have it; no workflow change needed.
- Each test ~1.2s (poll window) + ~5s container startup once per class. Manageable for CI.
- Container image pinned to \`postgres:17-alpine\` to match production schema migrations.

## Out of scope
- HTTP outbound is mocked, not a real receiver. \`HttpDeliveryService\` already has unit tests against a fake \`HttpMessageHandler\`; integrating a real receiver here would duplicate that coverage without adding signal.

## Labels
\`enhancement\` \`worker\` \`infrastructure\`

## Test plan
- [ ] CI \`Backend (build + test)\` job stays green
- [ ] All 4 new e2e scenarios pass on Linux runner with Docker
- [ ] Existing 161 tests still pass (no regression in InMemory fixture or unit tests)