### PR TITLE
fix(worker): CAS guard on Mark* — eliminate stale-lock duplicate delivery (C2)

### DIFF
--- a/src/WebhookEngine.Infrastructure/Repositories/MessageRepository.cs
+++ b/src/WebhookEngine.Infrastructure/Repositories/MessageRepository.cs
@@ -160,26 +160,39 @@ public class MessageRepository
                 .SetProperty(m => m.DeliveredAt, status == MessageStatus.Delivered ? DateTime.UtcNow : (DateTime?)null), ct);
     }
 
-    public async Task MarkDeliveredAsync(Guid messageId, int attemptCount, CancellationToken ct = default)
+    /// <summary>
+    /// Compare-and-set transition Sending → Delivered. Returns true when the
+    /// row matched (we owned the lock); false when the row had already been
+    /// stolen by stale-lock recovery or another worker — in that case the
+    /// caller must abandon and not record a duplicate attempt.
+    /// </summary>
+    public async Task<bool> MarkDeliveredAsync(Guid messageId, int attemptCount, string lockedBy, CancellationToken ct = default)
     {
-        await _dbContext.Messages
-            .Where(m => m.Id == messageId)
+        var rows = await _dbContext.Messages
+            .Where(m => m.Id == messageId
+                && m.Status == MessageStatus.Sending
+                && m.LockedBy == lockedBy)
             .ExecuteUpdateAsync(setters => setters
                 .SetProperty(m => m.Status, MessageStatus.Delivered)
                 .SetProperty(m => m.AttemptCount, attemptCount)
                 .SetProperty(m => m.DeliveredAt, DateTime.UtcNow)
                 .SetProperty(m => m.LockedAt, (DateTime?)null)
                 .SetProperty(m => m.LockedBy, (string?)null), ct);
+        return rows == 1;
     }
 
