### PR TITLE
perf(dashboard): React.lazy route splitting (524 KB → 16 KB initial)

### DIFF
--- a/src/dashboard/src/App.tsx
+++ b/src/dashboard/src/App.tsx
@@ -1,14 +1,36 @@
+import { lazy, Suspense } from "react";
 import { BrowserRouter, Navigate, Route, Routes } from "react-router";
 import { AuthProvider } from "./auth/AuthContext";
 import { AppShell } from "./layout/AppShell";
-import { ApplicationsPage } from "./pages/ApplicationsPage";
-import { DashboardPage } from "./pages/DashboardPage";
-import { DeliveryLogPage } from "./pages/DeliveryLogPage";
-import { EndpointsPage } from "./pages/EndpointsPage";
-import { EventTypesPage } from "./pages/EventTypesPage";
 import { LoginPage } from "./pages/LoginPage";
-import { MessagesPage } from "./pages/MessagesPage";
 import { ProtectedRoute } from "./routes/ProtectedRoute";
+
+const DashboardPage = lazy(() =>
+  import("./pages/DashboardPage").then((m) => ({ default: m.DashboardPage }))
+);
+const ApplicationsPage = lazy(() =>
+  import("./pages/ApplicationsPage").then((m) => ({ default: m.ApplicationsPage }))
+);
+const EventTypesPage = lazy(() =>
+  import("./pages/EventTypesPage").then((m) => ({ default: m.EventTypesPage }))
+);
+const EndpointsPage = lazy(() =>
+  import("./pages/EndpointsPage").then((m) => ({ default: m.EndpointsPage }))
+);
+const MessagesPage = lazy(() =>
+  import("./pages/MessagesPage").then((m) => ({ default: m.MessagesPage }))
+);
+const DeliveryLogPage = lazy(() =>
+  import("./pages/DeliveryLogPage").then((m) => ({ default: m.DeliveryLogPage }))
+);
+
+function PageFallback() {
+  return (
+    <div className="h-64 flex items-center justify-center text-text-muted text-xs">
+      Loading…
+    </div>
+  );
+}
 
 export function App() {
   return (
@@ -19,12 +41,54 @@ export function App() {
 
           <Route element={<ProtectedRoute />}>
             <Route element={<AppShell />}>
-              <Route path="/" element={<DashboardPage />} />
-              <Route path="/applications" element={<ApplicationsPage />} />
-              <Route path="/event-types" element={<EventTypesPage />} />
-              <Route path="/endpoints" element={<EndpointsPage />} />
-              <Route path="/messages" element={<MessagesPage />} />
-              <Route path="/delivery-log/:messageId" element={<DeliveryLogPage />} />
+              <Route
+                path="/"
+                element={
+                  <Suspense fallback={<PageFallback />}>
+                    <DashboardPage />
+                  </Suspense>
+                }
+              />
+              <Route
+                path="/applications"
+                element={
+                  <Suspense fallback={<PageFallback />}>
+                    <ApplicationsPage />
+                  </Suspense>
+                }
+              />
+              <Route
+                path="/event-types"
+                element={
+                  <Suspense fallback={<PageFallback />}>
+                    <EventTypesPage />
+                  </Suspense>
+                }
+              />
+              <Route
+                path="/endpoints"
+                element={
+                  <Suspense fallback={<PageFallback />}>
+                    <EndpointsPage />
+                  </Suspense>
+                }
+              />
+              <Route
+                path="/messages"
+                element={
+                  <Suspense fallback={<PageFallback />}>
+                    <MessagesPage />
+                  </Suspense>
+                }
+              />
+              <Route
+                path="/delivery-log/:messageId"
+                element={
+                  <Suspense fallback={<PageFallback />}>
+                    <DeliveryLogPage />
+                  </Suspense>
+                }
+              />
             </Route>
           </Route>
 

--- a/src/dashboard/vite.config.ts
+++ b/src/dashboard/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
           if (id.includes("react-dom") || id.includes("react-router") || id.includes("/react/")) return "vendor";
           if (id.includes("recharts")) return "charts";
           if (id.includes("signalr")) return "signalr";
+          if (id.includes("@codemirror") || id.includes("@uiw/react-codemirror") || id.includes("@lezer")) return "codemirror";
         }
       }
     }


### PR DESCRIPTION
## Summary
The dashboard SPA used to ship a single \`index.js\` of **524 KB** (158 KB gzip) — every route plus the CodeMirror-based transform editor loaded on the first paint regardless of which page the user opened. This PR splits each route into its own chunk via \`React.lazy\` and pulls CodeMirror into its own \`manualChunks\` entry.

## Bundle sizes (measured)

| Chunk | Before | After | Note |
|---|---|---|---|
| **Initial index.js** | **524 KB / 158 KB gzip** | **16 KB / 5 KB gzip** | -97% |
| DashboardPage | (in index) | 11 KB | only on \`/\` |
| ApplicationsPage | (in index) | 14 KB | only on \`/applications\` |
| EventTypesPage | (in index) | 10 KB | only on \`/event-types\` |
| EndpointsPage | (in index) | 25 KB | only on \`/endpoints\` |
| MessagesPage | (in index) | 13 KB | only on \`/messages\` |
| DeliveryLogPage | (in index) | 8 KB | only on \`/delivery-log/:id\` |
| codemirror | (in index) | 418 KB | only when TransformSection mounts |
| charts (recharts) | 345 KB | 345 KB | unchanged |
| vendor | 220 KB | 220 KB | unchanged |
| signalr | 55 KB | 55 KB | unchanged |

Vite's "chunks larger than 500 kB" warning no longer fires.

## UX
Lazy routes are wrapped in \`<Suspense fallback={<PageFallback />} />\` — a small "Loading…" placeholder that fits inside the existing shell layout. Sub-second on a warm cache, fast even on cold first nav since the chunk is small.

\`AppShell\`, \`ProtectedRoute\`, and \`LoginPage\` stay eagerly loaded so the shell renders before the first route resolves.

## Verified
- \`bun run lint\` clean
- \`bun run typecheck\` clean
- \`bun run build\` clean — no chunk warning
- Sizes captured above

## Labels
\`performance\` \`dashboard\`

## Test plan
- [ ] CI green
- [ ] First load lands on shell + LoginPage; only login chunk transferred
- [ ] After login, navigating to \`/endpoints\` shows brief Loading then the page (chunk fetched once, cached for subsequent visits)
- [ ] CodeMirror chunk only fetched when opening an endpoint edit dialog