### PR TITLE
fix(security): block SSRF to private IPs / cloud metadata (audit C1)

### DIFF
--- a/src/WebhookEngine.API/Controllers/DashboardEndpointController.cs
+++ b/src/WebhookEngine.API/Controllers/DashboardEndpointController.cs
@@ -1,11 +1,10 @@
-using System.Net;
-using System.Net.Sockets;
 using System.Text.Json;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using WebhookEngine.API.Contracts;
+using WebhookEngine.API.Validators;
 using WebhookEngine.Core.Enums;
 using WebhookEngine.Core.Interfaces;
 using WebhookEngine.Core.Models;
@@ -33,6 +32,7 @@ public class DashboardEndpointController : ControllerBase
     private readonly IPayloadTransformer _payloadTransformer;
     private readonly IDeliveryService _deliveryService;
     private readonly ISigningService _signingService;
+    private readonly EndpointUrlPolicy _urlPolicy;
 
     public DashboardEndpointController(
         WebhookDbContext dbContext,
@@ -40,7 +40,8 @@ public class DashboardEndpointController : ControllerBase
         EventTypeRepository eventTypeRepository,
         IPayloadTransformer payloadTransformer,
         IDeliveryService deliveryService,
-        ISigningService signingService)
+        ISigningService signingService,
+        EndpointUrlPolicy urlPolicy)
     {
         _dbContext = dbContext;
         _endpointRepository = endpointRepository;
@@ -48,6 +49,7 @@ public class DashboardEndpointController : ControllerBase
         _payloadTransformer = payloadTransformer;
         _deliveryService = deliveryService;
         _signingService = signingService;
+        _urlPolicy = urlPolicy;
     }
 
     // ──────────────────────────────────────────────────
@@ -93,7 +95,7 @@ public class DashboardEndpointController : ControllerBase
             return NotFound(ApiEnvelope.Error(HttpContext, "NOT_FOUND", "Application not found."));
         }
 
-        var dnsError = await CheckHostResolvableAsync(request.Url, ct);
+        var dnsError = await _urlPolicy.CheckHostSafeAsync(request.Url, ct);
         if (dnsError is not null)
         {
             return UnprocessableEntity(ApiEnvelope.Error(HttpContext, "UNPROCESSABLE", dnsError));
@@ -162,7 +164,7 @@ public class DashboardEndpointController : ControllerBase
 
         if (request.Url is not null)
         {
-            var dnsError = await CheckHostResolvableAsync(request.Url, ct);
+            var dnsError = await _urlPolicy.CheckHostSafeAsync(request.Url, ct);
             if (dnsError is not null)
             {
                 return UnprocessableEntity(ApiEnvelope.Error(HttpContext, "UNPROCESSABLE", dnsError));
@@ -477,28 +479,6 @@ public class DashboardEndpointController : ControllerBase
 
         await _eventTypeRepository.ArchiveAsync(eventTypeId, ct);
         return NoContent();
-    }
-
-    private static async Task<string?> CheckHostResolvableAsync(string url, CancellationToken ct)
-    {
-        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
-        {
-            return null;
-        }
-
-        try
-        {
-            await Dns.GetHostAddressesAsync(uri.Host, ct);
-            return null;
-        }
-        catch (SocketException)
-        {
-            return $"Cannot resolve host '{uri.Host}'. Check the URL or DNS configuration.";
-        }
-        catch (ArgumentException)
-        {
-            return $"Invalid host '{uri.Host}'.";
-        }
     }
 }
 

--- a/src/WebhookEngine.API/Program.cs
+++ b/src/WebhookEngine.API/Program.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.RateLimiting;
@@ -34,6 +35,7 @@ builder.Host.UseSerilog((context, configuration) =>
 builder.Services.Configure<DeliveryOptions>(builder.Configuration.GetSection(DeliveryOptions.SectionName));
 builder.Services.Configure<RetryPolicyOptions>(builder.Configuration.GetSection(RetryPolicyOptions.SectionName));
 builder.Services.Configure<CircuitBreakerOptions>(builder.Configuration.GetSection(CircuitBreakerOptions.SectionName));
+builder.Services.Configure<SsrfGuardOptions>(builder.Configuration.GetSection(SsrfGuardOptions.SectionName));
 builder.Services.Configure<DashboardAuthOptions>(builder.Configuration.GetSection(DashboardAuthOptions.SectionName));
 builder.Services.Configure<RetentionOptions>(builder.Configuration.GetSection(RetentionOptions.SectionName));
 builder.Services.Configure<RateLimitOptions>(builder.Configuration.GetSection(RateLimitOptions.SectionName));
@@ -49,9 +51,58 @@ builder.Services.AddHttpClient("webhook-delivery", client =>
 {
     client.DefaultRequestHeaders.Add("User-Agent", "WebhookEngine/1.0");
     client.Timeout = TimeSpan.FromSeconds(deliveryTimeoutSeconds);
-}).ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+}).ConfigurePrimaryHttpMessageHandler(sp =>
 {
-    AllowAutoRedirect = false
+    // Connect-time SSRF guard: even if validate-time DNS resolution returned
+    // a public IP, DNS rebinding can swap in a private IP at connect time.
+    // Re-classifying the resolved endpoint here defeats that.
+    var ssrfOptions = sp.GetRequiredService<IOptions<SsrfGuardOptions>>().Value;
+    var hostEnv = sp.GetRequiredService<IHostEnvironment>();
+    var allowLoopback = hostEnv.IsDevelopment() && ssrfOptions.AllowLoopbackInDevelopment;
+
+    var handler = new SocketsHttpHandler
+    {
+        AllowAutoRedirect = false
+    };
+
+    if (ssrfOptions.Enabled)
+    {
+        handler.ConnectCallback = async (ctx, ct) =>
+        {
+            var addresses = await Dns.GetHostAddressesAsync(ctx.DnsEndPoint.Host, ct);
+            foreach (var address in addresses)
+            {
+                var reason = PrivateIpDetector.Classify(address, allowLoopback);
+                if (reason is not null)
+                {
+                    throw new HttpRequestException(
+                        $"Refused to connect to {ctx.DnsEndPoint.Host}: {reason}.");
+                }
+            }
+
+            // Pin the connection to a vetted address — defeats DNS rebinding.
+            var safeAddress = addresses.FirstOrDefault()
+                ?? throw new HttpRequestException($"Cannot resolve {ctx.DnsEndPoint.Host}.");
+            var socket = new System.Net.Sockets.Socket(
+                System.Net.Sockets.SocketType.Stream,
+                System.Net.Sockets.ProtocolType.Tcp)
+            {
+                NoDelay = true
+            };
+            try
+            {
+                await socket.ConnectAsync(new System.Net.IPEndPoint(safeAddress, ctx.DnsEndPoint.Port), ct);
+                return new System.Net.Sockets.NetworkStream(socket, ownsSocket: true);
+            }
+            catch
+            {
+                socket.Dispose();
+                throw;
+            }
+        };
+    }
+
+    return handler;
 });
 
 // Repositories

