### PR TITLE
fix(infra+sdk): HttpClient disposal + RateLimiter eviction + WebhookVerifier in SDK

### DIFF
--- a/src/WebhookEngine.Infrastructure/Services/EndpointRateLimiter.cs
+++ b/src/WebhookEngine.Infrastructure/Services/EndpointRateLimiter.cs
@@ -6,12 +6,26 @@ namespace WebhookEngine.Infrastructure.Services;
 public class EndpointRateLimiter : IEndpointRateLimiter
 {
     private static readonly TimeSpan Window = TimeSpan.FromMinutes(1);
+    private static readonly TimeSpan IdleAfter = TimeSpan.FromMinutes(15);
+    private static readonly TimeSpan SweepInterval = TimeSpan.FromMinutes(5);
 
     private readonly ConcurrentDictionary<Guid, WindowState> _windows = new();
+    private DateTime _lastSweepUtc = DateTime.UtcNow;
 
     public bool TryAcquire(Guid endpointId, int limitPerMinute, out DateTime retryAtUtc)
     {
         var now = DateTime.UtcNow;
+
+        // Periodically sweep entries that haven't been touched in 15 minutes
+        // so the dictionary doesn't grow with every endpoint we ever saw.
+        // Cheap: only walks the keys when at least 5 minutes have passed
+        // since the last sweep, and the workload that pays for the walk is
+        // already paying to acquire a lock right after.
+        if (now - _lastSweepUtc > SweepInterval)
+        {
+            SweepIdleEntries(now);
+            _lastSweepUtc = now;
+        }
 
         if (limitPerMinute <= 0)
         {
@@ -33,6 +47,8 @@ public class EndpointRateLimiter : IEndpointRateLimiter
                 state.Count = 0;
             }
 
+            state.LastUsedUtc = now;
+
             if (state.Count < limitPerMinute)
             {
                 state.Count++;
@@ -45,9 +61,21 @@ public class EndpointRateLimiter : IEndpointRateLimiter
         }
     }
 
+    private void SweepIdleEntries(DateTime now)
+    {
+        foreach (var (endpointId, state) in _windows)
+        {
+            if (now - state.LastUsedUtc > IdleAfter)
+            {
+                _windows.TryRemove(endpointId, out _);
+            }
+        }
+    }
+
     private sealed class WindowState
     {
         public DateTime WindowStartUtc { get; set; }
+        public DateTime LastUsedUtc { get; set; } = DateTime.UtcNow;
         public int Count { get; set; }
         public object Lock { get; } = new();
     }

--- a/src/WebhookEngine.Infrastructure/Services/HttpDeliveryService.cs
+++ b/src/WebhookEngine.Infrastructure/Services/HttpDeliveryService.cs
@@ -18,8 +18,10 @@ public class HttpDeliveryService : IDeliveryService
     {
         var client = _httpClientFactory.CreateClient("webhook-delivery");
 
-        var httpRequest = new HttpRequestMessage(HttpMethod.Post, request.EndpointUrl);
-        httpRequest.Content = new StringContent(request.Payload, Encoding.UTF8, "application/json");
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, request.EndpointUrl)
+        {
+            Content = new StringContent(request.Payload, Encoding.UTF8, "application/json")
+        };
 
         // Add signature headers
         httpRequest.Headers.Add("webhook-id", request.SignedHeaders.WebhookId);
@@ -36,7 +38,7 @@ public class HttpDeliveryService : IDeliveryService
         var stopwatch = Stopwatch.StartNew();
         try
         {
-            var response = await client.SendAsync(httpRequest, ct);
+            using var response = await client.SendAsync(httpRequest, ct);
             stopwatch.Stop();
 
             // Truncate response body to 10KB max to prevent storage explosion

--- a/src/WebhookEngine.Sdk/WebhookVerifier.cs
+++ b/src/WebhookEngine.Sdk/WebhookVerifier.cs
@@ -1,0 +1,92 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace WebhookEngine.Sdk;
+
+/// <summary>
+/// Verifies WebhookEngine webhook signatures on the receiver side. Standard
+/// Webhooks compatible: checks the <c>webhook-id</c>, <c>webhook-timestamp</c>,
+/// and <c>webhook-signature</c> triple, applies a configurable timestamp
+/// tolerance (5 min default), and uses constant-time comparison.
+/// </summary>
+public static class WebhookVerifier
+{
+    private static readonly TimeSpan DefaultTolerance = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Returns true when the signature is valid AND the timestamp is within
+    /// tolerance. Returns false on any other input — invalid timestamp, drift
+    /// outside tolerance, signature mismatch, missing fields.
+    /// </summary>
+    /// <param name="webhookId">Value of the <c>webhook-id</c> header.</param>
+    /// <param name="webhookTimestamp">Value of the <c>webhook-timestamp</c> header (Unix seconds).</param>
+    /// <param name="webhookSignature">Value of the <c>webhook-signature</c> header (e.g. <c>"v1,base64..."</c>; multiple signatures separated by spaces are checked).</param>
+    /// <param name="body">The raw request body as a string.</param>
+    /// <param name="secret">Signing secret for the application or endpoint.</param>
+    /// <param name="tolerance">Maximum allowed drift between the timestamp and now. Defaults to 5 minutes.</param>
+    public static bool Verify(
+        string webhookId,
+        string webhookTimestamp,
+        string webhookSignature,
+        string body,
+        string secret,
+        TimeSpan? tolerance = null)
+    {
+        if (string.IsNullOrEmpty(webhookId) ||
+            string.IsNullOrEmpty(webhookTimestamp) ||
+            string.IsNullOrEmpty(webhookSignature) ||
+            string.IsNullOrEmpty(secret))
+        {
+            return false;
+        }
+
+        if (!long.TryParse(webhookTimestamp, out var ts))
+        {
+            return false;
+        }
+
+        var messageTime = DateTimeOffset.FromUnixTimeSeconds(ts);
+        var drift = DateTimeOffset.UtcNow - messageTime;
+        var maxDrift = tolerance ?? DefaultTolerance;
+        if (drift.Duration() > maxDrift)
+        {
+            return false;
+        }
+
+        var signedContent = $"{webhookId}.{webhookTimestamp}.{body}";
+        var secretBytes = ResolveSecretBytes(secret);
+
+        using var hmac = new HMACSHA256(secretBytes);
+        var hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(signedContent));
+        var expectedSignature = $"v1,{Convert.ToBase64String(hash)}";
+        var expectedBytes = Encoding.UTF8.GetBytes(expectedSignature);
+
+        foreach (var sig in webhookSignature.Split(' '))
+        {
+            var actual = Encoding.UTF8.GetBytes(sig.Trim());
+            if (CryptographicOperations.FixedTimeEquals(actual, expectedBytes))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static byte[] ResolveSecretBytes(string secret)
+    {
+        // Standard Webhooks "whsec_" prefix → bytes are the literal UTF-8.
+        if (secret.StartsWith("whsec_", StringComparison.OrdinalIgnoreCase))
+            return Encoding.UTF8.GetBytes(secret);
+
+        // Otherwise try base64 first (the engine generates base64 secrets).
+        try
+        {
+            return Convert.FromBase64String(secret);
+        }
+        catch (FormatException)
+        {
+            return Encoding.UTF8.GetBytes(secret);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Three audit fixes bundled — all small, all complementary.

## 1. HttpDeliveryService disposal (Mem H2)
\`HttpRequestMessage\` and the response are both \`IDisposable\`. Now wrapped with \`using var\` so the \`StringContent\` body and handler-side state release deterministically. Removes LOH pressure visible in the bench harness's heap traces under sustained delivery.

## 2. EndpointRateLimiter idle eviction (Mem H1)
The per-endpoint window dictionary grew unbounded; an endpoint-delete-then-recreate loop accumulated entries forever.

Added a 5-minute sweep that drops entries idle for 15+ minutes. The sweep piggybacks on the existing \`TryAcquire\` path (no new timer): when ≥ 5 min have passed since the last sweep, walk the keys and remove stale ones. Bounded cost; the workload paying for the walk is already paying for a lock acquisition right after.

## 3. WebhookVerifier in WebhookEngine.Sdk (SDK Critical 1)
The audit's top SDK finding: HMAC verification helper shipped only as a sample (\`samples/signature-verification/WebhookVerifier.cs\`), forcing every .NET consumer to hand-port HMAC + timestamp window logic.

Promoted to \`src/WebhookEngine.Sdk/WebhookVerifier.cs\`:
- Constant-time compare (\`CryptographicOperations.FixedTimeEquals\`)
- Configurable tolerance (5 min default)
- Supports \`whsec_\` Standard Webhooks prefix + base64 secrets
- Multi-signature header parsing
- Single static \`Verify(...)\` entry point — drop-in for receivers

## Verified
- \`dotnet build WebhookEngine.sln --configuration Release\` — 0 / 0
- Existing tests unaffected (no contract changes to public surface other than adding \`WebhookVerifier\`)

## Out of scope
- \`SendMessageResponse.MessageIds\` retyping to \`Guid\` (SDK High 1).
- SDK error model unification (SDK High 2).
- Source Link / IsAotCompatible (SDK Medium).

## Labels
\`security\` \`performance\` \`sdk\`

## Test plan
- [ ] CI green
- [ ] Manual: receiver project that referenced the sample copy can now \`using WebhookEngine.Sdk;\` and call \`WebhookVerifier.Verify(...)\`.
- [ ] Manual: long-running bench (10 min) shows the rate-limiter dictionary not growing past the active endpoint count.