### PR TITLE
fix(ci): drop duplicate release trigger from Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,8 +14,12 @@ on:
       - "robots.txt"
       - "sitemap.xml"
       - ".github/workflows/pages.yml"
-  release:
-    types: [published]
+  # Release events were producing a duplicate run on the same commit that the
+  # version-bump push had already deployed — the second run lost the
+  # concurrency lock and showed up as a failure on the workflow timeline.
+  # The push trigger above already covers landing changes (the version badge
+  # is bumped in the same commit that creates the tag), so no separate
+  # release trigger is needed.
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
The v0.1.4 release surfaced a phantom Pages workflow failure on the timeline. Cause: \`pages.yml\` had **both** \`push\` (path-filtered to landing assets) **and** \`release: published\` as triggers. During a release the version-bump commit fires the push run, then the tag publish fires the release run — both targeting the same SHA. The second run loses the concurrency lock and shows up as failed even though the first run already deployed the site.

The push trigger already covers every landing-page change (the version badge is bumped in the same commit that creates the tag), so the release trigger is redundant. Removed.

## Verified
- v0.1.4 landing is live at webhook.sametozkan.com.tr (deployed by the push run before the duplicate fired)
- Future releases will have a single Pages run

## Labels
\`bug\` \`ci\`

## Test plan
- [ ] CI green
- [ ] Next release leaves a single (successful) Pages run on the timeline