-    public async Task MarkFailedForRetryAsync(
+    /// <inheritdoc cref="MarkDeliveredAsync"/>
+    public async Task<bool> MarkFailedForRetryAsync(
         Guid messageId,
         int attemptCount,
         DateTime nextScheduledAt,
+        string lockedBy,
         CancellationToken ct = default)
     {
-        await _dbContext.Messages
-            .Where(m => m.Id == messageId)
+        var rows = await _dbContext.Messages
+            .Where(m => m.Id == messageId
+                && m.Status == MessageStatus.Sending
+                && m.LockedBy == lockedBy)
             .ExecuteUpdateAsync(setters => setters
                 .SetProperty(m => m.Status, MessageStatus.Failed)
                 .SetProperty(m => m.AttemptCount, attemptCount)
@@ -187,18 +200,23 @@ public class MessageRepository
                 .SetProperty(m => m.DeliveredAt, (DateTime?)null)
                 .SetProperty(m => m.LockedAt, (DateTime?)null)
                 .SetProperty(m => m.LockedBy, (string?)null), ct);
+        return rows == 1;
     }
 
-    public async Task MarkDeadLetterAsync(Guid messageId, int attemptCount, CancellationToken ct = default)
+    /// <inheritdoc cref="MarkDeliveredAsync"/>
+    public async Task<bool> MarkDeadLetterAsync(Guid messageId, int attemptCount, string lockedBy, CancellationToken ct = default)
     {
-        await _dbContext.Messages
-            .Where(m => m.Id == messageId)
+        var rows = await _dbContext.Messages
+            .Where(m => m.Id == messageId
+                && m.Status == MessageStatus.Sending
+                && m.LockedBy == lockedBy)
             .ExecuteUpdateAsync(setters => setters
                 .SetProperty(m => m.Status, MessageStatus.DeadLetter)
                 .SetProperty(m => m.AttemptCount, attemptCount)
                 .SetProperty(m => m.DeliveredAt, (DateTime?)null)
                 .SetProperty(m => m.LockedAt, (DateTime?)null)
                 .SetProperty(m => m.LockedBy, (string?)null), ct);
+        return rows == 1;
     }
 
     public async Task ReschedulePendingAsync(Guid messageId, DateTime scheduledAt, CancellationToken ct = default)

--- a/src/WebhookEngine.Worker/DeliveryWorker.cs
+++ b/src/WebhookEngine.Worker/DeliveryWorker.cs
@@ -118,8 +118,12 @@ public class DeliveryWorker : BackgroundService
 
                 if (currentAttemptForCircuit >= message.MaxRetries)
                 {
+                    if (!await messageRepo.MarkDeadLetterAsync(message.Id, currentAttemptForCircuit, _workerId, ct))
+                    {
+                        _logger.LogDebug("MarkDeadLetter (circuit-open) lost the row {MessageId} — abandoning", message.Id);
+                        return;
+                    }
                     _metrics?.RecordDeadLetter();
-                    await messageRepo.MarkDeadLetterAsync(message.Id, currentAttemptForCircuit, ct);
                     _logger.LogWarning(
                         "Message {MessageId} moved to dead letter — circuit open for endpoint {EndpointId}, max retries ({MaxRetries}) exhausted",
                         message.Id, message.EndpointId, message.MaxRetries);
@@ -135,7 +139,10 @@ public class DeliveryWorker : BackgroundService
                 var health = await healthTracker.GetHealthAsync(message.EndpointId, ct);
                 var nextTryAt = health?.CooldownUntil ?? DateTime.UtcNow.AddMinutes(1);
 
-                await messageRepo.MarkFailedForRetryAsync(message.Id, currentAttemptForCircuit, nextTryAt, ct);
+                if (!await messageRepo.MarkFailedForRetryAsync(message.Id, currentAttemptForCircuit, nextTryAt, _workerId, ct))
+                {
+                    _logger.LogDebug("MarkFailedForRetry (circuit-open) lost the row {MessageId} — abandoning", message.Id);
+                }
                 return;
             }
 
@@ -143,7 +150,7 @@ public class DeliveryWorker : BackgroundService
             if (endpoint is null)
             {
                 _logger.LogWarning("Endpoint {EndpointId} not found for message {MessageId}", message.EndpointId, message.Id);
-                await messageRepo.MarkDeadLetterAsync(message.Id, message.AttemptCount, ct);
+                await messageRepo.MarkDeadLetterAsync(message.Id, message.AttemptCount, _workerId, ct);
                 return;
             }
 
@@ -171,7 +178,7 @@ public class DeliveryWorker : BackgroundService
             if (string.IsNullOrWhiteSpace(signingSecret))
             {
                 _logger.LogError("Signing secret missing for endpoint {EndpointId}, message {MessageId}", message.EndpointId, message.Id);
-                await messageRepo.MarkDeadLetterAsync(message.Id, message.AttemptCount, ct);
+                await messageRepo.MarkDeadLetterAsync(message.Id, message.AttemptCount, _workerId, ct);
                 return;
             }
 
@@ -221,9 +228,15 @@ public class DeliveryWorker : BackgroundService
 
             if (result.Success)
             {
-                _metrics?.RecordDeliverySuccess(result.LatencyMs);
-                await messageRepo.MarkDeliveredAsync(message.Id, currentAttempt, ct);
+                if (!await messageRepo.MarkDeliveredAsync(message.Id, currentAttempt, _workerId, ct))
+                {
+                    _logger.LogWarning(
+                        "MarkDelivered lost the row {MessageId} (stale-lock recovered or another worker took over) — abandoning to avoid duplicate state",
+                        message.Id);
+                    return;
+                }
                 message.Status = MessageStatus.Delivered;
+                _metrics?.RecordDeliverySuccess(result.LatencyMs);
                 await healthTracker.RecordSuccessAsync(message.EndpointId, ct);
                 _logger.LogInformation("Message {MessageId} delivered to {EndpointId} in {LatencyMs}ms", message.Id, message.EndpointId, result.LatencyMs);
 
@@ -237,8 +250,12 @@ public class DeliveryWorker : BackgroundService
 
                 if (currentAttempt >= message.MaxRetries)
                 {
+                    if (!await messageRepo.MarkDeadLetterAsync(message.Id, currentAttempt, _workerId, ct))
+                    {
+                        _logger.LogWarning("MarkDeadLetter lost the row {MessageId} — abandoning", message.Id);
+                        return;
+                    }
                     _metrics?.RecordDeadLetter();
-                    await messageRepo.MarkDeadLetterAsync(message.Id, currentAttempt, ct);
                     message.Status = MessageStatus.DeadLetter;
                     _logger.LogWarning("Message {MessageId} moved to dead letter after {AttemptCount} attempts", message.Id, currentAttempt);
 
@@ -247,9 +264,13 @@ public class DeliveryWorker : BackgroundService
                 }
                 else
                 {
-                    _metrics?.RecordRetryScheduled();
                     var nextRetryAt = CalculateNextRetryAt(currentAttempt);
-                    await messageRepo.MarkFailedForRetryAsync(message.Id, currentAttempt, nextRetryAt, ct);
+                    if (!await messageRepo.MarkFailedForRetryAsync(message.Id, currentAttempt, nextRetryAt, _workerId, ct))
+                    {
+                        _logger.LogWarning("MarkFailedForRetry lost the row {MessageId} — abandoning", message.Id);
+                        return;
+                    }
+                    _metrics?.RecordRetryScheduled();
                     message.Status = MessageStatus.Failed;
                     _logger.LogWarning(
                         "Message {MessageId} delivery failed (attempt {AttemptCount}). Next retry at {NextRetryAt}. Error: {Error}",


### PR DESCRIPTION
## Summary
Closes the second-most-severe finding from the concurrency audit: duplicate delivery when a stale-lock handoff overlaps a slow worker's late return.

## The race
1. Worker A dequeues msg 1, transitions to \`Sending\`, sets \`LockedBy = A\`.
2. A's HTTP POST hangs past \`StaleLockMinutes\`.
3. \`StaleLockRecoveryWorker\` resets the row to \`Pending\`.
4. Worker B dequeues, delivers successfully, calls \`MarkDeliveredAsync\`.
5. **A's POST returns 200**, A calls \`MarkDeliveredAsync\` — and overwrites the row, appends a second attempt row, fires \`NotifyDeliverySuccess\` again.

Two real HTTP deliveries; observers see one row but two attempts; if A's response was 500, A overwrites \`Delivered → Failed\`, RetryScheduler re-enqueues, third delivery follows.

## Fix
\`Mark{Delivered,FailedForRetry,DeadLetter}Async\` now CAS on \`Status = Sending AND LockedBy = expectedLockedBy\` and return \`bool\`:

\`\`\`csharp
var rows = await _dbContext.Messages
    .Where(m => m.Id == messageId
        && m.Status == MessageStatus.Sending
        && m.LockedBy == lockedBy)
    .ExecuteUpdateAsync(...);
return rows == 1;
\`\`\`

\`DeliveryWorker\` passes \`_workerId\` and abandons on \`false\`:
\`\`\`
_logger.LogWarning("MarkDelivered lost the row {MessageId} — abandoning to avoid duplicate state", message.Id);
return;
\`\`\`

After abandon the worker does not record a second attempt and does not fire notifier callbacks, so observers see exactly one terminal state per message ID.

## Compatibility
\`MarkDeliveredAsync\`, \`MarkFailedForRetryAsync\`, \`MarkDeadLetterAsync\` gain a mandatory \`string lockedBy\` parameter and now return \`bool\`. \`MessageRepository\` is project-internal — no external API surface changes.

\`Worker.Tests\` and \`Infrastructure.Tests/EndToEnd/DeliveryFlowEndToEndTests\` exercise the success / failure / DeadLetter / circuit-open paths via \`DeliveryWorker\` (not directly), so the new parameter does not break test compilation.

## Verified
- \`dotnet build WebhookEngine.sln --configuration Release\` — 0 / 0
- CI Backend job will run the e2e Testcontainer suite against the new CAS path

## Out of scope
- \`EndpointHealthTracker\` advisory-lock fix (audit C1) — next PR (F3).
- Idempotency unique constraint (audit H1) — F7.

## Labels
\`security\` \`worker\` \`infrastructure\`

## Test plan
- [ ] CI green
- [ ] No regression in existing 4 e2e scenarios
- [ ] Manual: simulate a slow worker by inserting a delay, verify "lost the row" log on the late side