### PR TITLE
chore(repo): add CODEOWNERS to auto-route review requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,34 @@
+# CODEOWNERS — automatic review-request routing.
+#
+# Solo maintainer: every PR is auto-reviewed by @voyvodka. The path-scoped
+# entries below don't change ownership (still solo) but document which
+# surfaces carry the highest blast radius and should not be touched without
+# attention. They also pre-stage the file for future co-maintainers.
+#
+# Syntax: https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Global fallback — every change requests review from the maintainer.
+*                                       @voyvodka
+
+# Workflow / release / dependency surface (CI, secrets, supply chain).
+/.github/                               @voyvodka
+/.github/workflows/                     @voyvodka
+/.github/dependabot.yml                 @voyvodka
+
+# Public SDK + samples — ships to NuGet, breaking changes are user-visible.
+/src/WebhookEngine.Sdk/                 @voyvodka
+/samples/                               @voyvodka
+
+# Container surface — base-image bumps and Dockerfile structure ship with releases.
+/docker/                                @voyvodka
+
+# Database migrations and schema — irreversible state changes.
+/src/WebhookEngine.Infrastructure/Migrations/   @voyvodka
+/src/WebhookEngine.Infrastructure/Data/         @voyvodka
+
+# Public docs + governance — user-facing contracts and policy.
+/docs/                                  @voyvodka
+/README.md                              @voyvodka
+/CHANGELOG.md                           @voyvodka
+/SECURITY.md                            @voyvodka
+/LICENSE                                @voyvodka


### PR DESCRIPTION
## Summary

Adds `.github/CODEOWNERS` so every PR auto-requests review from the maintainer (@voyvodka), with explicit path scopes documenting the highest-blast-radius surfaces.

## Why

Solo maintainer today, so the practical effect is "every PR auto-asks @voyvodka." That's not the point — the point is:

1. **Pre-stage for future co-maintainers** — when someone joins, narrowing path ownership is a one-line change instead of a policy debate.
2. **Document blast-radius intent** — `/.github/workflows/`, `/src/WebhookEngine.Sdk/`, `/src/WebhookEngine.Infrastructure/Migrations/`, `/docker/`, `/CHANGELOG.md` are all explicitly listed. A careless edit to any of these gets reviewer attention by default, even from the same person.
3. **Cheap insurance** — a 34-line file with no behavior change for the current solo workflow.

Path scopes still resolve to `@voyvodka`, so this changes nothing about who can merge or who must approve. It only changes who GitHub auto-tags on the PR sidebar.

## Test plan

- [x] CODEOWNERS syntax validated against [GitHub docs](https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
- [x] No path collisions; later rules correctly override the global `*` per the documented precedence
- [ ] CI green
- [ ] On merge: open the next PR and verify review is auto-requested