### PR TITLE
fix(infra): close idempotency race with unique index + Stripe-style replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+- **Idempotency race condition closed (audit Concurrency H1).** Two concurrent requests with the same `idempotencyKey` previously slipped past the time-window pre-check and double-enqueued the message — both threads saw an empty lookup and both inserted. A new partial unique index on `(app_id, endpoint_id, idempotency_key) WHERE idempotency_key IS NOT NULL` now serializes inserts at the database, and the controllers (`POST /api/v1/messages`, `POST /api/v1/messages/batch`, `POST /api/v1/dashboard/messages`) catch the resulting `23505` conflict to perform a Stripe-style replay: fetch the winning row for that `(app, endpoint, key)` triple and return its id as if it had been freshly enqueued. The window-based reuse semantics are preserved — `RetentionCleanupWorker` now NULL-outs `idempotency_key` on rows past the per-app `IdempotencyWindowMinutes` so the same key can be re-used in a fresh window without violating the index. The companion non-unique index `idx_messages_app_idempotency` is kept for the lookup path. Migration `20260505140607_AddIdempotencyUniqueIndex` is defensive: it NULL-outs any pre-existing duplicate triples (keeping the most-recent row per group) before creating the unique index, so the migration cannot fail on legacy data.
+
 ## [0.1.4] - 2026-05-05
 
 ### Fixed

--- a/src/WebhookEngine.API/Controllers/DashboardMessagesController.cs
+++ b/src/WebhookEngine.API/Controllers/DashboardMessagesController.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
 using WebhookEngine.API.Contracts;
 using WebhookEngine.Core.Enums;
 using WebhookEngine.Core.Interfaces;
@@ -223,8 +225,21 @@ public class DashboardMessagesController : ControllerBase
                 ScheduledAt = DateTime.UtcNow
             };
 
-            await _messageQueue.EnqueueAsync(message, ct);
-            messageIds.Add(message.Id);
+            try
+            {
+                await _messageQueue.EnqueueAsync(message, ct);
+                messageIds.Add(message.Id);
+            }
+            catch (DbUpdateException ex) when (IsIdempotencyConflict(ex))
+            {
+                if (!string.IsNullOrWhiteSpace(request.IdempotencyKey))
+                {
+                    var winner = await _messageRepository.GetByEndpointAndIdempotencyKeyAsync(
+                        request.AppId, endpoint.Id, request.IdempotencyKey, ct);
+                    if (winner is not null)
+                        messageIds.Add(winner.Id);
+                }
+            }
         }
 
         return Accepted(ApiEnvelope.Success(HttpContext, new
@@ -234,6 +249,13 @@ public class DashboardMessagesController : ControllerBase
             eventType = eventTypeName
         }));
     }
+
+    private static bool IsIdempotencyConflict(DbUpdateException ex)
+        => ex.InnerException is PostgresException
+        {
+            SqlState: "23505",
+            ConstraintName: "idx_messages_app_endpoint_idempotency"
+        };
 
     [HttpPost("messages/{messageId:guid}/retry")]
     public async Task<IActionResult> RetryMessage(Guid messageId, CancellationToken ct)

--- a/src/WebhookEngine.API/Controllers/MessagesController.cs
+++ b/src/WebhookEngine.API/Controllers/MessagesController.cs
@@ -1,5 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
 using WebhookEngine.API.Contracts;
 using WebhookEngine.Core.Entities;
 using WebhookEngine.Core.Enums;
@@ -299,12 +301,35 @@ public class MessagesController : ControllerBase
                 ScheduledAt = DateTime.UtcNow
             };
 
-            await _messageQueue.EnqueueAsync(message, ct);
-            messageIds.Add(message.Id);
+            try
+            {
+                await _messageQueue.EnqueueAsync(message, ct);
+                messageIds.Add(message.Id);
+            }
+            catch (DbUpdateException ex) when (IsIdempotencyConflict(ex))
+            {
+                // Concurrent request raced with us on the same (app, endpoint,
+                // idempotency_key). Stripe-style replay: fetch the winning row
+                // and return its id as if we'd enqueued it ourselves.
+                if (!string.IsNullOrWhiteSpace(request.IdempotencyKey))
+                {
+                    var winner = await _messageRepo.GetByEndpointAndIdempotencyKeyAsync(
+                        appId, endpoint.Id, request.IdempotencyKey, ct);
+                    if (winner is not null)
+                        messageIds.Add(winner.Id);
+                }
+            }
         }
 
         return SendOperationResult.Ok(eventTypeResolution.EventTypeName!, messageIds, endpoints.Count);
     }