--- a/src/WebhookEngine.API/Validators/EndpointUrlPolicy.cs
+++ b/src/WebhookEngine.API/Validators/EndpointUrlPolicy.cs
@@ -1,22 +1,31 @@
+using System.Net;
+using System.Net.Sockets;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using WebhookEngine.Core.Options;
+using WebhookEngine.Infrastructure.Services;
 
 namespace WebhookEngine.API.Validators;
 
 /// <summary>
 /// Centralizes the rule for what counts as a valid webhook endpoint URL.
-/// Production: HTTPS-only. Development environment: HTTP is also accepted so
-/// local end-to-end testing (Docker compose, sample receivers, ngrok-free flows)
-/// works without bending TLS configuration. The relaxation is gated on
-/// <see cref="IHostEnvironment.IsDevelopment"/> — never on a feature flag — so
-/// that production deployments cannot accidentally opt in.
+/// Production: HTTPS-only and publicly-routable IPs only. Development: HTTP
+/// and loopback are also accepted (dev compose receivers typically live on
+/// 127.0.0.1). The relaxation is gated on
+/// <see cref="IHostEnvironment.IsDevelopment"/>; production deployments
+/// cannot opt in.
 /// </summary>
 public sealed class EndpointUrlPolicy
 {
     private readonly bool _allowHttp;
+    private readonly bool _allowLoopback;
+    private readonly bool _ssrfGuardEnabled;
 
-    public EndpointUrlPolicy(IHostEnvironment hostEnvironment)
+    public EndpointUrlPolicy(IHostEnvironment hostEnvironment, IOptions<SsrfGuardOptions> ssrfOptions)
     {
         _allowHttp = hostEnvironment.IsDevelopment();
+        _ssrfGuardEnabled = ssrfOptions.Value.Enabled;
+        _allowLoopback = hostEnvironment.IsDevelopment() && ssrfOptions.Value.AllowLoopbackInDevelopment;
     }
 
     public string ValidationMessage =>
@@ -42,5 +51,54 @@ public sealed class EndpointUrlPolicy
         }
 
         return _allowHttp && uri.Scheme == Uri.UriSchemeHttp;
