### PR TITLE
feat(dashboard): test webhook button + DNS check on save

### DIFF
--- a/src/WebhookEngine.API/Controllers/DashboardEndpointController.cs
+++ b/src/WebhookEngine.API/Controllers/DashboardEndpointController.cs
@@ -1,3 +1,6 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text.Json;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -5,6 +8,7 @@ using Microsoft.EntityFrameworkCore;
 using WebhookEngine.API.Contracts;
 using WebhookEngine.Core.Enums;
 using WebhookEngine.Core.Interfaces;
+using WebhookEngine.Core.Models;
 using WebhookEngine.Infrastructure.Data;
 using WebhookEngine.Infrastructure.Repositories;
 using Endpoint = WebhookEngine.Core.Entities.Endpoint;
@@ -24,17 +28,23 @@ public class DashboardEndpointController : ControllerBase
     private readonly EndpointRepository _endpointRepository;
     private readonly EventTypeRepository _eventTypeRepository;
     private readonly IPayloadTransformer _payloadTransformer;
+    private readonly IDeliveryService _deliveryService;
+    private readonly ISigningService _signingService;
 
     public DashboardEndpointController(
         WebhookDbContext dbContext,
         EndpointRepository endpointRepository,
         EventTypeRepository eventTypeRepository,
-        IPayloadTransformer payloadTransformer)
+        IPayloadTransformer payloadTransformer,
+        IDeliveryService deliveryService,
+        ISigningService signingService)
     {
         _dbContext = dbContext;
         _endpointRepository = endpointRepository;
         _eventTypeRepository = eventTypeRepository;
         _payloadTransformer = payloadTransformer;
+        _deliveryService = deliveryService;
+        _signingService = signingService;
     }
 
     // ──────────────────────────────────────────────────
@@ -78,6 +88,12 @@ public class DashboardEndpointController : ControllerBase
         if (!appExists)
         {
             return NotFound(ApiEnvelope.Error(HttpContext, "NOT_FOUND", "Application not found."));
+        }
+
+        var dnsError = await CheckHostResolvableAsync(request.Url, ct);
+        if (dnsError is not null)
+        {
+            return UnprocessableEntity(ApiEnvelope.Error(HttpContext, "UNPROCESSABLE", dnsError));
         }
 
         var endpoint = new Endpoint
@@ -142,7 +158,14 @@ public class DashboardEndpointController : ControllerBase
         }
 
         if (request.Url is not null)
+        {
+            var dnsError = await CheckHostResolvableAsync(request.Url, ct);
+            if (dnsError is not null)
+            {
+                return UnprocessableEntity(ApiEnvelope.Error(HttpContext, "UNPROCESSABLE", dnsError));
+            }
             endpoint.Url = request.Url;
+        }
 
         if (request.Description is not null)
             endpoint.Description = request.Description;
@@ -256,6 +279,55 @@ public class DashboardEndpointController : ControllerBase
 
         await _endpointRepository.DeleteAsync(endpointId, ct);
         return NoContent();
+    }
+
+    [HttpPost("endpoints/{endpointId:guid}/test")]
+    public async Task<IActionResult> TestEndpoint(Guid endpointId, CancellationToken ct)
+    {
+        var endpoint = await _endpointRepository.GetByIdAsync(endpointId, ct);
+        if (endpoint is null)
+        {
+            return NotFound(ApiEnvelope.Error(HttpContext, "NOT_FOUND", "Endpoint not found."));
+        }
+
+        var signingSecret = endpoint.SecretOverride ?? endpoint.Application?.SigningSecret;
+        if (string.IsNullOrWhiteSpace(signingSecret))
+        {
+            return UnprocessableEntity(ApiEnvelope.Error(HttpContext, "UNPROCESSABLE", "Endpoint has no signing secret configured."));
+        }
+
+        var messageId = $"msg_test_{Guid.NewGuid():N}"[..24];
+        var body = JsonSerializer.Serialize(new
+        {
+            test = true,
+            message = "WebhookEngine test event",
+            sentAt = DateTime.UtcNow,
+            endpointId = endpoint.Id
+        });
+
+        var customHeaders = string.IsNullOrWhiteSpace(endpoint.CustomHeadersJson)
+            ? new Dictionary<string, string>()
+            : JsonSerializer.Deserialize<Dictionary<string, string>>(endpoint.CustomHeadersJson) ?? new Dictionary<string, string>();
+
+        var signed = _signingService.Sign(messageId, DateTimeOffset.UtcNow.ToUnixTimeSeconds(), body, signingSecret);
+        var deliveryRequest = new DeliveryRequest
+        {
+            MessageId = messageId,
+            EndpointUrl = endpoint.Url,
+            Payload = body,
+            SignedHeaders = signed,
+            CustomHeaders = customHeaders
+        };
+
+        var result = await _deliveryService.DeliverAsync(deliveryRequest, ct);
+
+        return Ok(ApiEnvelope.Success(HttpContext, new
+        {
+            success = result.Success,
+            statusCode = result.StatusCode,
+            latencyMs = result.LatencyMs,
+            error = result.Error
+        }));
     }
 
     // ──────────────────────────────────────────────────
