### PR TITLE
fix(security): sanitize JMESPath expression in transformer logs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,12 +70,15 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # Sync the repository README to the Docker Hub "Overview" tab so what
-      # users see on Docker Hub matches the GitHub README. The repo logo
-      # itself is a one-time manual upload via the Docker Hub web UI;
-      # description sync runs on every release.
+      # Sync the repository README to the Docker Hub "Overview" tab. Treated
+      # as best-effort: if the DOCKERHUB_TOKEN doesn't carry the
+      # "repo:write_metadata" scope (PAT v2 introduced finer-grained scopes
+      # mid-release), the step fails 403 but the image push above is already
+      # committed. Operators can fix the token scope in repo Settings without
+      # blocking a subsequent release.
       - name: Sync Docker Hub description
         uses: peter-evans/dockerhub-description@v4
+        continue-on-error: true
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/src/WebhookEngine.API/Middleware/ExceptionHandlingMiddleware.cs
+++ b/src/WebhookEngine.API/Middleware/ExceptionHandlingMiddleware.cs
@@ -1,6 +1,6 @@
 using System.Net;
 using System.Text.Json;
-using WebhookEngine.API.Services;
+using WebhookEngine.Core.Utilities;
 
 namespace WebhookEngine.API.Middleware;
 

--- a/src/WebhookEngine.API/Middleware/RequestLoggingMiddleware.cs
+++ b/src/WebhookEngine.API/Middleware/RequestLoggingMiddleware.cs
@@ -1,5 +1,5 @@
 using System.Diagnostics;
-using WebhookEngine.API.Services;
+using WebhookEngine.Core.Utilities;
 
 namespace WebhookEngine.API.Middleware;
 

--- a/src/WebhookEngine.Core/Utilities/LogSanitizer.cs
+++ b/src/WebhookEngine.Core/Utilities/LogSanitizer.cs
@@ -1,13 +1,14 @@
-namespace WebhookEngine.API.Services;
+namespace WebhookEngine.Core.Utilities;
 
 /// <summary>
 /// Helpers for safely emitting user-controlled values into log entries.
 ///
 /// <para>
 /// <b>Log forging</b> (CodeQL <c>cs/log-forging</c>): an attacker can put
-/// <c>\r\n</c> sequences into request paths, headers, or message bodies to
-/// inject fake log lines. <see cref="ForLog"/> strips control characters and
-/// caps length so the output is single-line and bounded.
+/// <c>\r\n</c> sequences into request paths, headers, message bodies, or
+/// dashboard-supplied configuration (e.g. JMESPath transform expressions)
+/// to inject fake log lines. <see cref="ForLog"/> strips control characters
+/// and caps length so the output is single-line and bounded.
 /// </para>
 /// <para>
 /// <b>PII exposure</b> (CodeQL <c>cs/exposure-of-sensitive-information</c>):
@@ -15,6 +16,10 @@ namespace WebhookEngine.API.Services;
 /// shouldn't appear verbatim in shared logs. <see cref="RedactEmail"/> keeps
 /// just enough of the local part for an operator to recognise the user.
 /// </para>
+///
+/// Lives in <c>Core</c> so both the API host and the Infrastructure layer
+/// (workers, services) can reuse it without taking a project reference back
+/// up the dependency graph.
 /// </summary>
 public static class LogSanitizer
 {
@@ -22,7 +27,7 @@ public static class LogSanitizer
 
     /// <summary>
     /// Strip CR/LF/tab characters and clamp length so a malicious request
-    /// path or header cannot break out of the current log line.
+    /// path, header, or expression cannot break out of the current log line.
     /// </summary>
     public static string ForLog(string? value, int maxLength = DefaultMaxLength)
     {

--- a/src/WebhookEngine.Infrastructure/Services/JmesPathPayloadTransformer.cs
+++ b/src/WebhookEngine.Infrastructure/Services/JmesPathPayloadTransformer.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using WebhookEngine.Core.Interfaces;
 using WebhookEngine.Core.Options;
+using WebhookEngine.Core.Utilities;
 
 namespace WebhookEngine.Infrastructure.Services;
 
@@ -34,6 +35,12 @@ public sealed class JmesPathPayloadTransformer : IPayloadTransformer
             return PayloadTransformResult.FailOpen("Expression is empty.");
         }
 
+        // The expression is dashboard-supplied (user-controlled), so it must
+        // pass through LogSanitizer.ForLog before reaching any log entry —
+        // otherwise CR/LF inside the expression could forge fake log lines
+        // (CodeQL cs/log-forging).
+        var safeExpression = LogSanitizer.ForLog(expression);
+
         // Run the JMESPath evaluation on a thread-pool task so we can enforce a
         // hard wall-clock timeout even if the expression hits a pathological
         // pattern that the parser does not detect ahead of time.
@@ -45,7 +52,7 @@ public sealed class JmesPathPayloadTransformer : IPayloadTransformer
             {
                 _logger.LogWarning(
                     "JMESPath transformation timed out after {TimeoutMs}ms for expression {Expression}",
-                    _options.TimeoutMs, expression);
+                    _options.TimeoutMs, safeExpression);
                 return PayloadTransformResult.FailOpen($"Timeout after {_options.TimeoutMs}ms.");
             }
         }
