### PR TITLE
docs: warn that docker hub standalone run is not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,12 @@ Self-hosted webhook delivery platform with reliable at-least-once delivery, expo
 
 ## Quick Start
 
+> [!IMPORTANT]
+> **The published image requires a PostgreSQL database** — it cannot be launched standalone via Docker Hub's "Run" button. The container's first action on startup is `Database.MigrateAsync()`; with no database reachable it exits within seconds. Use one of the two options below.
+
 ### Docker Compose (recommended)
+
+The bundled compose file starts PostgreSQL alongside the engine, with sensible defaults:
 
 ```bash
 git clone https://github.com/voyvodka/webhook-engine.git
@@ -42,6 +47,21 @@ docker compose -f docker/docker-compose.yml up -d
 ```
 
 The app starts on `http://localhost:5100`. Dashboard login: `admin@example.com` / `changeme`.
+
+### Manual `docker run` against an existing PostgreSQL
+
+If you already operate a PostgreSQL instance, run the image directly and point it at your database:
+
+```bash
+docker run -d --name webhook-engine \
+  -p 8080:8080 \
+  -e ConnectionStrings__WebhookDb="Host=your-postgres;Port=5432;Database=webhookengine;Username=postgres;Password=secret" \
+  -e Dashboard__AdminEmail="admin@example.com" \
+  -e Dashboard__AdminPassword="StrongPassword123!" \
+  voyvodka/webhook-engine:latest
+```
+
+The container listens on port `8080` internally; map it to whatever host port suits your environment. See [`docs/SELF-HOSTING.md`](docs/SELF-HOSTING.md) for the full configuration reference (rate limits, retention, retry policy, signing secret rotation, etc.).
 
 ### Local Development
 


### PR DESCRIPTION
## Summary
A user hit the Docker Hub Run dialog and got a series of confusing UI errors (\`Invalid container name\`, \`invalid port specification\`). Even with valid input, the container would still exit within seconds — the image requires PostgreSQL and \`Database.MigrateAsync()\` runs on startup.

This PR makes that explicit in README:
- Adds a GitHub Markdown \`> [!IMPORTANT]\` callout at the top of the **Quick Start** section.
- Adds a **Manual \`docker run\`** subsection showing the required env vars (\`ConnectionStrings__WebhookDb\`, \`Dashboard__AdminEmail\`, \`Dashboard__AdminPassword\`).
- Both subsections now point to \`docs/SELF-HOSTING.md\` for full config reference.

Hub Overview is synced from README on every release, so the warning will also land on the Docker Hub repo page once the next release tag publishes.

## Labels
\`documentation\`

## Test plan
- [ ] CI green
- [ ] Markdown renders correctly on GitHub
- [ ] Next release picks up the README change in Docker Hub Overview