### PR TITLE
test(perf): k6 load-test harness + baseline + bottleneck inventory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ docs/*
 !docs/RELEASE.md
 !docs/ROADMAP.md
 !docs/PRD.md
+!docs/PERFORMANCE.md
 !docs/adr/
 docs/adr/*
 !docs/adr/*.md
@@ -526,3 +527,8 @@ src/WebhookEngine.API/wwwroot/favicon.svg
 .vscode/
 *.code-workspace
 .planning/
+
+# Benchmark artifacts
+tests/benchmark/results/
+tests/benchmark/.bench.env
+tests/benchmark/k6/*-*.json

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,64 @@
+# Performance & Benchmarks
+
+WebhookEngine ships a reproducible load-test harness under `tests/benchmark/`. The numbers below are captured from a single Apple Silicon laptop running the full stack inside Docker (PostgreSQL 17 + WebhookEngine API + a no-op echo receiver) — they reflect engine throughput, not network or downstream cost.
+
+## Running the harness yourself
+
+```bash
+tests/benchmark/run-bench.sh up                   # start postgres + engine + receiver, seed app/endpoint
+tests/benchmark/run-bench.sh single 1000 60s      # 1000 events/s for 60s
+tests/benchmark/run-bench.sh batch  50 60s        # 50 batches/s × 50 messages = 2500 msg/s
+tests/benchmark/run-bench.sh mixed  300 50 60s    # 300 sends/s + 50 lists/s
+tests/benchmark/run-bench.sh down                 # tear down + drop volume
+```
+
+`run-bench.sh` wraps the [k6](https://k6.io/) Docker image (`grafana/k6`) and writes JSON summaries to `tests/benchmark/results/<scenario>-<timestamp>.json` (gitignored). The scripts under `tests/benchmark/k6/` are plain JS and easy to fork.
+
+The bench compose file lifts the default rate limits (defaults are conservative and would shape the curve before any internal bottleneck appeared) so the benchmark measures the engine, not the rate limiter. See `tests/benchmark/docker-compose.bench.yml`.
+
+## Baseline (v0.1.4)
+
+| Scenario | Target rate | Sustained | p50 | p95 | p99 |
+|---|---|---|---|---|---|
+| `single-send` | 1000 req/s | **916 req/s** | 3.3 ms | 299 ms | 509 ms |
+| `batch-send` (50 msg / batch) | 2500 msg/s | **2500 msg/s** | 79 ms | 324 ms | — |
+| `mixed` (send + list) | 350 req/s | **350 req/s** | 2.7 ms | 10 ms | — |
+
+Measurement details:
+- All numbers from a 60 s window on Apple Silicon, 0 % HTTP failures across all scenarios.
+- `single-send` p50→p95 jumps **~96×** (3.3 ms → 299 ms). Median is fast; the long tail comes from the bottlenecks inventoried below.
+- Light mixed load is comfortably handled — list endpoint p95 stays under 10 ms.
+
+## Bottleneck inventory (from `pg_stat_statements`)
+
+After ~220 K messages enqueued during the baseline runs:
+
+| Query | % of DB time | Calls | Mean | Notes |
+|---|---|---|---|---|
+| `INSERT INTO messages …` | 50.8 % | 222 K | 0.42 ms | Hot path, expected dominant share. |
+| `SELECT count(*) FROM messages WHERE app_id = $1` | 12.9 % | 3 K | **7.88 ms** | Pagination count — dashboard list query. Parallel seq scan; could be cached or replaced with `ApproximateRowCount`. |
+| `SELECT … FROM endpoints …` | 8.1 % | 222 K | 0.07 ms | Endpoint lookup once per message. Cacheable (memory cache + invalidation on update). |
+| `DISCARD ALL` | 4.4 % | **987 K** | 0.01 ms | Npgsql connection-reset noise; suggests pool churn under burst load. Tune `Max Pool Size` and `Connection Idle Lifetime`. |
+| Navigation `FOR KEY SHARE` locks (`applications`, `endpoints`, `event_types`) | ~11 % | 700 K | 0.02-0.04 ms | EF Core taking a row-share lock on referenced rows. Often unnecessary when reading; consider `.AsNoTracking()` on hot paths. |
+| `SELECT … FROM event_types …` | 3.1 % | 222 K | 0.03 ms | Same caching opportunity as endpoints. |
+| API key auth `SELECT … FROM applications …` | 2.8 % | 79 K | 0.07 ms | Validated on every public-API request. Memory cache with short TTL would eliminate this. |
+| `WITH next_batch …` (queue dequeue) | 0.6 % | 391 | 2.66 ms | `SKIP LOCKED` query. OK on absolute terms, but 2.66 ms mean is room to improve when batch size grows. |
+| `INSERT message_attempts` | 3.1 % | 33 K | 0.17 ms | Fine. |
+| `UPDATE messages SET status …` | 1.2 % | 33 K | 0.06 ms | Fine. |
+
+## Configuration findings
+
+- **Default rate limit is too tight for production traffic.** `WebhookEngine:RateLimit` defaults to `PermitLimit=100, TokensPerPeriod=2, QueueLimit=0`. That sustains only 2 req/s per app long-term, with a 100-burst bucket. The bench compose lifts these to 20 000 to measure the engine; the production defaults should be revisited so a self-hosted operator does not hit a wall at 2 req/s.
+
+## Planned optimizations
+
+These follow as separate PRs so each can be measured in isolation:
+
+1. **Memory cache for API key auth** — drops `SELECT applications` from every request to one per cache TTL.
+2. **Memory cache for endpoint + event-type lookup** in the delivery path — drops `SELECT endpoints` / `event_types` from every enqueue.
+3. **Production rate limit defaults** — raise the floor to a sensible self-host baseline (e.g. 500 burst, 100/s sustain) and document the knob.
+4. **`AsNoTracking` on read-only navigation paths** — eliminate the FOR KEY SHARE locks taken by EF for ownership rows that are never mutated in the same scope.
+5. **Connection pool tuning** — explicit `Max Pool Size`, `Connection Idle Lifetime`, evaluate `Multiplexing=true` (Npgsql 9.x).
+6. **Pagination count short-circuit** — return cached / approximate counts on the dashboard list endpoint when the client is paging.
+
+After each optimization the same three k6 scenarios are re-run; a before/after table is appended to this document.

--- a/tests/benchmark/docker-compose.bench.yml
+++ b/tests/benchmark/docker-compose.bench.yml
@@ -1,0 +1,67 @@
+services:
+  postgres:
+    image: postgres:17-alpine
+    environment:
+      - POSTGRES_DB=webhookengine
+      - POSTGRES_USER=webhookengine
+      - POSTGRES_PASSWORD=webhookengine
+    command: >
+      postgres
+      -c shared_buffers=256MB
+      -c work_mem=16MB
+      -c max_connections=200
+      -c log_min_duration_statement=100
+      -c shared_preload_libraries=pg_stat_statements
+      -c pg_stat_statements.track=all
+    ports:
+      - "55432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U webhookengine -d webhookengine"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    networks:
+      - bench
+
+  webhook-engine:
+    build:
+      context: ../..
+      dockerfile: docker/Dockerfile
+    ports:
+      - "5100:8080"
+    environment:
+      # Development env relaxes the HTTPS-only endpoint URL guard so the
+      # in-network http://receiver target is accepted (no TLS in the bench
+      # stack on purpose — we want raw delivery throughput, not TLS overhead).
+      - ASPNETCORE_ENVIRONMENT=Development
+      - ConnectionStrings__Default=Host=postgres;Port=5432;Database=webhookengine;Username=webhookengine;Password=webhookengine
+      - WebhookEngine__DashboardAuth__AdminEmail=admin@bench.local
+      - WebhookEngine__DashboardAuth__AdminPassword=BenchPassword123!
+      - WebhookEngine__Delivery__BatchSize=100
+      - WebhookEngine__Delivery__PollIntervalMs=200
+      # Default rate limits (100 burst, 2/s sustain) are too tight for a
+      # benchmark — they would shape the curve before any internal
+      # bottleneck shows up. Lift them so the bench measures engine
+      # throughput, not the rate limiter.
+      - WebhookEngine__RateLimit__PermitLimit=20000
+      - WebhookEngine__RateLimit__TokensPerPeriod=20000
+      - WebhookEngine__RateLimit__QueueLimit=5000
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - bench
+
+  receiver:
+    # Lightweight HTTP echo: every POST returns 200, no signature check, no
+    # latency. Used as the webhook receiver target so the bench numbers
+    # reflect WebhookEngine throughput, not network or downstream load.
+    image: ealen/echo-server:latest
+    environment:
+      - PORT=80
+    networks:
+      - bench
+
+networks:
+  bench:
+    driver: bridge

--- a/tests/benchmark/k6/batch-send.js
+++ b/tests/benchmark/k6/batch-send.js
@@ -1,0 +1,54 @@
+import http from "k6/http";
+import { check } from "k6";
+
+const API_BASE = __ENV.API_BASE || "http://host.docker.internal:5100";
+const API_KEY = __ENV.API_KEY;
+const BATCH_SIZE = Number(__ENV.BATCH_SIZE || 50);
+
+if (!API_KEY) {
+  throw new Error("API_KEY env var is required (run seed.sh first).");
+}
+
+export const options = {
+  scenarios: {
+    sustained: {
+      executor: "constant-arrival-rate",
+      rate: Number(__ENV.RATE || 50),
+      timeUnit: "1s",
+      duration: __ENV.DURATION || "60s",
+      preAllocatedVUs: 30,
+      maxVUs: 100,
+    },
+  },
+  thresholds: {
+    http_req_failed: ["rate<0.01"],
+    http_req_duration: ["p(95)<2000"],
+  },
+};
+
+const items = [];
+for (let i = 0; i < BATCH_SIZE; i++) {
+  items.push({ eventType: "bench.event", payload: { idx: i } });
+}
+const body = JSON.stringify({ messages: items });
+
+export default function () {
+  const res = http.post(`${API_BASE}/api/v1/messages/batch`, body, {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${API_KEY}`,
+    },
+  });
+
+  check(res, {
+    "status is 202": (r) => r.status === 202,
+    "all accepted": (r) => {
+      try {
+        const data = r.json("data");
+        return data.acceptedEvents === BATCH_SIZE;
+      } catch {
+        return false;
+      }
+    },
+  });
+}

--- a/tests/benchmark/k6/mixed.js
+++ b/tests/benchmark/k6/mixed.js
@@ -1,0 +1,57 @@
+import http from "k6/http";
+import { check } from "k6";
+
+const API_BASE = __ENV.API_BASE || "http://host.docker.internal:5100";
+const API_KEY = __ENV.API_KEY;
+
+if (!API_KEY) {
+  throw new Error("API_KEY env var is required (run seed.sh first).");
+}
+
+const headers = {
+  "Content-Type": "application/json",
+  Authorization: `Bearer ${API_KEY}`,
+};
+
+export const options = {
+  scenarios: {
+    sends: {
+      executor: "constant-arrival-rate",
+      exec: "send",
+      rate: Number(__ENV.SEND_RATE || 300),
+      timeUnit: "1s",
+      duration: __ENV.DURATION || "60s",
+      preAllocatedVUs: 30,
+      maxVUs: 150,
+    },
+    lists: {
+      executor: "constant-arrival-rate",
+      exec: "list",
+      rate: Number(__ENV.LIST_RATE || 50),
+      timeUnit: "1s",
+      duration: __ENV.DURATION || "60s",
+      preAllocatedVUs: 10,
+      maxVUs: 30,
+    },
+  },
+  thresholds: {
+    http_req_failed: ["rate<0.02"],
+  },
+};
+
+export function send() {
+  const res = http.post(
+    `${API_BASE}/api/v1/messages`,
+    JSON.stringify({
+      eventType: "bench.event",
+      payload: { orderId: `ord_${__VU}_${__ITER}` },
+    }),
+    { headers }
+  );
+  check(res, { "send 202": (r) => r.status === 202 });
+}
+
+export function list() {
+  const res = http.get(`${API_BASE}/api/v1/messages?page=1&pageSize=20`, { headers });
+  check(res, { "list 200": (r) => r.status === 200 });
+}

--- a/tests/benchmark/k6/single-send.js
+++ b/tests/benchmark/k6/single-send.js
@@ -1,0 +1,48 @@
+import http from "k6/http";
+import { check } from "k6";
+
+const API_BASE = __ENV.API_BASE || "http://host.docker.internal:5100";
+const API_KEY = __ENV.API_KEY;
+
+if (!API_KEY) {
+  throw new Error("API_KEY env var is required (run seed.sh first).");
+}
+
+export const options = {
+  scenarios: {
+    sustained: {
+      executor: "constant-arrival-rate",
+      rate: Number(__ENV.RATE || 500),
+      timeUnit: "1s",
+      duration: __ENV.DURATION || "60s",
+      preAllocatedVUs: 50,
+      maxVUs: 200,
+    },
+  },
+  thresholds: {
+    http_req_failed: ["rate<0.01"],
+    http_req_duration: ["p(95)<500", "p(99)<1500"],
+  },
+};
+
+export default function () {
+  const payload = JSON.stringify({
+    eventType: "bench.event",
+    payload: {
+      orderId: `ord_${__VU}_${__ITER}`,
+      amount: 100 + (__ITER % 1000),
+    },
+  });
+
+  const res = http.post(`${API_BASE}/api/v1/messages`, payload, {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${API_KEY}`,
+    },
+  });
+
+  check(res, {
+    "status is 202": (r) => r.status === 202,
+    "has messageId": (r) => r.status === 202 && r.body.length > 0,
+  });
+}

--- a/tests/benchmark/run-bench.sh
+++ b/tests/benchmark/run-bench.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Orchestrates the benchmark stack and runs k6 scenarios.
+#
+#   tests/benchmark/run-bench.sh up                    # start stack + seed
+#   tests/benchmark/run-bench.sh down                  # tear down
+#   tests/benchmark/run-bench.sh seed                  # (re)seed app/endpoint
+#   tests/benchmark/run-bench.sh single [RATE] [DUR]   # single-send k6 run
+#   tests/benchmark/run-bench.sh batch  [RATE] [DUR]   # batch-send k6 run
+#   tests/benchmark/run-bench.sh mixed  [SR] [LR] [DUR]
+#   tests/benchmark/run-bench.sh all                   # single + batch + mixed
+#
+# Results land in tests/benchmark/results/<scenario>-<timestamp>.json plus a
+# stdout summary.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+COMPOSE="$DIR/docker-compose.bench.yml"
+RESULTS="$DIR/results"
+SECRETS="$DIR/.bench.env"
+
+mkdir -p "$RESULTS"
+
+cmd="${1:-help}"
+shift || true
+
+up() {
+  docker compose -f "$COMPOSE" up -d --build
+  echo "Waiting for /health…"
+  for _ in $(seq 1 60); do
+    if curl -fsS http://localhost:5100/health >/dev/null 2>&1; then
+      echo "ready."
+      seed
+      return
+    fi
+    sleep 1
+  done
+  echo "API never came up." >&2
+  docker compose -f "$COMPOSE" logs --tail 80 webhook-engine
+  exit 1
+}
+
+down() {
+  docker compose -f "$COMPOSE" down -v
+}
+
+seed() {
+  bash "$DIR/seed.sh" > "$SECRETS"
+  echo "seeded → $SECRETS"
+  cat "$SECRETS"
+}
+
+run_k6() {
+  local script="$1"; shift
+  local label="$1"; shift
+  local stamp
+  stamp="$(date +%Y%m%d-%H%M%S)"
+  local out="$RESULTS/${label}-${stamp}.json"
+
+  if [[ ! -f "$SECRETS" ]]; then
+    echo "missing $SECRETS — run 'up' or 'seed' first." >&2
+    exit 1
+  fi
+
+  # Read API_KEY from .bench.env without leaking it to the parent shell history.
+  # shellcheck disable=SC1090
+  source "$SECRETS"
+
+  docker run --rm -i \
+    --add-host=host.docker.internal:host-gateway \
+    -v "$DIR/k6:/scripts" \
+    -e API_BASE="http://host.docker.internal:5100" \
+    -e API_KEY="$API_KEY" \
+    "$@" \
+    grafana/k6 run --summary-export "/scripts/${label}-${stamp}.json" "/scripts/${script}"
+
+  if [[ -f "$DIR/k6/${label}-${stamp}.json" ]]; then
+    mv "$DIR/k6/${label}-${stamp}.json" "$out"
+    echo "summary → $out"
+  fi
+}
+
+case "$cmd" in
+  up) up ;;
+  down) down ;;
+  seed) seed ;;
+  single)
+    rate="${1:-500}"; dur="${2:-60s}"
+    run_k6 single-send.js "single-r${rate}" -e RATE="$rate" -e DURATION="$dur"
+    ;;
+  batch)
+    rate="${1:-50}"; dur="${2:-60s}"
+    run_k6 batch-send.js "batch-r${rate}" -e RATE="$rate" -e DURATION="$dur"
+    ;;
+  mixed)
+    sr="${1:-300}"; lr="${2:-50}"; dur="${3:-60s}"
+    run_k6 mixed.js "mixed-s${sr}-l${lr}" -e SEND_RATE="$sr" -e LIST_RATE="$lr" -e DURATION="$dur"
+    ;;
+  all)
+    "$0" single
+    "$0" batch
+    "$0" mixed
+    ;;
+  *)
+    sed -n '2,15p' "$0"
+    ;;
+esac

--- a/tests/benchmark/seed.sh
+++ b/tests/benchmark/seed.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Seeds a benchmark application + endpoint + event type into a running
+# WebhookEngine instance and prints the API key + endpoint id so the k6
+# scripts can target them.
+set -euo pipefail
+
+API_BASE="${API_BASE:-http://localhost:5100}"
+ADMIN_EMAIL="${ADMIN_EMAIL:-admin@bench.local}"
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-BenchPassword123!}"
+APP_NAME="${APP_NAME:-bench-app}"
+
+cookie_jar="$(mktemp)"
+trap 'rm -f "$cookie_jar"' EXIT
+
+login_response=$(curl -sS -c "$cookie_jar" -H 'Content-Type: application/json' \
+  -d "{\"email\":\"$ADMIN_EMAIL\",\"password\":\"$ADMIN_PASSWORD\"}" \
+  "$API_BASE/api/v1/auth/login")
+echo "$login_response" | grep -q '"data"' || { echo "login failed: $login_response" >&2; exit 1; }
+
+app_response=$(curl -sS -b "$cookie_jar" -H 'Content-Type: application/json' \
+  -d "{\"name\":\"$APP_NAME\"}" \
+  "$API_BASE/api/v1/applications")
+
+app_id=$(echo "$app_response" | python3 -c "import json, sys; print(json.load(sys.stdin)['data']['id'])")
+api_key=$(echo "$app_response" | python3 -c "import json, sys; print(json.load(sys.stdin)['data']['apiKey'])")
+
+et_response=$(curl -sS -b "$cookie_jar" -H 'Content-Type: application/json' \
+  -d "{\"appId\":\"$app_id\",\"name\":\"bench.event\"}" \
+  "$API_BASE/api/v1/dashboard/event-types")
+event_type_id=$(echo "$et_response" | python3 -c "import json, sys; print(json.load(sys.stdin)['data']['id'])")
+
+ep_response=$(curl -sS -b "$cookie_jar" -H 'Content-Type: application/json' \
+  -d "{\"appId\":\"$app_id\",\"url\":\"http://receiver/echo\",\"filterEventTypes\":[\"$event_type_id\"]}" \
+  "$API_BASE/api/v1/dashboard/endpoints")
+endpoint_id=$(echo "$ep_response" | python3 -c "import json, sys; print(json.load(sys.stdin)['data']['id'])")
+
+cat <<EOF
+APP_ID=$app_id
+API_KEY=$api_key
+EVENT_TYPE_ID=$event_type_id
+ENDPOINT_ID=$endpoint_id
+EOF


### PR DESCRIPTION
## Summary
Lays the foundation for the load-test work: a reproducible benchmark stack under \`tests/benchmark/\`, three baseline k6 scenarios, and a written-up bottleneck inventory with planned optimizations.

## Harness (\`tests/benchmark/\`)
- \`docker-compose.bench.yml\` — postgres + webhook-engine + ealen/echo receiver. Rate limits lifted on purpose so we measure the engine, not the limiter.
- \`seed.sh\` — provisions an app + endpoint + event type via the dashboard API.
- \`run-bench.sh\` — wraps \`grafana/k6\` in Docker; sub-commands: \`up\`, \`down\`, \`seed\`, \`single\`, \`batch\`, \`mixed\`, \`all\`.
- \`k6/single-send.js\`, \`batch-send.js\`, \`mixed.js\`.
- Results (\`results/*.json\`) and \`.bench.env\` are gitignored.

## Baseline (v0.1.4, Apple Silicon, full Docker stack)

| Scenario | Target | Sustained | p50 | p95 | p99 |
|---|---|---|---|---|---|
| \`single-send\` | 1000 req/s | **916 req/s** | 3.3 ms | **299 ms** | 509 ms |
| \`batch-send\` (50 msg/batch) | 2500 msg/s | **2500 msg/s** | 79 ms | 324 ms | — |
| \`mixed\` (send + list) | 350 req/s | **350 req/s** | 2.7 ms | 10 ms | — |

Zero HTTP failures across all three scenarios.

## Bottleneck inventory (full table in \`docs/PERFORMANCE.md\`)
After ~220K messages enqueued, \`pg_stat_statements\` flags:
- INSERT messages 50.8% (expected, hot path)
- \`SELECT count(*) FROM messages WHERE app_id\` 12.9%, **7.88 ms mean** (pagination count)
- DISCARD ALL **987K calls** in 60 s (Npgsql pool churn)
- ~11% spent on EF Core \`FOR KEY SHARE\` navigation locks
- Endpoint + event-type lookup repeats 222K times (cacheable)

## Configuration finding
Default rate limit (\`PermitLimit=100\`, \`TokensPerPeriod=2\`) sustains only 2 req/s per app — too tight for a self-host production baseline. Tracked separately in the optimization plan in the perf doc.

## Out of scope
This PR is the **harness + baseline + observation only.** The optimizations (auth caching, endpoint cache, pool tuning, rate limit defaults, \`AsNoTracking\` cleanup) are sequenced as separate PRs so each can be measured in isolation. Each PR will append a before/after row to \`docs/PERFORMANCE.md\`.

## Labels
\`performance\` \`documentation\` \`infrastructure\`

## Test plan
- [ ] CI green
- [ ] Run \`tests/benchmark/run-bench.sh up && tests/benchmark/run-bench.sh single 100 10s\` locally — produces a result JSON
- [ ] \`docs/PERFORMANCE.md\` renders correctly on GitHub