### PR TITLE
fix(dashboard): visible text in transform editor (dark baseline)

### DIFF
--- a/src/dashboard/src/components/TransformSection.tsx
+++ b/src/dashboard/src/components/TransformSection.tsx
@@ -176,6 +176,7 @@ export function TransformSection({
             <CodeMirror
               value={expression}
               onChange={handleExpressionChange}
+              theme="dark"
               extensions={expressionExtensions}
               basicSetup={{
                 lineNumbers: false,
@@ -218,6 +219,7 @@ export function TransformSection({
                 <CodeMirror
                   value={samplePayload}
                   onChange={handleSampleChange}
+                  theme="dark"
                   extensions={payloadExtensions}
                   basicSetup={{
                     lineNumbers: true,
@@ -266,6 +268,7 @@ export function TransformSection({
                     <CodeMirror
                       value={result.output}
                       editable={false}
+                      theme="dark"
                       extensions={payloadExtensions}
                       basicSetup={{
                         lineNumbers: true,


### PR DESCRIPTION
## Summary
The Edit Endpoint dialog rendered the JMESPath expression editor and the sample-payload / transformed-output editors with a white background, making typed text invisible (white-on-white). Cause: the editors only carried a partial \`EditorView.theme\` override; CodeMirror's default light baseline shone through everything we didn't explicitly style.

Adds \`theme="dark"\` on the three \`<CodeMirror />\` instances so the library's built-in dark baseline applies, then our \`dashboardEditorTheme\` extension layers the dashboard's accent + token colors on top.

## Verified
- \`bun run lint\` clean
- \`bun run typecheck\` clean
- \`bun run build\` clean

## Labels
\`bug\` \`dashboard\`

## Test plan
- [ ] CI green
- [ ] Open an endpoint, edit it, type into the JMESPath box → text visible
- [ ] Open the playground, type into the sample payload → text visible
- [ ] Run with a valid expression → transformed output visible