### PR TITLE
fix(ci): multi-arch Docker (amd64+arm64) + remove unknown/unknown noise

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      # QEMU enables cross-architecture builds on the standard amd64 runner —
+      # required for the linux/arm64 leg of the manifest list so Apple Silicon
+      # Macs and arm64 servers can `docker pull voyvodka/webhook-engine`.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -41,11 +49,22 @@ jobs:
           context: .
           file: docker/Dockerfile
           push: true
+          # Multi-arch publish so `docker pull` works on Apple Silicon Macs
+          # and arm64 Linux servers (without this only linux/amd64 ships and
+          # arm64 hosts get "no matching manifest" errors).
+          platforms: linux/amd64,linux/arm64
           # Force a fresh pull of base images on every release so security
           # patches in the upstream Microsoft / Bun / Alpine images flow
           # into the published WebhookEngine image instead of being
           # shadowed by the GHA build cache.
           pull: true
+          # Disable build provenance / SBOM attestations. They land on Docker
+          # Hub as a phantom "unknown/unknown" platform entry that confuses
+          # users browsing the tag list and isn't useful for a single-binary
+          # OSS tool. Re-enable later if/when supply-chain attestation
+          # becomes a documented project deliverable.
+          provenance: false
+          sbom: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+- **Multi-architecture Docker image:** the published image now ships for both `linux/amd64` and `linux/arm64`. Previous releases were amd64-only, which meant Apple Silicon Macs and arm64 Linux servers got `no matching manifest for linux/arm64/v8` when running `docker pull voyvodka/webhook-engine`. The release workflow gains a QEMU setup step and the build action now passes `platforms: linux/amd64,linux/arm64`.
+- **Removed phantom "unknown / unknown" tag entry on Docker Hub:** `docker/build-push-action`'s default provenance + SBOM attestations were landing on Docker Hub as a separate "unknown / unknown" platform row alongside the real architectures. `provenance: false` and `sbom: false` are now set explicitly so each tag lists only the platforms it actually contains.
+
 ### Security
 - **Docker base image refresh (Docker Scout cleanup):** all three Dockerfile stages (`oven/bun:1-alpine`, `mcr.microsoft.com/dotnet/sdk:10.0`, `mcr.microsoft.com/dotnet/aspnet:10.0-alpine`) now ship with SHA-256 digest pins so Dependabot can track and bump them, and the release workflow forces `pull: true` to bypass the GitHub Actions build cache when fetching upstream layers. The published image picks up the latest Alpine 3.23.4 patches: openssl/libcrypto3/libssl3 `3.5.5-r0` → `3.5.6-r0` (1 critical + 5 high CVEs cleared) and musl `1.2.5-r21` → `1.2.5-r23` (1 high CVE cleared). The remaining busybox advisory has no upstream patch yet and persists across the Alpine ecosystem.
 


### PR DESCRIPTION
## Summary
Two regressions visible on Docker Hub for the v0.1.3 image, both fixed in \`.github/workflows/release.yml\`:

### 1. arm64 pull broken
\`\`\`
$ docker pull voyvodka/webhook-engine:latest
no matching manifest for linux/arm64/v8 in the manifest list entries
\`\`\`
Apple Silicon Macs and arm64 Linux servers couldn't pull the image because only \`linux/amd64\` was being built.

**Fix:** \`docker/setup-qemu-action@v4\` step + \`platforms: linux/amd64,linux/arm64\` on the build action.

### 2. "unknown / unknown" phantom row on Docker Hub
The tag listing showed a 55 KB \`unknown / unknown\` entry next to the real architecture row. That was the build-push-action's default provenance + SBOM attestations landing as a separate manifest.

**Fix:** \`provenance: false\` and \`sbom: false\` on the build action.

## Verified locally
\`\`\`
$ docker buildx build --platform linux/amd64,linux/arm64 \\
    --provenance=false --sbom=false \\
    -f docker/Dockerfile --target runtime .
\`\`\`
Output manifest list contains exactly two entries: \`linux/amd64\` and \`linux/arm64\`. No attestation manifests.

## Trade-off
Provenance/SBOM attestations are useful for supply-chain verification on enterprise images. For this single-binary OSS tool the Hub UI noise outweighs the benefit; we can re-enable them later if/when supply-chain attestation becomes a documented project deliverable.

## Labels
\`bug\` \`docker\` \`ci\`

## Test plan
- [ ] CI green
- [ ] Next release tag publishes a manifest list with both \`linux/amd64\` and \`linux/arm64\`
- [ ] Confirm via \`docker manifest inspect voyvodka/webhook-engine:latest\` after release
- [ ] Confirm Docker Hub tag listing no longer shows "unknown / unknown"