### PR TITLE
fix(infra): cap IMemoryCache + per-app invalidation (audit Mem C1/C2)

### DIFF
--- a/src/WebhookEngine.API/Controllers/DashboardEndpointController.cs
+++ b/src/WebhookEngine.API/Controllers/DashboardEndpointController.cs
@@ -10,6 +10,7 @@ using WebhookEngine.Core.Interfaces;
 using WebhookEngine.Core.Models;
 using WebhookEngine.Infrastructure.Data;
 using WebhookEngine.Infrastructure.Repositories;
+using WebhookEngine.Infrastructure.Services;
 using Endpoint = WebhookEngine.Core.Entities.Endpoint;
 
 namespace WebhookEngine.API.Controllers;
@@ -131,6 +132,7 @@ public class DashboardEndpointController : ControllerBase
         }
 
         await _endpointRepository.CreateAsync(endpoint, ct);
+        DeliveryLookupCache.InvalidateApplication(endpoint.AppId);
         var created = await _endpointRepository.GetByIdAsync(endpoint.Id, ct);
 
         return Created($"/api/v1/dashboard/endpoints/{endpoint.Id}", ApiEnvelope.Success(HttpContext, new
@@ -214,6 +216,7 @@ public class DashboardEndpointController : ControllerBase
         }
 
         await _endpointRepository.UpdateAsync(endpoint, ct);
+        DeliveryLookupCache.InvalidateApplication(endpoint.AppId);
         var updated = await _endpointRepository.GetByIdAsync(endpoint.Id, ct);
 
         return Ok(ApiEnvelope.Success(HttpContext, new
@@ -246,6 +249,7 @@ public class DashboardEndpointController : ControllerBase
 
         endpoint.Status = EndpointStatus.Disabled;
         await _endpointRepository.UpdateAsync(endpoint, ct);
+        DeliveryLookupCache.InvalidateApplication(endpoint.AppId);
 
         return Ok(ApiEnvelope.Success(HttpContext, new
         {
@@ -265,6 +269,7 @@ public class DashboardEndpointController : ControllerBase
 
         endpoint.Status = EndpointStatus.Active;
         await _endpointRepository.UpdateAsync(endpoint, ct);
+        DeliveryLookupCache.InvalidateApplication(endpoint.AppId);
 
         return Ok(ApiEnvelope.Success(HttpContext, new
         {
@@ -283,6 +288,7 @@ public class DashboardEndpointController : ControllerBase
         }
 
         await _endpointRepository.DeleteAsync(endpointId, ct);
+        DeliveryLookupCache.InvalidateApplication(endpoint.AppId);
         return NoContent();
     }
 
@@ -408,6 +414,7 @@ public class DashboardEndpointController : ControllerBase
         };
 
         await _eventTypeRepository.CreateAsync(eventType, ct);
+        DeliveryLookupCache.InvalidateApplication(eventType.AppId);
 
         return Created($"/api/v1/dashboard/event-types/{eventType.Id}", ApiEnvelope.Success(HttpContext, new
         {
@@ -456,6 +463,7 @@ public class DashboardEndpointController : ControllerBase
             eventType.Description = request.Description;
 
         await _eventTypeRepository.UpdateAsync(eventType, ct);
+        DeliveryLookupCache.InvalidateApplication(eventType.AppId);
 
         return Ok(ApiEnvelope.Success(HttpContext, new
         {
@@ -478,6 +486,7 @@ public class DashboardEndpointController : ControllerBase
         }
 
         await _eventTypeRepository.ArchiveAsync(eventTypeId, ct);
+        DeliveryLookupCache.InvalidateApplication(eventType.AppId);
         return NoContent();
     }
 }

--- a/src/WebhookEngine.API/Controllers/EndpointsController.cs
+++ b/src/WebhookEngine.API/Controllers/EndpointsController.cs
@@ -4,6 +4,7 @@ using WebhookEngine.API.Contracts;
 using WebhookEngine.Core.Enums;
 using WebhookEngine.Infrastructure.Data;
 using WebhookEngine.Infrastructure.Repositories;
+using WebhookEngine.Infrastructure.Services;
 using Endpoint = WebhookEngine.Core.Entities.Endpoint;
 
 namespace WebhookEngine.API.Controllers;
@@ -63,6 +64,7 @@ public class EndpointsController : ControllerBase
         }
 
         await _endpointRepo.CreateAsync(endpoint, ct);
+        DeliveryLookupCache.InvalidateApplication(appId);
         var createdEndpoint = await _endpointRepo.GetByIdAsync(appId, endpoint.Id, ct) ?? endpoint;
 
         return Created(
@@ -149,6 +151,7 @@ public class EndpointsController : ControllerBase
         }
 
         await _endpointRepo.UpdateAsync(endpoint, ct);
+        DeliveryLookupCache.InvalidateApplication(appId);
         var updatedEndpoint = await _endpointRepo.GetByIdAsync(appId, endpoint.Id, ct) ?? endpoint;
 
         return Ok(ApiEnvelope.Success(HttpContext, updatedEndpoint.ToDto()));
@@ -164,6 +167,7 @@ public class EndpointsController : ControllerBase
 
         endpoint.Status = EndpointStatus.Disabled;
         await _endpointRepo.UpdateAsync(endpoint, ct);
+        DeliveryLookupCache.InvalidateApplication(appId);
 
         return Ok(ApiEnvelope.Success(HttpContext, endpoint.ToDto()));
     }
@@ -178,6 +182,7 @@ public class EndpointsController : ControllerBase
 
         endpoint.Status = EndpointStatus.Active;
         await _endpointRepo.UpdateAsync(endpoint, ct);
+        DeliveryLookupCache.InvalidateApplication(appId);
 
         return Ok(ApiEnvelope.Success(HttpContext, endpoint.ToDto()));
     }
@@ -187,6 +192,7 @@ public class EndpointsController : ControllerBase
     {
         var appId = (Guid)HttpContext.Items["AppId"]!;
         await _endpointRepo.DeleteAsync(appId, endpointId, ct);
+        DeliveryLookupCache.InvalidateApplication(appId);
         return NoContent();
     }
 

--- a/src/WebhookEngine.API/Controllers/EventTypesController.cs
+++ b/src/WebhookEngine.API/Controllers/EventTypesController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using WebhookEngine.API.Contracts;
 using WebhookEngine.Core.Entities;
 using WebhookEngine.Infrastructure.Repositories;
+using WebhookEngine.Infrastructure.Services;
 
 namespace WebhookEngine.API.Controllers;
 
@@ -44,6 +45,7 @@ public class EventTypesController : ControllerBase
         };
 
         await _eventTypeRepo.CreateAsync(eventType, ct);
+        DeliveryLookupCache.InvalidateApplication(appId);
 
         return Created(
             $"/api/v1/event-types/{eventType.Id}",
@@ -99,6 +101,7 @@ public class EventTypesController : ControllerBase
             eventType.SchemaJson = System.Text.Json.JsonSerializer.Serialize(request.Schema);
 
         await _eventTypeRepo.UpdateAsync(eventType, ct);
+        DeliveryLookupCache.InvalidateApplication(eventType.AppId);
 
         return Ok(ApiEnvelope.Success(HttpContext, eventType.ToDto()));
     }
@@ -112,6 +115,7 @@ public class EventTypesController : ControllerBase
             return NotFound(ApiEnvelope.Error(HttpContext, "NOT_FOUND", "Event type not found."));
 
         await _eventTypeRepo.ArchiveAsync(appId, eventTypeId, ct);
+        DeliveryLookupCache.InvalidateApplication(appId);
         return NoContent();
     }
 }

--- a/src/WebhookEngine.API/Middleware/ApiKeyAuthMiddleware.cs
+++ b/src/WebhookEngine.API/Middleware/ApiKeyAuthMiddleware.cs
@@ -71,7 +71,11 @@ public class ApiKeyAuthMiddleware
             app = await appRepo.GetByApiKeyPrefixAsync(prefix);
             if (app is not null)
             {
-                cache.Set(CacheKeyFor(prefix), app, CacheTtl);
+                cache.Set(CacheKeyFor(prefix), app, new MemoryCacheEntryOptions
+                {
+                    AbsoluteExpirationRelativeToNow = CacheTtl,
+                    Size = 1
+                });
             }
         }
 

--- a/src/WebhookEngine.API/Program.cs
+++ b/src/WebhookEngine.API/Program.cs
@@ -183,10 +183,10 @@ builder.Services.AddMvcCore(options => options.Filters.Add<FluentValidationFilte
 builder.Services.AddSignalR();
 
 // In-memory cache used by ApiKeyAuthMiddleware (api-key→application) and
-// DeliveryLookupCache (event-type / subscribed-endpoints lookups on the
-// public send path). Auth cache invalidates synchronously; the delivery
-// lookups rely on a 30 s TTL.
-builder.Services.AddMemoryCache();
+// DeliveryLookupCache (event-type / subscribed-endpoints on the public
+// send path). SizeLimit caps unbounded growth in multi-tenant deployments;
+// every Set passes Size=1 so the limit translates to "10k entries".
+builder.Services.AddMemoryCache(o => o.SizeLimit = 10_000);
 builder.Services.AddScoped<DeliveryLookupCache>();
 
 // OpenAPI

--- a/src/WebhookEngine.Infrastructure/Services/DeliveryLookupCache.cs
+++ b/src/WebhookEngine.Infrastructure/Services/DeliveryLookupCache.cs
@@ -1,4 +1,6 @@
+using System.Collections.Concurrent;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Primitives;
 using WebhookEngine.Core.Entities;
 using WebhookEngine.Infrastructure.Repositories;
 
@@ -7,14 +9,22 @@ namespace WebhookEngine.Infrastructure.Services;
 /// <summary>
 /// Short-TTL cache for the per-message lookups that the public send / batch
 /// endpoints make on every call: event-type-by-name, event-type-by-id, and
-/// the set of endpoints subscribed to a given event type. The 30 s TTL is a
-/// trade-off — operators that just added a new endpoint or a new event type
-/// see it pick up traffic within at most 30 s, and same-node mutation paths
-/// invalidate the cache synchronously via Invalidate.
+/// the set of endpoints subscribed to a given event type.
+///
+/// Invalidation: a per-application <see cref="CancellationTokenSource"/>
+/// is registered as a change-token on every entry. Calling
+/// <see cref="InvalidateApplication"/> cancels the token and the cache
+/// drops every entry for that app on next access. TTL stays as a
+/// safety net for multi-node deployments where another instance mutates.
 /// </summary>
 public sealed class DeliveryLookupCache
 {
     private static readonly TimeSpan Ttl = TimeSpan.FromSeconds(30);
+
+    // The CancellationTokenSource per application is shared across all
+    // entries for that app. Replacing the entry on cancel resets the
+    // source so future entries get a live token.
+    private static readonly ConcurrentDictionary<Guid, CancellationTokenSource> AppTokens = new();
 
     private readonly IMemoryCache _cache;
     private readonly EventTypeRepository _eventTypeRepository;
@@ -41,7 +51,7 @@ public sealed class DeliveryLookupCache
         var fresh = await _eventTypeRepository.GetByIdAsync(appId, eventTypeId, ct);
         if (fresh is not null)
         {
-            _cache.Set(key, fresh, Ttl);
+            Set(appId, key, fresh);
         }
         return fresh;
     }
@@ -57,7 +67,7 @@ public sealed class DeliveryLookupCache
         var fresh = await _eventTypeRepository.GetByNameAsync(appId, name, ct);
         if (fresh is not null)
         {
-            _cache.Set(key, fresh, Ttl);
+            Set(appId, key, fresh);
         }
         return fresh;
     }
@@ -71,8 +81,38 @@ public sealed class DeliveryLookupCache
         }
 
         var fresh = await _endpointRepository.GetSubscribedEndpointsAsync(appId, eventTypeId, ct);
-        _cache.Set(key, fresh, Ttl);
+        Set(appId, key, fresh);
         return fresh;
     }
 
