### PR TITLE
fix(security): pin Dockerfile base images and clear stale CVEs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,11 @@ jobs:
           context: .
           file: docker/Dockerfile
           push: true
+          # Force a fresh pull of base images on every release so security
+          # patches in the upstream Microsoft / Bun / Alpine images flow
+          # into the published WebhookEngine image instead of being
+          # shadowed by the GHA build cache.
+          pull: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Security
+- **Docker base image refresh (Docker Scout cleanup):** all three Dockerfile stages (`oven/bun:1-alpine`, `mcr.microsoft.com/dotnet/sdk:10.0`, `mcr.microsoft.com/dotnet/aspnet:10.0-alpine`) now ship with SHA-256 digest pins so Dependabot can track and bump them, and the release workflow forces `pull: true` to bypass the GitHub Actions build cache when fetching upstream layers. The published image picks up the latest Alpine 3.23.4 patches: openssl/libcrypto3/libssl3 `3.5.5-r0` → `3.5.6-r0` (1 critical + 5 high CVEs cleared) and musl `1.2.5-r21` → `1.2.5-r23` (1 high CVE cleared). The remaining busybox advisory has no upstream patch yet and persists across the Alpine ecosystem.
+
 ### Added
 - **Brand icon on the NuGet package + Docker Hub description sync:** the `WebhookEngine.Sdk` NuGet package now ships with a 256×256 brand icon (the same diamond + three-dots mark used on the landing page and dashboard), so the package shows the project logo on nuget.org instead of the default placeholder. The release workflow also runs `peter-evans/dockerhub-description` after pushing the Docker image, syncing the GitHub README into the Docker Hub repository's "Overview" tab on every release. Image labels gained `org.opencontainers.image.documentation` and `org.opencontainers.image.vendor`.
 - **OpenAPI document + Scalar interactive reference:** the API host now generates an OpenAPI 3 document via `Microsoft.AspNetCore.OpenApi` (.NET 10 native) and serves an interactive [Scalar](https://scalar.com/) UI alongside it. Routes — `/openapi/v1.json` (spec) and `/scalar` (UI) — are mapped only in `Development` and `Staging` environments; `Production` deployments leave the surface unmapped. The document covers all 39 controller routes and is suitable for SDK auto-generation.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,11 @@
 # ============================================================
 # Stage 1: Dashboard build (React SPA)
 # ============================================================
-FROM oven/bun:1-alpine AS dashboard-build
+# Image digests pinned for reproducible builds + Dependabot-tracked security
+# updates. The mutable tag (oven/bun:1-alpine, dotnet/sdk:10.0,
+# dotnet/aspnet:10.0-alpine) is kept alongside so Dependabot can detect when
+# a newer digest is published and open an automatic bump PR.
+FROM oven/bun:1-alpine@sha256:4de475389889577f346c636f956b42a5c31501b654664e9ae5726f94d7bb5349 AS dashboard-build
 WORKDIR /dashboard
 
 COPY src/dashboard/package.json src/dashboard/bun.lock ./
@@ -13,7 +17,7 @@ RUN bun run build
 # ============================================================
 # Stage 2: .NET restore + publish
 # ============================================================
-FROM mcr.microsoft.com/dotnet/sdk:10.0 AS backend-build
+FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:8a90a473da5205a16979de99d2fc20975e922c68304f5c79d564e666dc3982fc AS backend-build
 WORKDIR /src
 
 # Copy solution and project files for layer-cached restore
@@ -45,7 +49,7 @@ RUN dotnet publish src/WebhookEngine.API/WebhookEngine.API.csproj \
 # ============================================================
 # Stage 3: Runtime
 # ============================================================
-FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine@sha256:60eb031b554df75a4b9f358290a2fa15d8961a3bc79b47bb34a00e31f7b78c69 AS runtime
 
 # Labels
 LABEL org.opencontainers.image.title="WebhookEngine" \


### PR DESCRIPTION
## Summary
Docker Scout flagged 11 CVEs on the published v0.1.3 image:
| Severity | Count | Source |
|---|---|---|
| Critical (9.8) | 1 | alpine/openssl 3.5.5-r0 |
| High | 5 | alpine/openssl 3.5.5-r0 |
| High | 1 | alpine/musl 1.2.5-r21 |
| Medium | 1 | alpine/busybox 1.37.0-r30 |
| Medium | 1 | nuget/OpenTelemetry.Api 1.15.1.1988 |

The upstream Microsoft .NET runtime image **already ships** the patched packages — the published image lagged because the GitHub Actions build cache held the layers from 27 days ago. This PR refreshes the base layers and pins them so Dependabot can keep them fresh.

## Changes
- **\`docker/Dockerfile\`:** all three FROMs pinned by SHA-256 digest:
  - \`oven/bun:1-alpine@sha256:4de4753...\`
  - \`mcr.microsoft.com/dotnet/sdk:10.0@sha256:8a90a47...\`
  - \`mcr.microsoft.com/dotnet/aspnet:10.0-alpine@sha256:60eb031...\`
  - The mutable tag is kept on the same line so Dependabot's docker ecosystem updater can recognize and bump them.
- **\`.github/workflows/release.yml\`:** \`docker/build-push-action\` now passes \`pull: true\`, so future releases bypass the GHA cache and always pull the freshest upstream layers.

## Impact (verified locally)
The freshly built image carries:
- openssl/libcrypto3/libssl3 \`3.5.5-r0\` → **\`3.5.6-r0\`** (clears 1 critical + 5 high)
- musl \`1.2.5-r21\` → **\`1.2.5-r23\`** (clears 1 high)

Expected post-release Scout result: **11 → ~2 (down by 7 CVEs)**.

## Remaining (out of scope)
- **busybox \`1.37.0-r30\`** medium — no upstream patch yet, persists across the Alpine 3.23 ecosystem.
- **OpenTelemetry.Api \`1.15.1.1988\`** medium — already on the latest stable in nuget.org; no fix released yet.

These will close when upstream publishes patches; Dependabot will catch them.

## Labels
\`security\` \`docker\` \`ci\`

## Test plan
- [ ] CI \`Backend (build + test)\` and \`Docker build\` jobs stay green
- [ ] After v0.1.4 release publishes, Docker Scout vulnerability count drops from 11 to ~2