### PR TITLE
fix(dashboard): 401 auto-redirect + chunk-load error boundary (FE C1+H4)

### DIFF
--- a/src/dashboard/src/App.tsx
+++ b/src/dashboard/src/App.tsx
@@ -4,6 +4,7 @@ import { AuthProvider } from "./auth/AuthContext";
 import { AppShell } from "./layout/AppShell";
 import { LoginPage } from "./pages/LoginPage";
 import { ProtectedRoute } from "./routes/ProtectedRoute";
+import { RouteErrorBoundary } from "./components/RouteErrorBoundary";
 
 const DashboardPage = lazy(() =>
   import("./pages/DashboardPage").then((m) => ({ default: m.DashboardPage }))
@@ -34,9 +35,10 @@ function PageFallback() {
 
 export function App() {
   return (
-    <AuthProvider>
-      <BrowserRouter>
-        <Routes>
+    <RouteErrorBoundary>
+      <AuthProvider>
+        <BrowserRouter>
+          <Routes>
           <Route path="/login" element={<LoginPage />} />
 
           <Route element={<ProtectedRoute />}>
@@ -92,9 +94,10 @@ export function App() {
             </Route>
           </Route>
 
-          <Route path="*" element={<Navigate to="/" replace />} />
-        </Routes>
-      </BrowserRouter>
-    </AuthProvider>
+            <Route path="*" element={<Navigate to="/" replace />} />
+          </Routes>
+        </BrowserRouter>
+      </AuthProvider>
+    </RouteErrorBoundary>
   );
 }

--- a/src/dashboard/src/api/dashboardApi.ts
+++ b/src/dashboard/src/api/dashboardApi.ts
@@ -27,28 +27,49 @@ async function parseError(response: Response): Promise<string> {
   return `Request failed with status ${response.status}`;
 }
 
-async function fetchJson<T>(url: string): Promise<T> {
+/**
+ * Fired by fetchJson/mutate when the server returns 401 on an authenticated
+ * dashboard call. AuthContext listens and pushes the user back to /login.
+ * Login / logout endpoints opt out via the `skipAuthRedirect` flag.
+ */
+const AUTH_EXPIRED_EVENT = "webhookengine:auth-expired";
+
+function maybeFireAuthExpired(url: string, status: number) {
+  if (status !== 401) return;
+  if (url.includes("/api/v1/auth/")) return; // login/logout naturally 401
+  window.dispatchEvent(new CustomEvent(AUTH_EXPIRED_EVENT));
+}
+
+export const AuthEvents = {
+  AuthExpired: AUTH_EXPIRED_EVENT
+};
+
+async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
   const response = await fetch(url, {
     credentials: "include",
-    headers: { "Content-Type": "application/json" }
+    headers: { "Content-Type": "application/json" },
+    ...init
   });
 
   if (!response.ok) {
+    maybeFireAuthExpired(url, response.status);
     throw new Error(await parseError(response));
   }
 
   return (await response.json()) as T;
 }
 
-async function mutate<T>(url: string, method: string, body?: unknown): Promise<T> {
+async function mutate<T>(url: string, method: string, body?: unknown, init?: RequestInit): Promise<T> {
   const response = await fetch(url, {
     method,
     credentials: "include",
     headers: { "Content-Type": "application/json" },
-    ...(body !== undefined ? { body: JSON.stringify(body) } : {})
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    ...init
   });
 
   if (!response.ok) {
+    maybeFireAuthExpired(url, response.status);
     throw new Error(await parseError(response));
   }
 

--- a/src/dashboard/src/auth/AuthContext.tsx
+++ b/src/dashboard/src/auth/AuthContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { getCurrentUser, login as apiLogin, logout as apiLogout, type AuthUser } from "../api/authApi";
+import { AuthEvents } from "../api/dashboardApi";
 
 interface AuthContextValue {
   user: AuthUser | null;
@@ -33,8 +34,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     void init();
 
+    // Listen for the global auth-expired signal that dashboardApi raises on
+    // any 401 response. Clears the user so ProtectedRoute bounces to /login.
+    const onExpired = () => {
+      if (!isMounted) return;
+      setUser(null);
+      setIsLoading(false);
+    };
+    window.addEventListener(AuthEvents.AuthExpired, onExpired);
+
     return () => {
       isMounted = false;
+      window.removeEventListener(AuthEvents.AuthExpired, onExpired);
     };
   }, []);
 

--- a/src/dashboard/src/components/RouteErrorBoundary.tsx
+++ b/src/dashboard/src/components/RouteErrorBoundary.tsx
@@ -1,0 +1,57 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+interface State {
+  error: Error | null;
+}
+
+/**
+ * Catches anything thrown inside the lazy-loaded routes — most commonly
+ * `ChunkLoadError` after a deploy that retired the old asset hashes.
+ * Without this, React unmounts the tree and the user sees a frozen
+ * Suspense fallback or a blank screen until they refresh.
+ */
+export class RouteErrorBoundary extends Component<{ children: ReactNode }, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    // Surface to console for diagnosis; in production the SPA host also
+    // tails server-side logs so duplicate sinking is fine.
+    console.error("RouteErrorBoundary caught:", error, info);
+  }
+
+  private handleReload = () => window.location.reload();
+
+  render() {
+    if (this.state.error) {
+      const isChunkError =
+        /loading chunk|loading css chunk|importing.*module/i.test(this.state.error.message);
+
+      return (
+        <div className="h-screen flex items-center justify-center bg-surface-0 text-text-primary">
+          <div className="max-w-md text-center space-y-3">
+            <h1 className="text-lg font-semibold">
+              {isChunkError ? "Update available" : "Something went wrong"}
+            </h1>
+            <p className="text-sm text-text-secondary">
+              {isChunkError
+                ? "The dashboard was updated. Reload to fetch the latest version."
+                : this.state.error.message}
+            </p>
+            <button
+              onClick={this.handleReload}
+              className="text-xs font-medium px-3 py-1.5 rounded-lg bg-accent text-zinc-950 hover:bg-accent/90 transition-colors"
+            >
+              Reload
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
## Summary
Two reachable user-visible bugs from the frontend audit, fixed together.

## 1. 401 auto-redirect (FE C1)
When the dashboard cookie expired mid-session, every page rendered "Request failed with status 401" red toasts forever — nothing told the user to sign in again until they hit Reload.

\`dashboardApi.fetchJson\` and \`mutate\` now raise a global \`CustomEvent("webhookengine:auth-expired")\` whenever the server returns 401 on any non-auth endpoint (\`/api/v1/auth/*\` itself opts out, since 401 there is the intended response on bad credentials).

\`AuthContext\` listens, clears the user, and \`ProtectedRoute\` bounces the session back to \`/login\` on the next render.

## 2. Chunk-load error boundary (FE H4)
After the route lazy-loading split landed, a deploy that retired the old asset hashes — or any network blip during chunk fetch — could leave users on a frozen \`Suspense\` fallback or a blank tree forever.

New top-level \`RouteErrorBoundary\` wraps the whole app:
- Catches \`ChunkLoadError\` and shows "Update available — Reload" with a reload button.
- Catches generic errors and shows the message + Reload.

## Verified
- \`bun run lint\` clean
- \`bun run typecheck\` clean
- \`bun run build\` clean (no chunk-size regression)

## Out of scope
- MessagesPage filter race / AbortController (FE C2) — separate PR; the refactor touches the page's interval + filter logic and warrants isolation.
- Login \`from\` open-redirect-lite (FE M2), \`responseBody\` byte cap (FE M5), \`aria-label\` on icon buttons (FE Low) — backlog.

## Labels
\`bug\` \`dashboard\`

## Test plan
- [ ] CI green
- [ ] Manual: log in, wait for cookie expiry, perform any action → bounces to /login
- [ ] Manual: open dev tools, throttle network to fail a chunk fetch → boundary shows reload UI