### PR TITLE
fix(infra): advisory-lock EndpointHealthTracker mutations (audit C1)

### DIFF
--- a/src/WebhookEngine.Infrastructure/Services/EndpointHealthTracker.cs
+++ b/src/WebhookEngine.Infrastructure/Services/EndpointHealthTracker.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using WebhookEngine.Core.Entities;
 using WebhookEngine.Core.Enums;
@@ -14,27 +15,108 @@ public class EndpointHealthTracker : IEndpointHealthTracker
     private readonly WebhookDbContext _dbContext;
     private readonly CircuitBreakerOptions _options;
     private readonly WebhookMetrics? _metrics;
+    private readonly ILogger<EndpointHealthTracker>? _logger;
 
     public EndpointHealthTracker(
         WebhookDbContext dbContext,
         IOptions<CircuitBreakerOptions> options,
-        WebhookMetrics? metrics = null)
+        WebhookMetrics? metrics = null,
+        ILogger<EndpointHealthTracker>? logger = null)
     {
         _dbContext = dbContext;
         _options = options.Value;
         _metrics = metrics;
+        _logger = logger;
     }
 
-    public async Task RecordSuccessAsync(Guid endpointId, CancellationToken ct = default)
-    {
-        var health = await GetOrCreateHealthAsync(endpointId, ct);
-        var now = DateTime.UtcNow;
+    public Task RecordSuccessAsync(Guid endpointId, CancellationToken ct = default) =>
+        WithEndpointLockAsync(endpointId, ApplySuccess, ct);
 
+    public Task RecordFailureAsync(Guid endpointId, CancellationToken ct = default) =>
+        WithEndpointLockAsync(endpointId, ApplyFailure, ct);
+
+    public async Task<CircuitState> GetCircuitStateAsync(Guid endpointId, CancellationToken ct = default)
+    {
+        var health = await _dbContext.EndpointHealths
+            .AsNoTracking()
+            .FirstOrDefaultAsync(h => h.EndpointId == endpointId, ct);
+        return health?.CircuitState ?? CircuitState.Closed;
+    }
+
+    public async Task<EndpointHealth?> GetHealthAsync(Guid endpointId, CancellationToken ct = default)
+    {
+        return await _dbContext.EndpointHealths
+            .AsNoTracking()
+            .FirstOrDefaultAsync(h => h.EndpointId == endpointId, ct);
+    }
+
+    /// <summary>
+    /// Wraps a health-mutation in an advisory-locked transaction so two
+    /// concurrent attempts on the same endpoint can't race the consecutive-
+    /// failure counter or step on each other's state transitions. Same
+    /// lock-key namespace as <c>CircuitBreakerWorker</c> so a sweep and a
+    /// delivery attempt serialize against each other.
+    /// </summary>
+    private async Task WithEndpointLockAsync(Guid endpointId, Action<EndpointHealth> mutate, CancellationToken ct)
+    {
+        var isInMemory = string.Equals(
+            _dbContext.Database.ProviderName,
+            "Microsoft.EntityFrameworkCore.InMemory",
+            StringComparison.Ordinal);
+
+        if (isInMemory)
+        {
+            // InMemory tests don't speak Postgres advisory locks; tests don't
+            // exercise concurrent writers anyway.
+            var memHealth = await GetOrCreateHealthAsync(endpointId, ct);
+            mutate(memHealth);
+            await UpdateEndpointStatusAsync(endpointId, memHealth, DateTime.UtcNow, ct);
+            await _dbContext.SaveChangesAsync(ct);
+            return;
+        }
+
+        await using var transaction = await _dbContext.Database.BeginTransactionAsync(ct);
+        try
+        {
+            var endpointBytes = endpointId.ToByteArray();
+            var low = BitConverter.ToUInt32(endpointBytes, 0);
+            var lockKey = ((long)100_001 << 32) | low;
+            await _dbContext.Database
+                .ExecuteSqlInterpolatedAsync($"SELECT pg_advisory_xact_lock({lockKey})", ct);
+
+            // Re-read inside the lock so we mutate the freshest state.
+            var health = await _dbContext.EndpointHealths
+                .FirstOrDefaultAsync(h => h.EndpointId == endpointId, ct);
+
+            if (health is null)
+            {
+                health = new EndpointHealth { EndpointId = endpointId };
+                _dbContext.EndpointHealths.Add(health);
+            }
+
+            mutate(health);
+            await UpdateEndpointStatusAsync(endpointId, health, DateTime.UtcNow, ct);
+            await _dbContext.SaveChangesAsync(ct);
+            await transaction.CommitAsync(ct);
+        }
+        catch
+        {
+            try { await transaction.RollbackAsync(ct); } catch { /* best-effort */ }
+            throw;
+        }
+    }
+
+    private void ApplySuccess(EndpointHealth health)
+    {
+        var now = DateTime.UtcNow;
         health.LastSuccessAt = now;
         health.UpdatedAt = now;
 
         if (health.CircuitState == CircuitState.HalfOpen)
         {
+            // ConsecutiveFailures doubles as the half-open success counter
+            // by historical accident — flagged in the audit, tracked as a
+            // follow-up to keep blast radius small.
             var successThreshold = Math.Max(1, _options.SuccessThreshold);
             health.ConsecutiveFailures = Math.Max(0, health.ConsecutiveFailures) + 1;
 
@@ -49,68 +131,40 @@ public class EndpointHealthTracker : IEndpointHealthTracker
         else
         {
             health.ConsecutiveFailures = 0;
+            health.CooldownUntil = null;
         }
-
-        await UpdateEndpointStatusAsync(endpointId, health, now, ct);
-
-        await _dbContext.SaveChangesAsync(ct);
     }
 
-    public async Task RecordFailureAsync(Guid endpointId, CancellationToken ct = default)
+    private void ApplyFailure(EndpointHealth health)
     {
-        var health = await GetOrCreateHealthAsync(endpointId, ct);
-
+        var now = DateTime.UtcNow;
         health.ConsecutiveFailures++;
-        health.LastFailureAt = DateTime.UtcNow;
-        health.UpdatedAt = DateTime.UtcNow;
+        health.LastFailureAt = now;
+        health.UpdatedAt = now;
 
-        if (health.ConsecutiveFailures >= _options.FailureThreshold && health.CircuitState == CircuitState.Closed)
+        if (health.CircuitState == CircuitState.Closed
+            && health.ConsecutiveFailures >= _options.FailureThreshold)
         {
             health.CircuitState = CircuitState.Open;
-            health.CooldownUntil = DateTime.UtcNow.AddMinutes(_options.CooldownMinutes);
+            health.CooldownUntil = now.AddMinutes(_options.CooldownMinutes);
             _metrics?.RecordCircuitOpened();
         }
         else if (health.CircuitState == CircuitState.HalfOpen)
         {
             health.CircuitState = CircuitState.Open;
-            health.CooldownUntil = DateTime.UtcNow.AddMinutes(_options.CooldownMinutes);
+            health.CooldownUntil = now.AddMinutes(_options.CooldownMinutes);
             _metrics?.RecordCircuitOpened();
         }
-
-        await UpdateEndpointStatusAsync(endpointId, health, DateTime.UtcNow, ct);
-
-        await _dbContext.SaveChangesAsync(ct);
-    }
-
-    public async Task<CircuitState> GetCircuitStateAsync(Guid endpointId, CancellationToken ct = default)
-    {
-        var health = await _dbContext.EndpointHealths
-            .AsNoTracking()
-            .FirstOrDefaultAsync(h => h.EndpointId == endpointId, ct);
-
-        if (health is null)
-            return CircuitState.Closed;
-
-        return health.CircuitState;
-    }
-
-    public async Task<EndpointHealth?> GetHealthAsync(Guid endpointId, CancellationToken ct = default)
-    {
-        return await _dbContext.EndpointHealths
-            .AsNoTracking()
-            .FirstOrDefaultAsync(h => h.EndpointId == endpointId, ct);
     }
 
     private async Task<EndpointHealth> GetOrCreateHealthAsync(Guid endpointId, CancellationToken ct)
     {
         var health = await _dbContext.EndpointHealths.FirstOrDefaultAsync(h => h.EndpointId == endpointId, ct);
-
         if (health is null)
         {
             health = new EndpointHealth { EndpointId = endpointId };
             _dbContext.EndpointHealths.Add(health);
         }
-
         return health;
     }
 


### PR DESCRIPTION
## Summary
Closes the highest-severity finding from the concurrency audit: \`EndpointHealthTracker.RecordSuccess/Failure\` mutated rows without serialization, so two concurrent deliveries could race the consecutive-failure counter and step on each other's circuit transitions. \`CircuitBreakerWorker\` already used the right pattern; this PR makes the tracker honor the same invariant.

## The race
1. Two delivery workers both fail to the same endpoint at ~the same instant.
2. Both load \`ConsecutiveFailures = 4\`, increment to 5, save. Final counter: 5 (should be 6).
3. In HalfOpen, one success + one failure could race so the success "wins" and Closes the circuit despite the concurrent failure.

## Fix
Both methods go through a new private \`WithEndpointLockAsync\`:
\`\`\`csharp
BEGIN;
SELECT pg_advisory_xact_lock(((100_001::bigint << 32) | endpoint_low_4_bytes));
-- re-read EndpointHealth under the lock
mutate(health);
SaveChanges;
COMMIT;
\`\`\`

Same lock-key shape as \`CircuitBreakerWorker\` so a CB sweep and a delivery attempt serialize against each other rather than racing. The re-read inside the lock catches the case where the candidate state changed between the worker's first peek and the lock acquisition.

## InMemory test handling
\`Microsoft.EntityFrameworkCore.InMemory\` doesn't speak advisory locks. The helper detects that provider and runs without the lock — InMemory tests don't exercise concurrent writers anyway. The real concurrency-correctness coverage comes from \`Infrastructure.Tests/EndToEnd/DeliveryFlowEndToEndTests\` against real Postgres in CI.

## Compatibility
Public \`IEndpointHealthTracker\` surface unchanged. Same method signatures, same semantics outside the rare race window. The audit's H2 finding (dual-meaning \`ConsecutiveFailures\` field that also acts as the half-open success counter) is left as a follow-up because fixing it requires a schema change.

## Verified
- \`dotnet build WebhookEngine.sln --configuration Release\` — 0 / 0
- CI's e2e Testcontainer suite will exercise the new lock path

## Out of scope
- ConsecutiveFailures vs ConsecutiveSuccesses split — needs a migration, separate PR.
- Idempotency unique constraint (audit H1) — F7.

## Labels
\`security\` \`infrastructure\` \`worker\`

## Test plan
- [ ] CI green
- [ ] No regression in the four \`DeliveryFlowEndToEndTests\` scenarios