+    /// <summary>
+    /// Drops every cached lookup for the given application synchronously on
+    /// this node. Other nodes still rely on the 30 s TTL.
+    /// </summary>
+    public static void InvalidateApplication(Guid appId)
+    {
+        if (AppTokens.TryRemove(appId, out var source))
+        {
+            try
+            {
+                source.Cancel();
+            }
+            finally
+            {
+                source.Dispose();
+            }
+        }
+    }
+
+    private void Set(Guid appId, string key, object value)
+    {
+        var token = AppTokens.GetOrAdd(appId, _ => new CancellationTokenSource());
+        var entryOptions = new MemoryCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = Ttl,
+            Size = 1
+        };
+        entryOptions.AddExpirationToken(new CancellationChangeToken(token.Token));
+        _cache.Set(key, value, entryOptions);
+    }
 }


### PR DESCRIPTION
## Summary
Closes the two critical memory-leak findings:

1. **IMemoryCache had no \`SizeLimit\`.** Auth and delivery-lookup caches grew unbounded — multi-tenant deployments with thousands of apps / event types / subscribed-endpoint tuples never evicted hot keys.
2. **\`DeliveryLookupCache\` had no \`Invalidate\` API** despite the XML doc claiming sync invalidation. Endpoint or event-type changes only took effect after a 30 s TTL, and the now-stale EF entity stayed pinned in memory until then.

## Changes
- **\`Program.cs\`**: \`AddMemoryCache(o => o.SizeLimit = 10_000)\`. Both consumers pass \`Size = 1\` on every \`Set\` so the limit translates to "10 000 entries". Beyond that, LRU eviction kicks in.
- **\`DeliveryLookupCache\`**: per-application \`CancellationTokenSource\` (concurrent dictionary) registered as an expiration token on every entry. New static \`InvalidateApplication(appId)\` cancels + disposes the token, dropping every cached lookup for that app on next access. Static so call sites don't need to inject the cache.
- **Mutation hooks** in \`EventTypesController\`, \`EndpointsController\`, \`DashboardEndpointController\` call \`DeliveryLookupCache.InvalidateApplication(appId)\` after every Create / Update / Delete / Archive / Disable / Enable. Same-node mutations now reflect immediately; multi-node still relies on the 30 s TTL.
- **Auth cache** (\`ApiKeyAuthMiddleware\`) entries gain \`Size = 1\` so they participate in the size limit.

## Trade-offs
- 10 000 entry default fits the projected upper bound for most self-hosts with room to spare. Operators with much larger fleets can override via configuration once we expose it (out of scope here).
- Multi-node deployments still see at most 30 s lag for delivery-lookup invalidations across nodes — same SLO as before this PR. The auth cache already had sync cluster invalidation pending; flagged in audit, separate work.

## Verified
- \`dotnet build WebhookEngine.sln --configuration Release\` — 0 / 0
- CI Backend job will exercise the new code paths against the e2e Testcontainer suite

## Out of scope
- \`EndpointRateLimiter\` ConcurrentDictionary eviction (audit Mem H1).
- HttpRequestMessage / Response disposal in HttpDeliveryService (Mem H2).

## Labels
\`performance\` \`infrastructure\` \`api\`

## Test plan
- [ ] CI green
- [ ] No regression in the four e2e DeliveryFlowEndToEndTests
- [ ] Manual: create endpoint, send to it, modify it (e.g. disable), confirm next send reflects the change without waiting 30 s