### PR TITLE
docs(landing): bump version badge to v0.1.5

### DIFF
--- a/index.html
+++ b/index.html
@@ -983,7 +983,7 @@
           <line x1="18" y1="19.5" x2="19" y2="19.8" stroke="#3EFFA0" stroke-width="1" opacity="0.3"/>
         </svg>
         <span class="logo-wordmark">Webhook<span>Engine</span></span>
-        <span class="version-badge">v0.1.4</span>
+        <span class="version-badge">v0.1.5</span>
       </a>
       <div class="nav-links">
         <a href="https://github.com/voyvodka/webhook-engine/blob/main/docs/GETTING-STARTED.md" class="nav-link" target="_blank" rel="noopener">
@@ -1323,7 +1323,7 @@
       <div class="footer-left">
         <span class="footer-name">Webhook<span>Engine</span></span>
         <span class="footer-sep">·</span>
-        <span class="footer-meta">MIT License · v0.1.4</span>
+        <span class="footer-meta">MIT License · v0.1.5</span>
       </div>
       <div class="footer-links">
         <a href="https://github.com/voyvodka/webhook-engine" class="footer-link" target="_blank" rel="noopener">GitHub</a>


### PR DESCRIPTION
## Summary

Bumps the version reference on the landing page from `v0.1.4` to `v0.1.5`. Touches the header version badge and the footer meta line in `index.html`.

## Files

- `index.html` — header `.version-badge` and footer `.footer-meta`

## Test plan

- [x] Two occurrences replaced (lines 986 + 1326)
- [ ] CI green; `pages.yml` re-deploys the landing site