### PR TITLE
chore(api): raise default rate limits to a production floor

### DIFF
--- a/docs/SELF-HOSTING.md
+++ b/docs/SELF-HOSTING.md
@@ -92,6 +92,14 @@ WebhookEngine__Retention__DeadLetterRetentionDays=90
 # Dashboard auth
 WebhookEngine__DashboardAuth__AdminEmail=admin@example.com
 WebhookEngine__DashboardAuth__AdminPassword=changeme
+
+# Rate limit (per-application token bucket on public API endpoints)
+# Defaults: 500-burst bucket, 100 req/s sustained per app, 200 queued.
+# Tighten for shared multi-tenant deployments; loosen for high-throughput
+# senders.
+WebhookEngine__RateLimit__PermitLimit=500
+WebhookEngine__RateLimit__TokensPerPeriod=100
+WebhookEngine__RateLimit__QueueLimit=200
 ```
 
 ## Security Checklist

--- a/src/WebhookEngine.API/appsettings.json
+++ b/src/WebhookEngine.API/appsettings.json
@@ -27,10 +27,10 @@
       "DeadLetterRetentionDays": 90
     },
     "RateLimit": {
-      "PermitLimit": 100,
+      "PermitLimit": 500,
       "ReplenishmentPeriodSeconds": 1,
-      "TokensPerPeriod": 2,
-      "QueueLimit": 0
+      "TokensPerPeriod": 100,
+      "QueueLimit": 200
     }
   },
   "Serilog": {

--- a/src/WebhookEngine.Core/Options/RateLimitOptions.cs
+++ b/src/WebhookEngine.Core/Options/RateLimitOptions.cs
@@ -4,15 +4,20 @@ public class RateLimitOptions
 {
     public const string SectionName = "WebhookEngine:RateLimit";
 
-    /// <summary>Token bucket: max tokens in bucket at any time.</summary>
-    public int PermitLimit { get; set; } = 100;
+    /// <summary>Token bucket: max tokens in bucket at any time. Default 500
+    /// supports a sensible burst for self-hosted single-tenant deployments.</summary>
+    public int PermitLimit { get; set; } = 500;
 
     /// <summary>Token bucket: replenishment period in seconds.</summary>
     public int ReplenishmentPeriodSeconds { get; set; } = 1;
 
-    /// <summary>Tokens added per replenishment tick.</summary>
-    public int TokensPerPeriod { get; set; } = 2;
+    /// <summary>Tokens added per replenishment tick. Default 100 sustains
+    /// 100 req/s per app long-term — well above the original 2 req/s
+    /// floor that surprised early operators.</summary>
+    public int TokensPerPeriod { get; set; } = 100;
 
-    /// <summary>Max requests queued when bucket empty (0 = reject immediately).</summary>
-    public int QueueLimit { get; set; } = 0;
+    /// <summary>Max requests queued when bucket empty. Default 200 absorbs
+    /// transient bursts above PermitLimit instead of returning 429
+    /// immediately; 0 keeps the strict reject-on-empty behavior.</summary>
+    public int QueueLimit { get; set; } = 200;
 }


### PR DESCRIPTION
## Summary
Raises the out-of-the-box rate limit defaults so a fresh self-host doesn't hit a wall at 2 req/s per application.

| Setting | Before | After | Purpose |
|---|---|---|---|
| \`PermitLimit\` | 100 | **500** | burst capacity |
| \`TokensPerPeriod\` | 2 | **100** | sustained throughput per app |
| \`QueueLimit\` | 0 | **200** | absorb transient bursts vs. reject on empty |
| \`ReplenishmentPeriodSeconds\` | 1 | 1 | unchanged |

The bench harness in \`tests/benchmark/\` flagged the original defaults as the immediate ceiling — any load above 2 req/s per app produced an instant 429. New defaults mirror what a single-tenant self-host would expect from a webhook delivery service.

## Compatibility
- Existing operators that override these via \`WebhookEngine__RateLimit__*\` env vars are unaffected.
- 429 response shape (\`Retry-After\` header + ApiEnvelope error body) unchanged.
- Multi-tenant operators who need a tighter ceiling per app should set the env vars explicitly. \`docs/SELF-HOSTING.md\` gains an example block.

## Labels
\`enhancement\` \`api\` \`documentation\`

## Test plan
- [ ] CI green
- [ ] Default deployment (no overrides) handles ≥ 100 req/s per app for at least a minute without 429
- [ ] Existing override path still works: setting \`WebhookEngine__RateLimit__PermitLimit=10\` enforces the tighter cap