### PR TITLE
fix(ops): readiness probe + migration lock + tracing + admin defaults (audit Ops C1-H4)

### DIFF
--- a/src/WebhookEngine.API/Controllers/HealthController.cs
+++ b/src/WebhookEngine.API/Controllers/HealthController.cs
@@ -1,7 +1,19 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using WebhookEngine.API.Services;
+using WebhookEngine.Infrastructure.Data;
 
 namespace WebhookEngine.API.Controllers;
 
+/// <summary>
+/// Three probes:
+///   /health        — alias of /health/live, kept for back-compat.
+///   /health/live   — liveness, just confirms the process is up.
+///   /health/ready  — readiness, returns 503 until migrations + seeders
+///                    finish AND the database is reachable. This is the
+///                    one a Kubernetes / Compose readiness probe should
+///                    actually call.
+/// </summary>
 [ApiController]
 [Produces("application/json")]
 [Route("health")]
@@ -9,5 +21,46 @@ namespace WebhookEngine.API.Controllers;
 public class HealthController : ControllerBase
 {
     [HttpGet]
-    public IActionResult Get() => Ok(new { status = "healthy", timestamp = DateTime.UtcNow });
+    [HttpGet("live")]
+    public IActionResult Live() =>
+        Ok(new { status = "healthy", timestamp = DateTime.UtcNow });
+
+    [HttpGet("ready")]
+    public async Task<IActionResult> Ready(
+        [FromServices] AppReadinessGate gate,
+        [FromServices] WebhookDbContext db,
+        CancellationToken ct)
+    {
+        if (!gate.IsReady)
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, new
+            {
+                status = "starting",
+                reason = "migrations or seeding not complete",
+                timestamp = DateTime.UtcNow
+            });
+        }
+
+        bool dbOk;
+        try
+        {
+            dbOk = await db.Database.CanConnectAsync(ct);
+        }
+        catch
+        {
+            dbOk = false;
+        }
+
+        if (!dbOk)
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, new
+            {
+                status = "degraded",
+                reason = "database unreachable",
+                timestamp = DateTime.UtcNow
+            });
+        }
+
+        return Ok(new { status = "healthy", timestamp = DateTime.UtcNow });
+    }
 }

--- a/src/WebhookEngine.API/Program.cs
+++ b/src/WebhookEngine.API/Program.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
 using Scalar.AspNetCore;
 using Serilog;
 using WebhookEngine.API.Hubs;
@@ -189,6 +190,10 @@ builder.Services.AddSignalR();
 builder.Services.AddMemoryCache(o => o.SizeLimit = 10_000);
 builder.Services.AddScoped<DeliveryLookupCache>();
 
