### PR TITLE
test(api): widen transform timeout in TestWebApplicationFactory to defeat cold-start flake

### DIFF
--- a/tests/WebhookEngine.API.Tests/Integration/TestWebApplicationFactory.cs
+++ b/tests/WebhookEngine.API.Tests/Integration/TestWebApplicationFactory.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using WebhookEngine.Infrastructure.Data;
@@ -19,6 +20,19 @@ public class TestWebApplicationFactory : WebApplicationFactory<Program>
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Testing");
+
+        // Production payload-transform timeout is 100 ms; on a cold CI runner
+        // the first JmesPath.Net invocation pays a one-off reflection cost
+        // that occasionally exceeds it and turned the validate-endpoint test
+        // flaky. Lift the budget for the Testing environment only — production
+        // behavior is unchanged.
+        builder.ConfigureAppConfiguration((_, cfg) =>
+        {
+            cfg.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["WebhookEngine:Transformation:TimeoutMs"] = "2000"
+            });
+        });
 
         builder.ConfigureServices(services =>
         {


### PR DESCRIPTION
## Summary

Closes a flake on `WebhookEngine.API.Tests.Integration.TransformValidateEndpointTests.Validate_Returns_Transformed_Payload_For_Valid_Expression`. The test passed on PR check but failed on the post-merge main push of #50 (run [25417212365](https://github.com/voyvodka/webhook-engine/actions/runs/25417212365)); the rerun without changes was green, confirming the test is sensitive to runner warmth, not to the change under test.

## Root cause

`TransformationOptions.TimeoutMs` defaults to **100 ms** — the production guardrail that keeps the JMESPath payload-transformation step from blocking delivery. On a cold CI runner the first `JmesPath.Net` invocation pays a one-off reflection-setup cost that can cross 100 ms, so the transformation fails-open and the test sees `data.success = false` instead of the expected `true`.

This is the documented `fail-open` path working correctly — but it makes the test runner-warmth-dependent.

## Fix

Override `WebhookEngine:Transformation:TimeoutMs` to **2000 ms** in `TestWebApplicationFactory` via `ConfigureAppConfiguration`. The override applies only when the host is built under the `Testing` environment, so production behavior is untouched.

```csharp
builder.ConfigureAppConfiguration((_, cfg) =>
{
    cfg.AddInMemoryCollection(new Dictionary<string, string?>
    {
        ["WebhookEngine:Transformation:TimeoutMs"] = "2000"
    });
});
```

## Why not raise the production timeout

The 100 ms cap is the documented delivery-pipeline budget. Raising it would let real expressions block delivery for longer; the cold-start cost is a test-environment artifact only.

## Test plan

- [x] `dotnet build tests/WebhookEngine.API.Tests/WebhookEngine.API.Tests.csproj --configuration Release` — 0 warnings, 0 errors
- [ ] CI green; in particular, the `TransformValidate` test stays green across multiple cold-start runs