### PR TITLE
chore(release): v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.1.4] - 2026-05-05
+
 ### Fixed
 - **Multi-architecture Docker image:** the published image now ships for both `linux/amd64` and `linux/arm64`. Previous releases were amd64-only, which meant Apple Silicon Macs and arm64 Linux servers got `no matching manifest for linux/arm64/v8` when running `docker pull voyvodka/webhook-engine`. The release workflow gains a QEMU setup step and the build action now passes `platforms: linux/amd64,linux/arm64`.
 - **Removed phantom "unknown / unknown" tag entry on Docker Hub:** `docker/build-push-action`'s default provenance + SBOM attestations were landing on Docker Hub as a separate "unknown / unknown" platform row alongside the real architectures. `provenance: false` and `sbom: false` are now set explicitly so each tag lists only the platforms it actually contains.

--- a/index.html
+++ b/index.html
@@ -983,7 +983,7 @@
           <line x1="18" y1="19.5" x2="19" y2="19.8" stroke="#3EFFA0" stroke-width="1" opacity="0.3"/>
         </svg>
         <span class="logo-wordmark">Webhook<span>Engine</span></span>
-        <span class="version-badge">v0.1.3</span>
+        <span class="version-badge">v0.1.4</span>
       </a>
       <div class="nav-links">
         <a href="https://github.com/voyvodka/webhook-engine/blob/main/docs/GETTING-STARTED.md" class="nav-link" target="_blank" rel="noopener">
@@ -1323,7 +1323,7 @@
       <div class="footer-left">
         <span class="footer-name">Webhook<span>Engine</span></span>
         <span class="footer-sep">·</span>
-        <span class="footer-meta">MIT License · v0.1.3</span>
+        <span class="footer-meta">MIT License · v0.1.4</span>
       </div>
       <div class="footer-links">
         <a href="https://github.com/voyvodka/webhook-engine" class="footer-link" target="_blank" rel="noopener">GitHub</a>

--- a/src/WebhookEngine.Sdk/WebhookEngine.Sdk.csproj
+++ b/src/WebhookEngine.Sdk/WebhookEngine.Sdk.csproj
@@ -8,7 +8,7 @@
 
     <!-- NuGet package metadata -->
     <PackageId>WebhookEngine.Sdk</PackageId>
-    <Version>0.1.3</Version>
+    <Version>0.1.4</Version>
     <Authors>WebhookEngine</Authors>
     <Description>.NET SDK for WebhookEngine — self-hosted webhook delivery platform. Send webhooks, manage endpoints and event types, retry failed deliveries.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/dashboard/package.json
+++ b/src/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webhookengine-dashboard",
   "private": true,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
Promotes the merged 7-PR cleanup wave (PR #15-#23) to a v0.1.4 release.

## Version bumps
- \`WebhookEngine.Sdk\` NuGet → \`0.1.4\` (now ships with the project icon embedded)
- \`webhookengine-dashboard\` (npm) → \`0.1.4\`
- Landing page version badge + footer → \`v0.1.4\`
- \`CHANGELOG.md\` Unreleased block → \`[0.1.4] - 2026-05-05\`

## Highlights since v0.1.3

### Added
- Payload transformation (ADR-003) — schema, delivery integration, dashboard CodeMirror editor, validate endpoint
- Brand icon on the NuGet package + Docker Hub overview README sync
- OpenAPI document + Scalar interactive reference (Dev/Staging only)
- Security automations: CodeQL, Dependency Review, Dependabot

### Fixed
- Multi-arch Docker image (linux/amd64 + linux/arm64) — Apple Silicon Macs and arm64 Linux can finally pull the image
- Removed phantom \`unknown / unknown\` row on Docker Hub

### Security
- Refreshed Alpine base image: openssl 3.5.5→3.5.6, musl 1.2.5-r21→r23 (clears 1 critical + 6 high CVEs from Docker Scout)
- Dockerfile FROM lines now SHA-pinned for Dependabot tracking

### Changed
- Frontend toolchain migrated from Yarn to Bun 1.2+

### Removed
- Empty \`WebhookEngine.Application\` scaffold project

## Post-merge steps (handled outside this PR)
1. Tag \`v0.1.4\` from \`main\`
2. Push tag — \`release.yml\` then publishes Docker (multi-arch) + NuGet (with icon) and syncs Hub overview
3. Create the GitHub Release with the v0.1.4 CHANGELOG section as the body

## Labels
\`documentation\` \`enhancement\`

## Test plan
- [ ] CI green
- [ ] Solution builds clean (0 warnings, 0 errors)
- [ ] Tag publish triggers Docker + NuGet jobs successfully
- [ ] \`docker manifest inspect voyvodka/webhook-engine:0.1.4\` shows linux/amd64 + linux/arm64 only
- [ ] nuget.org/packages/WebhookEngine.Sdk/0.1.4 shows the project icon