+
+    private static bool IsIdempotencyConflict(DbUpdateException ex)
+        => ex.InnerException is PostgresException
+        {
+            SqlState: "23505",
+            ConstraintName: "idx_messages_app_endpoint_idempotency"
+        };
 
     private async Task<EventTypeResolutionResult> ResolveEventTypeAsync(
         Guid appId,

--- a/src/WebhookEngine.Infrastructure/Data/WebhookDbContext.cs
+++ b/src/WebhookEngine.Infrastructure/Data/WebhookDbContext.cs
@@ -126,6 +126,15 @@ public class WebhookDbContext : DbContext
             entity.HasIndex(e => e.LockedAt).HasDatabaseName("idx_messages_stale_locks").HasFilter("status = 'Sending' AND locked_at IS NOT NULL");
             entity.HasIndex(e => new { e.AppId, e.IdempotencyKey }).HasDatabaseName("idx_messages_app_idempotency").HasFilter("idempotency_key IS NOT NULL");
 
+            // Race-fix uniqueness: at most one row per (app, endpoint, idempotency_key).
+            // Window-based reuse is preserved — RetentionCleanupWorker NULL-outs
+            // idempotency_key on rows past the per-app retention window so the same
+            // key can be re-used in a fresh window without violating this index.
+            entity.HasIndex(e => new { e.AppId, e.EndpointId, e.IdempotencyKey })
+                .HasDatabaseName("idx_messages_app_endpoint_idempotency")
+                .HasFilter("idempotency_key IS NOT NULL")
+                .IsUnique();
+
             entity.HasOne(e => e.Application).WithMany(a => a.Messages).HasForeignKey(e => e.AppId);
             entity.HasOne(e => e.Endpoint).WithMany(ep => ep.Messages).HasForeignKey(e => e.EndpointId);
             entity.HasOne(e => e.EventType).WithMany().HasForeignKey(e => e.EventTypeId);

--- a/src/WebhookEngine.Infrastructure/Migrations/20260505140607_AddIdempotencyUniqueIndex.Designer.cs
+++ b/src/WebhookEngine.Infrastructure/Migrations/20260505140607_AddIdempotencyUniqueIndex.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WebhookEngine.Infrastructure.Data;
@@ -11,9 +12,11 @@ using WebhookEngine.Infrastructure.Data;
 namespace WebhookEngine.Infrastructure.Migrations
 {
     [DbContext(typeof(WebhookDbContext))]
-    partial class WebhookDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260505140607_AddIdempotencyUniqueIndex")]
+    partial class AddIdempotencyUniqueIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/WebhookEngine.Infrastructure/Migrations/20260505140607_AddIdempotencyUniqueIndex.cs
+++ b/src/WebhookEngine.Infrastructure/Migrations/20260505140607_AddIdempotencyUniqueIndex.cs
@@ -1,0 +1,50 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WebhookEngine.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIdempotencyUniqueIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Defensive: NULL out duplicate idempotency_keys before creating the
+            // unique index so this migration cannot fail on legacy rows. Keeps
+            // the most-recently-created message for each (app, endpoint, key)
+            // triple; older duplicates lose their idempotency_key (the rows
+            // themselves are preserved). On a fresh deployment with no
+            // duplicates this UPDATE matches zero rows and is a no-op.
+            migrationBuilder.Sql("""
+                UPDATE messages SET idempotency_key = NULL
+                WHERE id IN (
+                    SELECT id FROM (
+                        SELECT id, ROW_NUMBER() OVER (
+                            PARTITION BY app_id, endpoint_id, idempotency_key
+                            ORDER BY created_at DESC, id DESC
+                        ) AS rn
+                        FROM messages
+                        WHERE idempotency_key IS NOT NULL
+                    ) ranked
+                    WHERE rn > 1
+                );
+                """);
+
+            migrationBuilder.CreateIndex(
+                name: "idx_messages_app_endpoint_idempotency",
+                table: "messages",
+                columns: new[] { "app_id", "endpoint_id", "idempotency_key" },
+                unique: true,
+                filter: "idempotency_key IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "idx_messages_app_endpoint_idempotency",
+                table: "messages");
+        }
+    }
+}