@@ -402,6 +474,28 @@ public class DashboardEndpointController : ControllerBase
 
         await _eventTypeRepository.ArchiveAsync(eventTypeId, ct);
         return NoContent();
+    }
+
+    private static async Task<string?> CheckHostResolvableAsync(string url, CancellationToken ct)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            return null;
+        }
+
+        try
+        {
+            await Dns.GetHostAddressesAsync(uri.Host, ct);
+            return null;
+        }
+        catch (SocketException)
+        {
+            return $"Cannot resolve host '{uri.Host}'. Check the URL or DNS configuration.";
+        }
+        catch (ArgumentException)
+        {
+            return $"Invalid host '{uri.Host}'.";
+        }
     }
 }
 

--- a/src/dashboard/src/api/dashboardApi.ts
+++ b/src/dashboard/src/api/dashboardApi.ts
@@ -319,6 +319,21 @@ export async function deleteDashboardEndpoint(endpointId: string): Promise<void>
   await mutate<void>(`/api/v1/dashboard/endpoints/${endpointId}`, "DELETE");
 }
 
+export interface TestEndpointResult {
+  success: boolean;
+  statusCode: number;
+  latencyMs: number;
+  error: string | null;
+}
+
+export async function testDashboardEndpoint(endpointId: string): Promise<TestEndpointResult> {
+  const payload = await mutate<ApiEnvelope<TestEndpointResult>>(
+    `/api/v1/dashboard/endpoints/${endpointId}/test`,
+    "POST"
+  );
+  return payload.data;
+}
+
 // ── Messages ────────────────────────────────────
 
 export interface MessageListParams {

--- a/src/dashboard/src/pages/EndpointsPage.tsx
+++ b/src/dashboard/src/pages/EndpointsPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 import { EndpointHealthBadge } from "../components/EndpointHealthBadge";
 import { Modal } from "../components/Modal";
 import { ConfirmModal } from "../components/ConfirmModal";
@@ -12,8 +12,10 @@ import {
   listDashboardEventTypes,
   listEndpoints,
   setDashboardEndpointStatus,
+  testDashboardEndpoint,
   updateDashboardEndpoint
 } from "../api/dashboardApi";
+import type { TestEndpointResult } from "../api/dashboardApi";
 import type { ApplicationRow, EndpointRow, EventTypeSummary, Pagination } from "../types";
 import {
   Plus,
@@ -23,10 +25,13 @@ import {
   ToggleRight,
   Filter,
   AlertCircle,
+  CheckCircle2,
   X,
   ChevronLeft,
   ChevronRight,
-  Save
+  Save,
+  Send,
+  Loader2
 } from "lucide-react";
 import { formatLocaleDate } from "../utils/dateTime";
 
@@ -82,6 +87,10 @@ export function EndpointsPage() {
 
   // Confirm modal
   const [confirmState, setConfirmState] = useState<ConfirmState>(closedConfirm);
+
+  // Inline test result per endpoint id
+  const [testingId, setTestingId] = useState<string | null>(null);
+  const [testResults, setTestResults] = useState<Record<string, TestEndpointResult>>({});
 
   const editingEndpoint = useMemo(
     () => endpoints.find((e) => e.id === editingEndpointId) ?? null,
@@ -243,6 +252,26 @@ export function EndpointsPage() {
     });
   };
 
+  const handleTest = async (endpoint: EndpointRow) => {
+    setTestingId(endpoint.id);
+    try {
+      const result = await testDashboardEndpoint(endpoint.id);
+      setTestResults((prev) => ({ ...prev, [endpoint.id]: result }));
+    } catch (e) {
+      setTestResults((prev) => ({
+        ...prev,
+        [endpoint.id]: {
+          success: false,
+          statusCode: 0,
+          latencyMs: 0,
+          error: e instanceof Error ? e.message : "Test request failed"
+        }
+      }));
+    } finally {
+      setTestingId(null);
+    }
+  };
+
   const requestDelete = (endpoint: EndpointRow) => {
     setConfirmState({
       open: true,
@@ -355,7 +384,8 @@ export function EndpointsPage() {
                 </thead>
                 <tbody className="text-sm">
                   {endpoints.map((ep) => (
-                    <tr key={ep.id} className="border-t border-border-subtle hover:bg-surface-2/50 transition-colors">
+                  <Fragment key={ep.id}>
+                    <tr className="border-t border-border-subtle hover:bg-surface-2/50 transition-colors">
                       <td className="px-4 py-2 font-mono text-xs text-text-secondary max-w-[260px] truncate" title={ep.url}>{ep.url}</td>
                       <td className="px-4 py-2 text-text-secondary">{ep.appName ?? "-"}</td>
                       <td className="px-4 py-2">
@@ -370,6 +400,14 @@ export function EndpointsPage() {
                       <td className="px-4 py-2 text-xs text-text-muted">{formatLocaleDate(ep.createdAt)}</td>
                       <td className="px-4 py-2">
                         <div className="flex items-center justify-end gap-1">
+                          <button
+                            onClick={() => handleTest(ep)}
+                            disabled={testingId === ep.id || ep.status.toLowerCase() === "disabled"}
+                            className="p-1.5 rounded-md text-text-muted hover:text-accent hover:bg-accent-soft disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                            title="Send test event"
+                          >
+                            {testingId === ep.id ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Send className="w-3.5 h-3.5" />}
+                          </button>
                           <button onClick={() => startEdit(ep)} className="p-1.5 rounded-md text-text-muted hover:text-accent hover:bg-accent-soft transition-colors" title="Edit">
                             <Pencil className="w-3.5 h-3.5" />
                           </button>
@@ -382,6 +420,28 @@ export function EndpointsPage() {
                         </div>
                       </td>
                     </tr>
+                    {testResults[ep.id] && (
+                      <tr className="bg-surface-2/40">
+                        <td colSpan={7} className="px-4 py-2">
+                          <div className={`flex items-center gap-2 text-xs ${testResults[ep.id].success ? "text-success" : "text-danger"}`}>
+                            {testResults[ep.id].success ? <CheckCircle2 className="w-3.5 h-3.5" /> : <AlertCircle className="w-3.5 h-3.5" />}
+                            <span className="font-mono">
+                              {testResults[ep.id].success
+                                ? `Test event delivered → HTTP ${testResults[ep.id].statusCode} in ${testResults[ep.id].latencyMs}ms`
+                                : `Test failed → HTTP ${testResults[ep.id].statusCode || "—"} ${testResults[ep.id].error ?? ""}`}
+                            </span>
+                            <button
+                              onClick={() => setTestResults((prev) => { const next = { ...prev }; delete next[ep.id]; return next; })}
+                              className="ml-auto text-text-muted hover:text-text-primary"
+                              title="Dismiss"
+                            >
+                              <X className="w-3 h-3" />
+                            </button>
+                          </div>
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
                   ))}
                 </tbody>
               </table>


### PR DESCRIPTION
## Summary
Two UX wins for endpoint configuration:

### 1. Send test event button
New \`POST /api/v1/dashboard/endpoints/{id}/test\` signs a synthetic test payload with the endpoint's actual signing secret and routes it through the production \`IDeliveryService\`. Result (success / HTTP status / latency / error) is rendered **inline under the row** — no modal, no page navigation.

The button sits next to Edit/Toggle/Delete on the Endpoints page; it's disabled for endpoints currently in the \`Disabled\` state.

### 2. DNS resolution on save
Endpoint create + URL update now call \`Dns.GetHostAddressesAsync\` against the host before persisting. Unresolvable hostnames return **422** with \`Cannot resolve host 'x'. Check the URL or DNS configuration.\` instead of silently shipping a row that fails on every delivery attempt.

## Why
Both flows fix the same UX gap reported in dogfooding: a user pastes a webhook URL with a typo and only finds out after the message has been retried 7 times into the dead-letter queue. Now they:
- See "Cannot resolve host" the moment they hit Save.
- Or, for valid hosts, click Send and see the receiver's actual response in <1s.

## Reuse
- Backend: \`IDeliveryService\`, \`ISigningService\` already DI-registered, just inject into the dashboard controller.
- Frontend: same envelope-handling pattern as every other dashboard mutation.

## Out of scope
- Auto-retry the test, IP-allowlist preview, or response-body inspection — kept the scope tight.

## Labels
\`enhancement\` \`api\` \`dashboard\`

## Test plan
- [ ] CI green
- [ ] Manual: create endpoint with bogus host → 422 with DNS message
- [ ] Manual: create endpoint with valid host → row created, Test button works, inline result shows status code + latency