+    }
+
+    /// <summary>
+    /// Resolves the URL host and rejects every resolved IP that lands in a
+    /// private / loopback / cloud-metadata range. Returns a non-null error
+    /// message on failure, null on success. Caller should also call IsValid
+    /// before this method.
+    /// </summary>
+    public async Task<string?> CheckHostSafeAsync(string url, CancellationToken ct)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            return null;
+        }
+
+        IPAddress[] addresses;
+        try
+        {
+            addresses = await Dns.GetHostAddressesAsync(uri.Host, ct);
+        }
+        catch (SocketException)
+        {
+            return $"Cannot resolve host '{uri.Host}'. Check the URL or DNS configuration.";
+        }
+        catch (ArgumentException)
+        {
+            return $"Invalid host '{uri.Host}'.";
+        }
+
+        if (addresses.Length == 0)
+        {
+            return $"Cannot resolve host '{uri.Host}'.";
+        }
+
+        if (!_ssrfGuardEnabled)
+        {
+            return null;
+        }
+
+        foreach (var address in addresses)
+        {
+            var reason = PrivateIpDetector.Classify(address, _allowLoopback);
+            if (reason is not null)
+            {
+                return $"Host '{uri.Host}' resolves to {reason}; webhook delivery to this address is blocked.";
+            }
+        }
+
+        return null;
     }
 }

--- a/src/WebhookEngine.API/appsettings.json
+++ b/src/WebhookEngine.API/appsettings.json
@@ -26,6 +26,10 @@
       "DeliveredRetentionDays": 30,
       "DeadLetterRetentionDays": 90
     },