--- a/src/WebhookEngine.Infrastructure/Repositories/MessageRepository.cs
+++ b/src/WebhookEngine.Infrastructure/Repositories/MessageRepository.cs
@@ -114,6 +114,19 @@ public class MessageRepository
             .ToListAsync(ct);
     }
 
+    public async Task<Message?> GetByEndpointAndIdempotencyKeyAsync(
+        Guid appId,
+        Guid endpointId,
+        string idempotencyKey,
+        CancellationToken ct = default)
+    {
+        return await _dbContext.Messages
+            .AsNoTracking()
+            .FirstOrDefaultAsync(m => m.AppId == appId
+                && m.EndpointId == endpointId
+                && m.IdempotencyKey == idempotencyKey, ct);
+    }
+
     public async Task<List<MessageAttempt>> ListAttemptsAsync(Guid messageId, int page, int pageSize, CancellationToken ct = default)
     {
         return await _dbContext.MessageAttempts

--- a/src/WebhookEngine.Worker/RetentionCleanupWorker.cs
+++ b/src/WebhookEngine.Worker/RetentionCleanupWorker.cs
@@ -56,10 +56,15 @@ public class RetentionCleanupWorker : BackgroundService
                     deadLetterCutoff,
                     stoppingToken);
 
+                var nulledIdempotencyKeys = await NullifyExpiredIdempotencyKeysAsync(
+                    dbContext,
+                    stoppingToken);
+
                 _logger.LogInformation(
-                    "Retention cleanup completed. DeletedDelivered: {DeletedDelivered}, DeletedDeadLetter: {DeletedDeadLetter}",
+                    "Retention cleanup completed. DeletedDelivered: {DeletedDelivered}, DeletedDeadLetter: {DeletedDeadLetter}, NulledIdempotencyKeys: {NulledIdempotencyKeys}",
                     deletedDelivered,
-                    deletedDeadLetter);
+                    deletedDeadLetter,
+                    nulledIdempotencyKeys);
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
@@ -100,6 +105,56 @@ public class RetentionCleanupWorker : BackgroundService
         }
 
         return totalDeleted;
+    }
+
+    // Window-expired rows lose their idempotency_key so the same key can be
+    // re-used in a fresh window without violating the unique partial index
+    // on (app_id, endpoint_id, idempotency_key) WHERE idempotency_key IS NOT NULL.
+    // Stripe-style: idempotency keys are valid only inside the configured
+    // per-app window (default 24h) and the row itself is preserved.
+    private static async Task<int> NullifyExpiredIdempotencyKeysAsync(
+        WebhookDbContext dbContext,
+        CancellationToken ct)
+    {
+        var apps = await dbContext.Applications
+            .AsNoTracking()
+            .Select(a => new { a.Id, a.IdempotencyWindowMinutes })
+            .ToListAsync(ct);
+
+        var totalNulled = 0;
+        var nowUtc = DateTime.UtcNow;
+
+        foreach (var app in apps)
+        {
+            if (ct.IsCancellationRequested)
+            {
+                break;
+            }
+
+            var cutoff = nowUtc.AddMinutes(-app.IdempotencyWindowMinutes);
+
+            while (!ct.IsCancellationRequested)
+            {
+                var batch = await dbContext.Messages
+                    .Where(m => m.AppId == app.Id
+                        && m.IdempotencyKey != null
+                        && m.CreatedAt < cutoff)
+                    .OrderBy(m => m.CreatedAt)
+                    .Take(BatchSize)
+                    .ExecuteUpdateAsync(
+                        s => s.SetProperty(m => m.IdempotencyKey, (string?)null),
+                        ct);
+
+                if (batch == 0)
+                {
+                    break;
+                }
+
+                totalNulled += batch;
+            }
+        }
+
+        return totalNulled;
     }
 
     private static TimeSpan GetDelayUntilNextRunUtc(DateTime nowUtc)


### PR DESCRIPTION
## Summary