+// Readiness gate — flipped to true after migrations + admin seeding
+// complete. /health/ready reads this; orchestrators should probe that.
+builder.Services.AddSingleton<AppReadinessGate>();
+
 // OpenAPI
 builder.Services.AddOpenApi(options =>
 {
@@ -206,12 +211,21 @@ builder.Services.AddOpenApi(options =>
 
 // OpenTelemetry Metrics + Prometheus
 builder.Services.AddSingleton<WebhookMetrics>();
+var otlpEndpoint = builder.Configuration["OpenTelemetry:OtlpEndpoint"];
 builder.Services.AddOpenTelemetry()
     .WithMetrics(metrics => metrics
         .AddAspNetCoreInstrumentation()
         .AddRuntimeInstrumentation()
         .AddMeter(WebhookMetrics.MeterName)
-        .AddPrometheusExporter());
+        .AddPrometheusExporter())
+    .WithTracing(tracing =>
+    {
+        tracing.AddAspNetCoreInstrumentation();
+        if (!string.IsNullOrWhiteSpace(otlpEndpoint))
+        {
+            tracing.AddOtlpExporter(o => o.Endpoint = new Uri(otlpEndpoint));
+        }
+    });
 
 // Rate limiting — per-AppId token bucket (D-01)
 builder.Services.AddRateLimiter(options =>
@@ -258,18 +272,58 @@ builder.Services.AddRateLimiter(options =>
 
 var app = builder.Build();
 
-// Auto-apply EF Core migrations on startup (skip in Testing environment)
+// Auto-apply EF Core migrations on startup (skip in Testing environment).
+// Wrapped in a session-level Postgres advisory lock so multi-replica
+// deployments don't race the migration history table.
 if (!app.Environment.IsEnvironment("Testing"))
 {
     using var scope = app.Services.CreateScope();
     var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
-    await db.Database.MigrateAsync();
+
+    var isPostgres = string.Equals(
+        db.Database.ProviderName,
+        "Npgsql.EntityFrameworkCore.PostgreSQL",
+        StringComparison.Ordinal);
+
+    if (isPostgres)
+    {
+        // Namespace 200_000 reserved for migration coordination; key 1
+        // covers the whole schema (per-table coordination is overkill).
+        const long migrationLockKey = (200_000L << 32) | 1L;
+        await db.Database.ExecuteSqlInterpolatedAsync(
+            $"SELECT pg_advisory_lock({migrationLockKey})");
+        try
+        {
+            await db.Database.MigrateAsync();
+        }
+        finally
+        {
+            await db.Database.ExecuteSqlInterpolatedAsync(
+                $"SELECT pg_advisory_unlock({migrationLockKey})");
+        }
+    }
+    else
+    {
+        await db.Database.MigrateAsync();
+    }
 
     var dashboardAuthOptions = scope.ServiceProvider
         .GetRequiredService<IOptions<DashboardAuthOptions>>()
         .Value;
 
-    await DashboardAdminSeeder.SeedAsync(db, dashboardAuthOptions, app.Logger);
+    await DashboardAdminSeeder.SeedAsync(
+        db,
+        dashboardAuthOptions,
+        app.Logger,
+        app.Environment.IsDevelopment());
+
+    app.Services.GetRequiredService<AppReadinessGate>().MarkReady();
+}
+else
+{
+    // Testing env: nothing to bootstrap, tests are ready as soon as the
+    // host is up.
+    app.Services.GetRequiredService<AppReadinessGate>().MarkReady();
 }
 
 // Middleware pipeline (order matters)

--- a/src/WebhookEngine.API/Services/AppReadinessGate.cs
+++ b/src/WebhookEngine.API/Services/AppReadinessGate.cs
@@ -1,0 +1,16 @@
+namespace WebhookEngine.API.Services;
+
+/// <summary>
+/// Single source of truth for the readiness probe. Set to true once startup
+/// migrations + admin seeding finish. Until then, /health/ready returns 503
+/// so a load balancer or orchestrator does not route traffic to a pod that
+/// hasn't finished bootstrapping.
+/// </summary>
+public sealed class AppReadinessGate
+{
+    private volatile bool _ready;
+
+    public bool IsReady => _ready;
+
+    public void MarkReady() => _ready = true;
+}

--- a/src/WebhookEngine.API/Startup/DashboardAdminSeeder.cs
+++ b/src/WebhookEngine.API/Startup/DashboardAdminSeeder.cs
@@ -8,10 +8,16 @@ namespace WebhookEngine.API.Startup;
 
 public static class DashboardAdminSeeder
 {
+    private static readonly string[] WeakDefaults =
+    {
+        "changeme", "password", "admin", "admin@example.com"
+    };
+
     public static async Task SeedAsync(
         WebhookDbContext dbContext,
         DashboardAuthOptions options,
         ILogger logger,
+        bool isDevelopment,
         CancellationToken ct = default)
     {
         var adminEmail = options.AdminEmail.Trim();
@@ -21,6 +27,21 @@ public static class DashboardAdminSeeder
         {
             logger.LogWarning("Dashboard admin seed skipped because email/password is empty.");
             return;
+        }
+
+        // Refuse to seed the shipped defaults (admin@example.com / changeme)
+        // outside Development so a forgotten env-var override doesn't end up
+        // creating a known-weak admin in production.
+        var emailIsDefault = adminEmail.Equals("admin@example.com", StringComparison.OrdinalIgnoreCase);
+        var passwordIsWeak = WeakDefaults.Any(d => string.Equals(adminPassword, d, StringComparison.OrdinalIgnoreCase))
+            || adminPassword.Length < 12;
+
+        if (!isDevelopment && (emailIsDefault || passwordIsWeak))
+        {
+            throw new InvalidOperationException(
+                "Refusing to seed dashboard admin with default or weak credentials in non-Development environment. " +
+                "Set WebhookEngine__DashboardAuth__AdminEmail and WebhookEngine__DashboardAuth__AdminPassword " +
+                "(min 12 characters) before starting the host.");
         }
 
         var exists = await dbContext.DashboardUsers

--- a/src/WebhookEngine.API/WebhookEngine.API.csproj
+++ b/src/WebhookEngine.API/WebhookEngine.API.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />


### PR DESCRIPTION
## Summary
Bundles four ops audit findings — all small, all related to startup correctness, observability, and "what breaks on the first prod deploy".

## 1. \`/health/live\` + \`/health/ready\` (audit Ops C1, C2)
The old \`/health\` was a static \`200 { healthy }\` regardless of state. Replaced with:
- **\`/health\`** and **\`/health/live\`** — liveness, just confirms the process is up.
- **\`/health/ready\`** — returns **503** until migrations + admin seeding finish AND \`DbContext.CanConnectAsync\` succeeds.

New \`AppReadinessGate\` singleton holds the flag, flipped to true after the bootstrap block. Orchestrators should probe \`/health/ready\` for routing decisions and \`/health/live\` only as the liveness probe.

## 2. Migration advisory lock (audit Ops C3)
Postgres-only: \`pg_advisory_lock(((200_000::bigint << 32) | 1))\` wraps \`Database.MigrateAsync\` so multi-replica deployments can't race the \`__EFMigrationsHistory\` insert. Lock released in \`finally\`.

## 3. Tracing exporter wired (audit Ops H1)
\`.WithTracing(...)\` added with \`AddAspNetCoreInstrumentation\`. OTLP exporter activates when \`OpenTelemetry:OtlpEndpoint\` is set in config — point it at Tempo / Jaeger / Honeycomb without code changes.

Adds \`OpenTelemetry.Exporter.OpenTelemetryProtocol\` (1.15.3, in line with the other OTel packages already on the project).

## 4. \`DashboardAdminSeeder\` rejects defaults (audit Ops H4)
Throws \`InvalidOperationException\` at startup if **all** of these hold:
- Host env is **not** Development
- AND admin email is \`admin@example.com\` OR password is in a known-weak list (\`changeme\`, \`password\`, \`admin\`) OR password length < 12

The shipped \`appsettings.json\` defaults were a footgun for forgotten env-var overrides on first prod deploy. Dev environments are unaffected so quickstart still works out of the box.

## Out of scope (separate PRs)
- Graceful drain on SIGTERM (audit Ops H2).
- Options validation \`ValidateOnStart\` (audit Ops H3).
- Queue-depth gauge correctness (audit Ops M1).
- Audit log table (audit Ops M4).

## Verified
- \`dotnet build WebhookEngine.sln --configuration Release\` — 0 / 0
- Test fixtures use \`Testing\` env which short-circuits the bootstrap, so existing tests are unaffected.

## Labels
\`enhancement\` \`infrastructure\` \`api\`

## Test plan
- [ ] CI green
- [ ] Manual: run with \`ASPNETCORE_ENVIRONMENT=Production\` and default appsettings → host fails fast with the credential error
- [ ] Manual: run with valid creds, observe \`/health/ready\` returns 503 briefly during startup, then 200
- [ ] Set \`OpenTelemetry__OtlpEndpoint=http://otelcol:4317\` and confirm spans flow