@@ -54,12 +61,12 @@ public sealed class JmesPathPayloadTransformer : IPayloadTransformer
             _logger.LogWarning(
                 ex.InnerException,
                 "JMESPath transformation failed for expression {Expression}",
-                expression);
+                safeExpression);
             return PayloadTransformResult.FailOpen(ex.InnerException.Message);
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "JMESPath transformation failed for expression {Expression}", expression);
+            _logger.LogWarning(ex, "JMESPath transformation failed for expression {Expression}", safeExpression);
             return PayloadTransformResult.FailOpen(ex.Message);
         }
 
@@ -76,7 +83,7 @@ public sealed class JmesPathPayloadTransformer : IPayloadTransformer
         {
             _logger.LogWarning(
                 "JMESPath transformation output exceeded {MaxOutputBytes} bytes ({ActualBytes}) for expression {Expression}",
-                _options.MaxOutputBytes, byteCount, expression);
+                _options.MaxOutputBytes, byteCount, safeExpression);
             return PayloadTransformResult.FailOpen(
                 $"Output size {byteCount} exceeds limit {_options.MaxOutputBytes}.");
         }

--- a/tests/WebhookEngine.API.Tests/Services/LogSanitizerTests.cs
+++ b/tests/WebhookEngine.API.Tests/Services/LogSanitizerTests.cs
@@ -1,5 +1,5 @@
 using FluentAssertions;
-using WebhookEngine.API.Services;
+using WebhookEngine.Core.Utilities;
 
 namespace WebhookEngine.API.Tests.Services;
 


### PR DESCRIPTION
## Summary
Closes 4 \`cs/log-forging\` CodeQL alerts (#7-#10) on \`JmesPathPayloadTransformer.cs\`. The transformer's four \`LogWarning\` calls all interpolate the endpoint's JMESPath expression — and that expression is dashboard-supplied (user-controlled), so a CR/LF embedded in it could forge fake log lines downstream.

## What changed
- **\`LogSanitizer\` moved from \`WebhookEngine.API.Services\` to \`WebhookEngine.Core.Utilities\`.** Core has zero NuGet dependencies, so both API and Infrastructure can now consume it. Previously the Infrastructure layer couldn't import it (would have created a cycle).
- **\`JmesPathPayloadTransformer\`** runs the expression through \`LogSanitizer.ForLog\` once per call and uses the sanitized copy in every log line. CR/LF/tab stripped, length clamped to 256 chars.
- Existing API callers (\`RequestLoggingMiddleware\`, \`ExceptionHandlingMiddleware\`) and \`LogSanitizerTests\` updated to the new namespace.
- **Bonus:** \`release.yml\`'s "Sync Docker Hub description" step now has \`continue-on-error: true\`. The 403 we got on the v0.1.4 release didn't break the image push (which had already committed) but did fail the job — this prevents that.

## Why move LogSanitizer to Core
\`WebhookEngine.API.Services.LogSanitizer\` was reachable from API only. The Infrastructure layer (workers, services) couldn't reference it without inverting the project dependency direction. Putting it in \`WebhookEngine.Core.Utilities\` (which has zero external deps) is the canonical place for cross-layer utilities.

## Verification
- \`dotnet build WebhookEngine.sln --configuration Release\` — 0 warnings, 0 errors
- All existing \`LogSanitizerTests\` continue to pass against the new namespace

## Labels
\`security\` \`api\` \`infrastructure\`

## Test plan
- [ ] CI green
- [ ] CodeQL scheduled run drops 4 \`cs/log-forging\` alerts to 0
- [ ] No regression in middleware logging (request/exception lines still sanitized)