Closes the last open critical from the audit-driven fix plan: **F7 — Concurrency H1 (idempotency race)**. Two concurrent requests with the same `idempotencyKey` could both pass the time-window pre-check (each saw an empty lookup) and both insert, resulting in duplicate fan-out. This PR closes the race with database-enforced uniqueness and a Stripe-style conflict replay, while preserving the per-app idempotency window feature.

## What changes

### Database
- New partial unique index `idx_messages_app_endpoint_idempotency` on `(app_id, endpoint_id, idempotency_key) WHERE idempotency_key IS NOT NULL`. Endpoint-scoped uniqueness keeps fan-out semantics intact (the same key may legitimately produce N rows — one per subscribed endpoint).
- The existing non-unique `idx_messages_app_idempotency` is retained for the pre-check lookup path.
- Migration `20260505140607_AddIdempotencyUniqueIndex` includes a defensive `UPDATE ... ROW_NUMBER` step that NULL-outs any pre-existing duplicate triples (keeping the most-recently-created row per group) before creating the unique index — the migration cannot fail on legacy rows. On a fresh deployment with no duplicates the UPDATE matches zero rows.

### API
- `MessagesController.SendAsync` and `MessagesController.BatchSendAsync` (via shared `EnqueueSendRequestAsync`) and `DashboardMessagesController.SendAsync`: each `EnqueueAsync` call is now wrapped in a `try`/`catch DbUpdateException` filtered on `PostgresException { SqlState: "23505", ConstraintName: "idx_messages_app_endpoint_idempotency" }`. On conflict, the controller fetches the winning row for the `(app, endpoint, key)` triple via the new `MessageRepository.GetByEndpointAndIdempotencyKeyAsync` and returns its id — the second request appears to have succeeded with the first request's message id.

### Worker
- `RetentionCleanupWorker` gains `NullifyExpiredIdempotencyKeysAsync`: per-app, batched (1000 rows at a time), it sets `idempotency_key = NULL` on rows older than each app's `IdempotencyWindowMinutes`. This preserves the original "expire & reuse" semantics — the same key can be re-used in a fresh window without violating the unique index. Daily 03:00 UTC schedule unchanged.

## Why this design (vs. alternatives)

The audit research evaluated three approaches:

| Approach | Verdict |
|---|---|
| Advisory lock around `check → insert` | Rejected — `hash(appId, key)` collision risk; lock-release fragility on every code path |
| `(app_id, idempotency_key)` UNIQUE | Would break existing fan-out semantics: same key intentionally produces one row per subscribed endpoint |
| **`(app_id, endpoint_id, idempotency_key)` UNIQUE + retention NULL-out** | Chosen — matches PostgreSQL's canonical pattern (per docs: "applications should use INSERT with ON CONFLICT or use a UNIQUE constraint"); aligns with Stripe's idempotency model (key valid inside window, conflict → replay) |

## Test plan

- [x] `dotnet build WebhookEngine.sln --configuration Release` — 0 warnings, 0 errors
- [ ] CI green (backend test + frontend lint + Docker build + CodeQL)
- [ ] Migration auto-applies on startup against a fresh database (defensive UPDATE matches zero rows)
- [ ] Migration auto-applies cleanly against a database with one duplicate triple (UPDATE NULL-outs older row, unique index creates successfully)

## Files

- `src/WebhookEngine.Infrastructure/Data/WebhookDbContext.cs` — new `idx_messages_app_endpoint_idempotency` unique partial index
- `src/WebhookEngine.Infrastructure/Migrations/20260505140607_AddIdempotencyUniqueIndex.{cs,Designer.cs}` — migration
- `src/WebhookEngine.Infrastructure/Migrations/WebhookDbContextModelSnapshot.cs` — snapshot
- `src/WebhookEngine.Infrastructure/Repositories/MessageRepository.cs` — `GetByEndpointAndIdempotencyKeyAsync`
- `src/WebhookEngine.API/Controllers/MessagesController.cs` — try/catch + `IsIdempotencyConflict`
- `src/WebhookEngine.API/Controllers/DashboardMessagesController.cs` — try/catch + `IsIdempotencyConflict`
- `src/WebhookEngine.Worker/RetentionCleanupWorker.cs` — `NullifyExpiredIdempotencyKeysAsync`
- `CHANGELOG.md` — Unreleased > Fixed entry