### PR TITLE
test(infra): cover rate-limited endpoint defer behavior end-to-end

### DIFF
--- a/tests/WebhookEngine.Infrastructure.Tests/EndToEnd/DeliveryFlowEndToEndTests.cs
+++ b/tests/WebhookEngine.Infrastructure.Tests/EndToEnd/DeliveryFlowEndToEndTests.cs
@@ -111,6 +111,49 @@ public class DeliveryFlowEndToEndTests : IClassFixture<PostgresFixture>
     }
 
     [Fact]
+    public async Task Rate_Limited_Endpoint_Defers_Excess_Messages_To_Pending()
+    {
+        await _fixture.ResetAsync();
+
+        var deliveryService = Substitute.For<IDeliveryService>();
+        deliveryService
+            .DeliverAsync(Arg.Any<DeliveryRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new DeliveryResult { Success = true, StatusCode = 200, LatencyMs = 10 });
+
+        await using var sp = BuildServiceProvider(deliveryService);
+
+        // Endpoint allows exactly one delivery per minute. Of the three messages
+        // we enqueue, the first should drain through the limiter and deliver;
+        // the remaining two should be reset to Pending with a future
+        // ScheduledAt rather than failing or moving to DeadLetter.
+        var seed = await SeedAsync(sp, rateLimitPerMinute: 1);
+        var messageIds = await EnqueueMessagesAsync(sp, seed, count: 3);
+
+        await RunWorkerOnceAsync(sp);
+
+        using var scope = sp.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+        var messages = await db.Messages.AsNoTracking()
+            .Where(m => messageIds.Contains(m.Id))
+            .ToListAsync();
+
+        var delivered = messages.Where(m => m.Status == MessageStatus.Delivered).ToList();
+        var deferred = messages.Where(m => m.Status == MessageStatus.Pending).ToList();
+
+        delivered.Should().HaveCount(1);
+        deferred.Should().HaveCount(2);
+
+        deferred.Should().OnlyContain(m => m.ScheduledAt > DateTime.UtcNow);
+        deferred.Should().OnlyContain(m => m.LockedAt == null && m.LockedBy == null);
+        deferred.Should().OnlyContain(m => m.AttemptCount == 0);
+
+        // The delivery side-effect happened exactly once — the limiter must
+        // turn the other two attempts into reschedules without ever calling
+        // the delivery service for them.
+        await deliveryService.Received(1).DeliverAsync(Arg.Any<DeliveryRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task Repeated_Failures_Open_Endpoint_Circuit()
     {
         await _fixture.ResetAsync();
@@ -196,7 +239,7 @@ public class DeliveryFlowEndToEndTests : IClassFixture<PostgresFixture>
         await worker.StopAsync(CancellationToken.None);
     }
 
-    private static async Task<SeedIds> SeedAsync(IServiceProvider sp)
+    private static async Task<SeedIds> SeedAsync(IServiceProvider sp, int? rateLimitPerMinute = null)
     {
         using var scope = sp.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
@@ -210,12 +253,17 @@ public class DeliveryFlowEndToEndTests : IClassFixture<PostgresFixture>
             SigningSecret = "whsec_e2e_secret_for_signing_messages_in_tests"
         };
 
+        var metadataJson = rateLimitPerMinute is int rl
+            ? $$"""{"rateLimitPerMinute":{{rl}}}"""
+            : "{}";
+
         var endpoint = new Endpoint
         {
             Id = Guid.NewGuid(),
             AppId = app.Id,
             Url = "https://example.invalid/webhook",
-            Status = EndpointStatus.Active
+            Status = EndpointStatus.Active,
+            MetadataJson = metadataJson
         };
 
         var eventType = new EventType
@@ -262,6 +310,36 @@ public class DeliveryFlowEndToEndTests : IClassFixture<PostgresFixture>
 
         // Seed the message id back into the seed record for the caller to read.
         seed.LastMessageIdSetter(message.Id);
+    }
+
+    private static async Task<List<Guid>> EnqueueMessagesAsync(IServiceProvider sp, SeedIds seed, int count)
+    {
+        using var scope = sp.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+
+        var ids = new List<Guid>(count);
+        for (var i = 0; i < count; i++)
+        {
+            var message = new Message
+            {
+                Id = Guid.NewGuid(),
+                AppId = seed.AppId,
+                EndpointId = seed.EndpointId,
+                EventTypeId = seed.EventTypeId,
+                EventId = $"evt_batch_{i}_{Guid.NewGuid():N}"[..32],
+                Payload = """{"hello":"world"}""",
+                Status = MessageStatus.Pending,
+                AttemptCount = 0,
+                MaxRetries = 7,
+                ScheduledAt = DateTime.UtcNow.AddSeconds(-1)
+            };
+
+            db.Messages.Add(message);
+            ids.Add(message.Id);
+        }
+
+        await db.SaveChangesAsync();
+        return ids;
     }
 
     private static async Task<Message> GetMessageAsync(IServiceProvider sp, Guid messageId)


### PR DESCRIPTION
## Summary

Adds a Testcontainers-backed end-to-end test for the per-endpoint rate-limit path through `DeliveryWorker`. Closes the only remaining DeliveryWorker coverage gap from the planning notes.

## Why

Three layers of test coverage already touch the rate-limit path:

- `EndpointRateLimiterTests` — proves the limiter class allows up to N tokens per minute and resets at the window boundary.
- `DeliveryWorkerTests.ResolveRateLimitPerMinute*` — proves the JSON metadata is parsed correctly.
- `DeliveryFlowEndToEndTests` — proves the happy/failure/circuit paths.

What none of them cover is **what `DeliveryWorker` actually does to a message when `TryAcquire` rejects it**: per `DeliveryWorker.cs:163-174`, the worker calls `MessageRepository.ReschedulePendingAsync` so the row goes back to `Pending`, gets a future `ScheduledAt`, and has its lock cleared — without invoking the delivery service.

This PR adds `Rate_Limited_Endpoint_Defers_Excess_Messages_To_Pending`:

- Seeds an endpoint with `metadataJson = {"rateLimitPerMinute": 1}`.
- Enqueues three messages back-to-back.
- Runs one worker tick (~1.2s, 50ms poll → ~24 polling chances).
- Asserts: 1 `Delivered` + 2 `Pending` with `ScheduledAt > now`, `LockedAt == null`, `AttemptCount == 0`, and exactly **one** call into the mocked `IDeliveryService` (the limiter must not re-enter delivery for rejected acquires).

Two existing helpers were generalized along the way:
- `SeedAsync(rateLimitPerMinute = null)` — opt-in metadata writer; default behavior unchanged for the four pre-existing tests.
- `EnqueueMessagesAsync(count)` — plural counterpart of `EnqueueMessageAsync`, returns the `List<Guid>` so the assertion can scan all three rows.

## Test plan

- [x] `dotnet build tests/WebhookEngine.Infrastructure.Tests/...` — 0 errors, 0 warnings
- [ ] CI green (Backend test job will execute the new e2e against a real Postgres container)