### PR TITLE
fix(api+ops): graceful shutdown drain + custom-header allow-list (Ops H2 + Sec M3)

### DIFF
--- a/src/WebhookEngine.API/Program.cs
+++ b/src/WebhookEngine.API/Program.cs
@@ -28,6 +28,13 @@ using WebhookEngine.Worker;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Give in-flight HTTP deliveries up to 45 s to finish on SIGTERM rather
+// than the default 30 s host shutdown grace. Combined with the
+// DeliveryOptions.TimeoutSeconds (default 30 s), this covers the worst-
+// case slow receiver without leaving stale locks for StaleLockRecovery
+// to pick up after every rolling deploy.
+builder.Services.Configure<HostOptions>(o => o.ShutdownTimeout = TimeSpan.FromSeconds(45));
+
 // Serilog
 builder.Host.UseSerilog((context, configuration) =>
     configuration.ReadFrom.Configuration(context.Configuration));

--- a/src/WebhookEngine.API/Validators/CustomHeaderPolicy.cs
+++ b/src/WebhookEngine.API/Validators/CustomHeaderPolicy.cs
@@ -1,0 +1,59 @@
+namespace WebhookEngine.API.Validators;
+
+/// <summary>
+/// Reject custom headers that would override engine-set headers (signature
+/// triple, content-type, etc.) or smuggle credentials onto outbound webhook
+/// requests. Names are matched case-insensitively. Also strips CR/LF from
+/// values to defeat header injection on stacks that don't validate.
+/// </summary>
+public static class CustomHeaderPolicy
+{
+    private static readonly HashSet<string> Reserved = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Authorization",
+        "Cookie",
+        "Set-Cookie",
+        "Host",
+        "Content-Length",
+        "Content-Type",
+        "Content-Encoding",
+        "Transfer-Encoding",
+        "User-Agent",
+        "webhook-id",
+        "webhook-timestamp",
+        "webhook-signature"
+    };
+
+    public static string? Validate(IDictionary<string, string>? headers)
+    {
+        if (headers is null || headers.Count == 0)
+        {
+            return null;
+        }
+
+        foreach (var (name, value) in headers)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return "Custom header names must be non-empty.";
+            }
+
+            if (Reserved.Contains(name))
+            {
+                return $"Custom header '{name}' is reserved and cannot be overridden.";
+            }
+
+            if (value is not null && (value.Contains('\r') || value.Contains('\n')))
+            {
+                return $"Custom header '{name}' value contains CR/LF characters.";
+            }
+
+            if (name.Length > 128 || (value?.Length ?? 0) > 1024)
+            {
+                return $"Custom header '{name}' exceeds size limits (name <= 128, value <= 1024).";
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/WebhookEngine.API/Validators/RequestValidators.cs
+++ b/src/WebhookEngine.API/Validators/RequestValidators.cs
@@ -81,6 +81,11 @@ public class CreateEndpointRequestValidator : AbstractValidator<CreateEndpointRe
             .MaximumLength(4096)
             .When(x => x.TransformExpression is not null)
             .WithMessage("TransformExpression must not exceed 4096 characters.");
+
+        RuleFor(x => x.CustomHeaders)
+            .Must(headers => CustomHeaderPolicy.Validate(headers) is null)
+            .WithMessage(x => CustomHeaderPolicy.Validate(x.CustomHeaders) ?? "Invalid custom headers.")
+            .When(x => x.CustomHeaders is not null);
     }
 }
 
@@ -101,6 +106,11 @@ public class UpdateEndpointRequestValidator : AbstractValidator<UpdateEndpointRe
             .MaximumLength(4096)
             .When(x => x.TransformExpression is not null)
             .WithMessage("TransformExpression must not exceed 4096 characters.");