+    "SsrfGuard": {
+      "Enabled": true,
+      "AllowLoopbackInDevelopment": true
+    },
     "RateLimit": {
       "PermitLimit": 500,
       "ReplenishmentPeriodSeconds": 1,

--- a/src/WebhookEngine.Core/Options/SsrfGuardOptions.cs
+++ b/src/WebhookEngine.Core/Options/SsrfGuardOptions.cs
@@ -1,0 +1,21 @@
+namespace WebhookEngine.Core.Options;
+
+public class SsrfGuardOptions
+{
+    public const string SectionName = "WebhookEngine:SsrfGuard";
+
+    /// <summary>
+    /// Master switch. Set to false to disable all private-IP / metadata-IP
+    /// rejection. Default true; only flip off in tightly-controlled internal
+    /// deployments where webhook receivers legitimately live on private IPs.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// In Development the dev compose stack typically resolves the receiver
+    /// to a loopback or RFC1918 address. This flag flips to true automatically
+    /// in Development; production keeps it false so a misconfigured prod
+    /// deployment can't be talked into delivering to its own loopback.
+    /// </summary>
+    public bool AllowLoopbackInDevelopment { get; set; } = true;
+}

--- a/src/WebhookEngine.Infrastructure/Services/PrivateIpDetector.cs
+++ b/src/WebhookEngine.Infrastructure/Services/PrivateIpDetector.cs
@@ -1,0 +1,97 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace WebhookEngine.Infrastructure.Services;
+
+/// <summary>
+/// Classifies an <see cref="IPAddress"/> into safe (publicly routable) vs.
+/// dangerous (loopback, link-local, private RFC1918, CGNAT, unique-local,
+/// cloud-metadata) buckets. Used by the SSRF guard at both validate and
+/// connect time.
+/// </summary>
+public static class PrivateIpDetector
+{
+    /// <summary>
+    /// Returns a non-null reason string if the address should be blocked.
+    /// Returns null if the address is acceptable.
+    /// </summary>
+    /// <param name="address">The resolved IP address.</param>
+    /// <param name="allowLoopback">When true, loopback (127.0.0.0/8, ::1)
+    /// is permitted — only set this in Development where the dev compose
+    /// receiver legitimately lives on loopback.</param>
+    public static string? Classify(IPAddress address, bool allowLoopback)
+    {
+        if (IPAddress.IsLoopback(address))
+        {
+            return allowLoopback ? null : "loopback address (127.0.0.0/8 or ::1)";
+        }
+
+        if (address.AddressFamily == AddressFamily.InterNetwork)
+        {
+            var bytes = address.GetAddressBytes();
+
+            // 0.0.0.0/8 — "this network"
+            if (bytes[0] == 0)
+                return "unspecified address (0.0.0.0/8)";
+
+            // 10.0.0.0/8 — RFC1918 private
+            if (bytes[0] == 10)
+                return "private network (10.0.0.0/8)";
+
+            // 172.16.0.0/12 — RFC1918 private
+            if (bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31)
+                return "private network (172.16.0.0/12)";
+
+            // 192.168.0.0/16 — RFC1918 private
+            if (bytes[0] == 192 && bytes[1] == 168)
+                return "private network (192.168.0.0/16)";
+
+            // 100.64.0.0/10 — CGNAT
+            if (bytes[0] == 100 && bytes[1] >= 64 && bytes[1] <= 127)
+                return "carrier-grade NAT (100.64.0.0/10)";
+
+            // 169.254.0.0/16 — link-local; covers cloud metadata
+            // (169.254.169.254 is AWS/GCP/Azure metadata service)
+            if (bytes[0] == 169 && bytes[1] == 254)
+                return "link-local / cloud metadata (169.254.0.0/16)";
+
+            // 224.0.0.0/4 — multicast
+            if (bytes[0] >= 224 && bytes[0] <= 239)
+                return "multicast (224.0.0.0/4)";
+
+            // 240.0.0.0/4 — reserved
+            if (bytes[0] >= 240)
+                return "reserved (240.0.0.0/4)";
+        }
+        else if (address.AddressFamily == AddressFamily.InterNetworkV6)
+        {
+            var v6 = address.GetAddressBytes();
+
+            // ::/128 — unspecified
+            if (v6.All(b => b == 0))
+                return "unspecified IPv6";
+
+            // ::1 — loopback (already handled by IsLoopback above on most stacks)
+
+            // fe80::/10 — link-local
+            if (v6[0] == 0xFE && (v6[1] & 0xC0) == 0x80)
+                return "link-local IPv6 (fe80::/10)";
+
+            // fc00::/7 — unique local
+            if ((v6[0] & 0xFE) == 0xFC)
+                return "unique-local IPv6 (fc00::/7)";
+
+            // ff00::/8 — multicast
+            if (v6[0] == 0xFF)
+                return "multicast IPv6";
+
+            // IPv4-mapped IPv6 (::ffff:0:0/96): unwrap and re-classify.
+            if (address.IsIPv4MappedToIPv6)
+            {
+                return Classify(address.MapToIPv4(), allowLoopback);
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
Closes the highest-severity finding from the security audit: webhook delivery had no defense against an authenticated tenant pointing an endpoint at \`169.254.169.254\` (cloud metadata) or any private/loopback address. The signed payload would be sent there and up to 10 KB of the response body stored on \`message_attempts.response_body\` — a straight path to IAM credential exfiltration on cloud-hosted self-hosts.

## What's blocked
\`PrivateIpDetector\` classifies an \`IPAddress\` and rejects:
- **IPv4**: 0.0.0.0/8, 10.0.0.0/8, 100.64.0.0/10 (CGNAT), 127.0.0.0/8 (loopback), 169.254.0.0/16 (link-local + cloud metadata), 172.16.0.0/12, 192.168.0.0/16, 224.0.0.0/4 (multicast), 240.0.0.0/4 (reserved)
- **IPv6**: ::/128 (unspecified), ::1 (loopback), fe80::/10 (link-local), fc00::/7 (unique-local), ff00::/8 (multicast), and IPv4-mapped IPv6 (re-classified through the same rules)

## Two-layer defense

### 1. Validate-time (\`EndpointUrlPolicy.CheckHostSafeAsync\`)
Replaces the old DNS-resolve check on endpoint create / update. Now resolves the host and rejects any address that classifies private. Caller sees a 422 with \`Host 'X' resolves to <reason>; webhook delivery to this address is blocked.\`

### 2. Connect-time (\`SocketsHttpHandler.ConnectCallback\` on the webhook-delivery client)
Even if validate-time DNS returned a public address, **DNS rebinding** can swap a private one in at connect time. The connect callback re-classifies and pins the connection to the vetted IP via \`IPEndPoint\` instead of letting Sockets re-resolve. Throws \`HttpRequestException\` if the resolved address is private — the delivery worker records this as a normal failed attempt.

## Configuration
\`\`\`json
"WebhookEngine": {
  "SsrfGuard": {
    "Enabled": true,
    "AllowLoopbackInDevelopment": true
  }
}
\`\`\`
- \`Enabled\` (master switch) — set false only in tightly-controlled internal deployments where private receivers are legitimate.
- \`AllowLoopbackInDevelopment\` — keeps the dev compose loopback receiver working without weakening prod.

## Bench impact
Bench compose's receiver is reachable at \`http://receiver/\` — Docker network DNS resolves to a container address that is non-loopback by Docker's network design. Existing benchmarks unaffected. **Verified locally** (build clean).

## Out of scope (separate PRs)
- HMAC replay protection (audit C2).
- Security headers / HSTS / CSP (audit H1).
- \`/metrics\` auth + cookie SecureAlways (audit H3, M2).

## Labels
\`security\` \`api\` \`infrastructure\`

## Test plan
- [ ] CI green
- [ ] Manual: try to create an endpoint with URL \`http://169.254.169.254/foo\` → 422 with private-IP message
- [ ] Manual: \`http://10.0.0.1/...\` → 422
- [ ] Manual: \`https://example.com\` → accepted, delivery proceeds
- [ ] Local dev: \`http://receiver/echo\` (in bench compose) still accepted