+
+        RuleFor(x => x.CustomHeaders)
+            .Must(headers => CustomHeaderPolicy.Validate(headers) is null)
+            .WithMessage(x => CustomHeaderPolicy.Validate(x.CustomHeaders) ?? "Invalid custom headers.")
+            .When(x => x.CustomHeaders is not null);
 
         RuleFor(x => x)
             .Must(x => x.Url is not null
@@ -135,6 +145,11 @@ public class DashboardCreateEndpointRequestValidator : AbstractValidator<Dashboa
             .MaximumLength(4096)
             .When(x => x.TransformExpression is not null)
             .WithMessage("TransformExpression must not exceed 4096 characters.");
+
+        RuleFor(x => x.CustomHeaders)
+            .Must(headers => CustomHeaderPolicy.Validate(headers) is null)
+            .WithMessage(x => CustomHeaderPolicy.Validate(x.CustomHeaders) ?? "Invalid custom headers.")
+            .When(x => x.CustomHeaders is not null);
     }
 }
 
@@ -155,6 +170,11 @@ public class DashboardUpdateEndpointRequestValidator : AbstractValidator<Dashboa
             .MaximumLength(4096)
             .When(x => x.TransformExpression is not null)
             .WithMessage("TransformExpression must not exceed 4096 characters.");
+
+        RuleFor(x => x.CustomHeaders)
+            .Must(headers => CustomHeaderPolicy.Validate(headers) is null)
+            .WithMessage(x => CustomHeaderPolicy.Validate(x.CustomHeaders) ?? "Invalid custom headers.")
+            .When(x => x.CustomHeaders is not null);
 
         RuleFor(x => x)
             .Must(x => x.Url is not null


### PR DESCRIPTION
## Summary
Two related defenses — both touch outbound webhook delivery.

## 1. Graceful shutdown drain (audit Ops H2)
\`HostOptions.ShutdownTimeout = TimeSpan.FromSeconds(45)\`. The default 30 s grace was tight against \`DeliveryOptions.TimeoutSeconds\` (default 30 s); SIGTERM would yank the cancellation token while a slow receiver was mid-POST, leaving the message in \`Sending\` until \`StaleLockRecoveryWorker\` picked it up. The result was a measurable burst of stale locks on every rolling deploy.

45 s now covers worst-case slow receivers without exposing the timing to operators.

## 2. Custom-header allow-list (audit Sec M3)
New \`CustomHeaderPolicy\` rejects headers a tenant should never set on engine-driven outbound requests:

| Header | Reason |
|---|---|
| \`Authorization\`, \`Cookie\`, \`Set-Cookie\` | Credential smuggling (tenant pipes their auth onto our outbound) |
| \`Host\`, \`Content-Length\`, \`Content-Type\`, \`Content-Encoding\`, \`Transfer-Encoding\` | Protocol corruption |
| \`User-Agent\` | Engine identifies itself |
| \`webhook-id\`, \`webhook-timestamp\`, \`webhook-signature\` | Engine signs |

Also rejects values containing \`\\r\` or \`\\n\` (header injection on stacks that don't validate) and clamps name ≤ 128 / value ≤ 1024 chars.

Wired into all four endpoint validators (public Bearer create + update + dashboard create + update). Validation happens at request time; existing rows are not retroactively filtered (intentional — operators review and migrate, no breaking surprise on running deployments).

## Out of scope (deferred from F10)
- \`OptionsBuilder.ValidateOnStart\` for every options class — needs the \`AddOptions<T>().BindConfiguration().Validate(...)\` refactor across 8 options classes; better as a focused PR.
- Dashboard role check (\`[Authorize(Roles="admin")]\`) for mass-assign endpoints — \`DashboardUser.Role\` exists but isn't surfaced as a claim today; needs the login flow to mint the role claim before the \`[Authorize(Roles="...")]\` attribute does anything. Tracked separately.

## Verified
- \`dotnet build WebhookEngine.sln --configuration Release\` — 0 / 0
- Existing tests unaffected (none touch CustomHeaders directly)

## Labels
\`security\` \`api\` \`infrastructure\`

## Test plan
- [ ] CI green
- [ ] Manual: create endpoint with \`{"customHeaders": {"Authorization": "..."}}\` → 422 with reserved-header message
- [ ] Manual: create endpoint with \`{"customHeaders": {"X-My-Tenant": "tenant-1"}}\` → accepted
- [ ] Send-then-SIGTERM under load: in-flight POSTs complete instead of cancelling