### PR TITLE
feat(api+dashboard): customizable endpoint test webhook with signed-request preview

### DIFF
--- a/src/WebhookEngine.API/Controllers/DashboardEndpointController.cs
+++ b/src/WebhookEngine.API/Controllers/DashboardEndpointController.cs
@@ -30,26 +30,26 @@ public class DashboardEndpointController : ControllerBase
     private readonly WebhookDbContext _dbContext;
     private readonly EndpointRepository _endpointRepository;
     private readonly EventTypeRepository _eventTypeRepository;
+    private readonly ApplicationRepository _applicationRepository;
     private readonly IPayloadTransformer _payloadTransformer;
-    private readonly IDeliveryService _deliveryService;
-    private readonly ISigningService _signingService;
+    private readonly IEndpointTester _endpointTester;
     private readonly EndpointUrlPolicy _urlPolicy;
 
     public DashboardEndpointController(
         WebhookDbContext dbContext,
         EndpointRepository endpointRepository,
         EventTypeRepository eventTypeRepository,
+        ApplicationRepository applicationRepository,
         IPayloadTransformer payloadTransformer,
-        IDeliveryService deliveryService,
-        ISigningService signingService,
+        IEndpointTester endpointTester,
         EndpointUrlPolicy urlPolicy)
     {
         _dbContext = dbContext;
         _endpointRepository = endpointRepository;
         _eventTypeRepository = eventTypeRepository;
+        _applicationRepository = applicationRepository;
         _payloadTransformer = payloadTransformer;
-        _deliveryService = deliveryService;
-        _signingService = signingService;
+        _endpointTester = endpointTester;
         _urlPolicy = urlPolicy;
     }
 
@@ -293,7 +293,10 @@ public class DashboardEndpointController : ControllerBase
     }
 
     [HttpPost("endpoints/{endpointId:guid}/test")]
-    public async Task<IActionResult> TestEndpoint(Guid endpointId, CancellationToken ct)
+    public async Task<IActionResult> TestEndpoint(
+        Guid endpointId,
+        [FromBody] DashboardTestEndpointRequest? request,
+        CancellationToken ct)
     {
         var endpoint = await _endpointRepository.GetByIdAsync(endpointId, ct);
         if (endpoint is null)
@@ -301,44 +304,32 @@ public class DashboardEndpointController : ControllerBase
             return NotFound(ApiEnvelope.Error(HttpContext, "NOT_FOUND", "Endpoint not found."));
         }
 
-        var signingSecret = endpoint.SecretOverride ?? endpoint.Application?.SigningSecret;
+        // GetByIdAsync includes Application; defensive fallback in case the include is removed later.
+        var application = endpoint.Application ?? await _applicationRepository.GetByIdAsync(endpoint.AppId, ct);
+        if (application is null)
+        {
+            return NotFound(ApiEnvelope.Error(HttpContext, "NOT_FOUND", "Application not found."));
+        }
+
+        var signingSecret = endpoint.SecretOverride ?? application.SigningSecret;
         if (string.IsNullOrWhiteSpace(signingSecret))
         {
             return UnprocessableEntity(ApiEnvelope.Error(HttpContext, "UNPROCESSABLE", "Endpoint has no signing secret configured."));
         }
 
-        var messageId = $"msg_test_{Guid.NewGuid():N}"[..24];
-        var body = JsonSerializer.Serialize(new
+        var context = new EndpointTestContext
         {
-            test = true,
-            message = "WebhookEngine test event",
-            sentAt = DateTime.UtcNow,
-            endpointId = endpoint.Id
-        });
-
-        var customHeaders = string.IsNullOrWhiteSpace(endpoint.CustomHeadersJson)
-            ? new Dictionary<string, string>()
-            : JsonSerializer.Deserialize<Dictionary<string, string>>(endpoint.CustomHeadersJson) ?? new Dictionary<string, string>();
-
-        var signed = _signingService.Sign(messageId, DateTimeOffset.UtcNow.ToUnixTimeSeconds(), body, signingSecret);
-        var deliveryRequest = new DeliveryRequest
-        {
-            MessageId = messageId,
-            EndpointUrl = endpoint.Url,
-            Payload = body,
-            SignedHeaders = signed,
-            CustomHeaders = customHeaders
+            Endpoint = endpoint,
+            Application = application,
+            Request = new EndpointTestRequest
+            {
+                EventTypeName = request?.EventType ?? string.Empty,
+                Payload = request?.Payload
+            }
         };
 
-        var result = await _deliveryService.DeliverAsync(deliveryRequest, ct);
-
-        return Ok(ApiEnvelope.Success(HttpContext, new
-        {
-            success = result.Success,
-            statusCode = result.StatusCode,
-            latencyMs = result.LatencyMs,
-            error = result.Error
-        }));
+        var result = await _endpointTester.ExecuteAsync(context, ct);
+        return Ok(ApiEnvelope.Success(HttpContext, result));
     }
 
     // ──────────────────────────────────────────────────
@@ -533,4 +524,10 @@ public class ValidateTransformRequest
 {
     public string Expression { get; set; } = string.Empty;
     public string SamplePayload { get; set; } = string.Empty;
+}
+
+public class DashboardTestEndpointRequest
+{
+    public string? EventType { get; set; }
+    public JsonElement? Payload { get; set; }
 }

--- a/src/WebhookEngine.API/Controllers/EndpointsController.cs
+++ b/src/WebhookEngine.API/Controllers/EndpointsController.cs
@@ -1,7 +1,10 @@
+using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using WebhookEngine.API.Contracts;
 using WebhookEngine.Core.Enums;
+using WebhookEngine.Core.Interfaces;
+using WebhookEngine.Core.Models;
 using WebhookEngine.Infrastructure.Data;
 using WebhookEngine.Infrastructure.Repositories;
 using WebhookEngine.Infrastructure.Services;
@@ -18,15 +21,21 @@ public class EndpointsController : ControllerBase
 {
     private readonly EndpointRepository _endpointRepo;
     private readonly EventTypeRepository _eventTypeRepo;
+    private readonly ApplicationRepository _appRepo;
+    private readonly IEndpointTester _endpointTester;
     private readonly WebhookDbContext _dbContext;
 
     public EndpointsController(
         EndpointRepository endpointRepo,
         EventTypeRepository eventTypeRepo,
+        ApplicationRepository appRepo,
+        IEndpointTester endpointTester,
         WebhookDbContext dbContext)
     {
         _endpointRepo = endpointRepo;
         _eventTypeRepo = eventTypeRepo;
+        _appRepo = appRepo;
+        _endpointTester = endpointTester;
         _dbContext = dbContext;
     }
 
@@ -196,6 +205,34 @@ public class EndpointsController : ControllerBase
         return NoContent();
     }
 
+    [HttpPost("{endpointId:guid}/test")]
+    public async Task<IActionResult> SendTest(Guid endpointId, [FromBody] TestEndpointRequestDto request, CancellationToken ct)
+    {
+        var appId = (Guid)HttpContext.Items["AppId"]!;
+
+        var endpoint = await _endpointRepo.GetByIdAsync(appId, endpointId, ct);
+        if (endpoint is null)
+            return NotFound(ApiEnvelope.Error(HttpContext, "NOT_FOUND", "Endpoint not found."));
+
+        var application = await _appRepo.GetByIdAsync(appId, ct);
+        if (application is null)
+            return NotFound(ApiEnvelope.Error(HttpContext, "NOT_FOUND", "Application not found."));
+
+        var context = new EndpointTestContext
+        {
+            Endpoint = endpoint,
+            Application = application,
+            Request = new EndpointTestRequest
+            {
+                EventTypeName = request.EventType ?? string.Empty,
+                Payload = request.Payload
+            }
+        };
+
+        var result = await _endpointTester.ExecuteAsync(context, ct);
+        return Ok(ApiEnvelope.Success(HttpContext, result));
+    }
+
     [HttpGet("{endpointId:guid}/stats")]
     public async Task<IActionResult> Stats(Guid endpointId, [FromQuery] string period = "24h", CancellationToken ct = default)
     {
@@ -271,4 +308,10 @@ public class UpdateEndpointRequest
     public string? SecretOverride { get; set; }
     public string? TransformExpression { get; set; }
     public bool? TransformEnabled { get; set; }
+}
+
+public class TestEndpointRequestDto
+{
+    public string? EventType { get; set; }
+    public JsonElement? Payload { get; set; }
 }

--- a/src/WebhookEngine.API/Program.cs
+++ b/src/WebhookEngine.API/Program.cs
@@ -131,6 +131,7 @@ builder.Services.AddSingleton<IMessageStateMachine, MessageStateMachine>();
 builder.Services.AddSingleton<IDeliveryNotifier, SignalRDeliveryNotifier>();
 builder.Services.AddSingleton<IDevTrafficGenerator, DevTrafficGenerator>();
 builder.Services.AddSingleton<IPayloadTransformer, JmesPathPayloadTransformer>();
+builder.Services.AddScoped<IEndpointTester, EndpointTester>();
 
 // Background Workers
 builder.Services.AddHostedService<DeliveryWorker>();

--- a/src/WebhookEngine.API/Validators/RequestValidators.cs
+++ b/src/WebhookEngine.API/Validators/RequestValidators.cs
@@ -378,3 +378,35 @@ public class DevTrafficSeedRequestValidator : AbstractValidator<DevTrafficSeedRe
             .InclusiveBetween(1, 50);
     }
 }
+
+public class TestEndpointRequestDtoValidator : AbstractValidator<TestEndpointRequestDto>
+{
+    private const int MaxPayloadBytes = 256 * 1024;
+
+    public TestEndpointRequestDtoValidator()
+    {
+        RuleFor(x => x.EventType)
+            .MaximumLength(256)
+            .When(x => x.EventType is not null);
+
+        RuleFor(x => x.Payload)
+            .Must(payload => !payload.HasValue || payload.Value.GetRawText().Length <= MaxPayloadBytes)
+            .WithMessage($"Payload exceeds the {MaxPayloadBytes / 1024} KB probe cap.");
+    }
+}
+
+public class DashboardTestEndpointRequestValidator : AbstractValidator<DashboardTestEndpointRequest>
+{
+    private const int MaxPayloadBytes = 256 * 1024;
+
+    public DashboardTestEndpointRequestValidator()
+    {
+        RuleFor(x => x.EventType)
+            .MaximumLength(256)
+            .When(x => x.EventType is not null);
+
+        RuleFor(x => x.Payload)
+            .Must(payload => !payload.HasValue || payload.Value.GetRawText().Length <= MaxPayloadBytes)
+            .WithMessage($"Payload exceeds the {MaxPayloadBytes / 1024} KB probe cap.");
+    }
+}

--- a/src/WebhookEngine.Core/Interfaces/IEndpointTester.cs
+++ b/src/WebhookEngine.Core/Interfaces/IEndpointTester.cs
@@ -1,0 +1,17 @@
+using WebhookEngine.Core.Models;
+
+namespace WebhookEngine.Core.Interfaces;
+
+/// <summary>
+/// Sends a one-off, fully-signed webhook to an endpoint and returns the wire-level
+/// outcome (status code, latency, response body) plus a preview of the signed
+/// request. Used by the dashboard "Send test" button and by the public test API.
+/// The probe never touches the persisted message log, the idempotency table, or
+/// the circuit-breaker state — it goes through the same HMAC + custom-header +
+/// transformation pipeline as a real delivery, just with no side-effects on the
+/// engine's data.
+/// </summary>
+public interface IEndpointTester
+{
+    Task<EndpointTestResult> ExecuteAsync(EndpointTestContext context, CancellationToken ct = default);
+}

--- a/src/WebhookEngine.Core/Models/EndpointTestModels.cs
+++ b/src/WebhookEngine.Core/Models/EndpointTestModels.cs
@@ -1,0 +1,54 @@
+using System.Text.Json;
+using WebhookEngine.Core.Entities;
+using ApplicationEntity = WebhookEngine.Core.Entities.Application;
+
+namespace WebhookEngine.Core.Models;
+
+/// <summary>
+/// Caller-supplied payload for an ad-hoc endpoint probe. The probe is fire-and-forget:
+/// it does not persist a Message row, does not consult the idempotency window, does
+/// not move the endpoint's circuit, and does not appear in delivery logs.
+/// </summary>
+public class EndpointTestRequest
+{
+    public string EventTypeName { get; set; } = string.Empty;
+    public JsonElement? Payload { get; set; }
+}
+
+/// <summary>
+/// Outcome of a single ad-hoc endpoint probe. Mirrors <see cref="DeliveryResult"/>
+/// for the wire-level fields and adds a <see cref="Request"/> preview so the
+/// dashboard can show exactly what was signed and sent.
+/// </summary>
+public class EndpointTestResult
+{
+    public bool Success { get; set; }
+    public int StatusCode { get; set; }
+    public long LatencyMs { get; set; }
+    public string ResponseBody { get; set; } = string.Empty;
+    public string? Error { get; set; }
+    public EndpointTestRequestPreview Request { get; set; } = new();
+}
+
+/// <summary>
+/// Preview of the signed request that was actually sent — useful for debugging
+/// signature-verification failures on the receiver side.
+/// </summary>
+public class EndpointTestRequestPreview
+{
+    public string Url { get; set; } = string.Empty;
+    public Dictionary<string, string> Headers { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+    public string Body { get; set; } = "{}";
+}
+
+/// <summary>
+/// Bundle of inputs the tester needs to build a signed delivery. Caller resolves
+/// the endpoint and parent application from its own auth context (public API key
+/// vs dashboard cookie) and hands them to the service.
+/// </summary>
+public class EndpointTestContext
+{
+    public Endpoint Endpoint { get; init; } = null!;
+    public ApplicationEntity Application { get; init; } = null!;
+    public EndpointTestRequest Request { get; init; } = new();
+}

--- a/src/WebhookEngine.Infrastructure/Services/EndpointTester.cs
+++ b/src/WebhookEngine.Infrastructure/Services/EndpointTester.cs
@@ -1,0 +1,149 @@
+using System.Text.Json;
+using WebhookEngine.Core.Interfaces;
+using WebhookEngine.Core.Models;
+
+namespace WebhookEngine.Infrastructure.Services;
+
+/// <summary>
+/// Wire-compatible probe that signs and POSTs a one-off webhook through the same
+/// pipeline as <c>DeliveryWorker</c>. No persisted state mutates: no Message row,
+/// no MessageAttempt row, no idempotency consultation, no EndpointHealth update.
+/// The caller resolves auth + lookup; this service is the engine of the probe.
+/// </summary>
+public class EndpointTester : IEndpointTester
+{
+    private const int ResponseBodyTruncateBytes = 1024;
+
+    private readonly ISigningService _signingService;
+    private readonly IPayloadTransformer _payloadTransformer;
+    private readonly IDeliveryService _deliveryService;
+
+    public EndpointTester(
+        ISigningService signingService,
+        IPayloadTransformer payloadTransformer,
+        IDeliveryService deliveryService)
+    {
+        _signingService = signingService;
+        _payloadTransformer = payloadTransformer;
+        _deliveryService = deliveryService;
+    }
+
+    public async Task<EndpointTestResult> ExecuteAsync(EndpointTestContext context, CancellationToken ct = default)
+    {
+        var endpoint = context.Endpoint;
+        var application = context.Application;
+        var request = context.Request;
+
+        // Default payload when caller omits one — gives the receiver enough to
+        // recognise this as a probe but no app-specific data.
+        var rawPayload = request.Payload is JsonElement element
+            ? element.GetRawText()
+            : JsonSerializer.Serialize(new
+            {
+                test = true,
+                eventType = request.EventTypeName,
+                timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds()
+            });
+
+        var deliveryPayload = ApplyTransformation(rawPayload, endpoint);
+
+        var messageId = $"test_{Guid.NewGuid():N}";
+        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        var signingSecret = endpoint.SecretOverride ?? application.SigningSecret;
+        var signedHeaders = _signingService.Sign(messageId, timestamp, deliveryPayload, signingSecret);
+
+        var customHeaders = ParseCustomHeaders(endpoint.CustomHeadersJson);
+        var allHeaders = BuildHeadersPreview(signedHeaders, customHeaders);
+
+        var deliveryRequest = new DeliveryRequest
+        {
+            MessageId = messageId,
+            EndpointUrl = endpoint.Url,
+            Payload = deliveryPayload,
+            SignedHeaders = signedHeaders,
+            CustomHeaders = customHeaders
+        };
+
+        var deliveryResult = await _deliveryService.DeliverAsync(deliveryRequest, ct);
+
+        return new EndpointTestResult
+        {
+            Success = deliveryResult.Success,
+            StatusCode = deliveryResult.StatusCode,
+            LatencyMs = deliveryResult.LatencyMs,
+            ResponseBody = TruncateResponseBody(deliveryResult.ResponseBody),
+            Error = deliveryResult.Error,
+            Request = new EndpointTestRequestPreview
+            {
+                Url = endpoint.Url,
+                Headers = allHeaders,
+                Body = deliveryPayload
+            }
+        };
+    }
+
+    private string ApplyTransformation(string payload, Core.Entities.Endpoint endpoint)
+    {
+        if (!endpoint.TransformEnabled || string.IsNullOrWhiteSpace(endpoint.TransformExpression))
+        {
+            return payload;
+        }
+
+        var result = _payloadTransformer.Transform(endpoint.TransformExpression!, payload);
+        return result.IsSuccess && result.TransformedPayload is not null
+            ? result.TransformedPayload
+            : payload;
+    }
+
+    private static Dictionary<string, string> ParseCustomHeaders(string? customHeadersJson)
+    {
+        if (string.IsNullOrWhiteSpace(customHeadersJson))
+        {
+            return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<Dictionary<string, string>>(customHeadersJson);
+            return parsed is null
+                ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, string>(parsed, StringComparer.OrdinalIgnoreCase);
+        }
+        catch (JsonException)
+        {
+            return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        }
+    }
+
+    private static Dictionary<string, string> BuildHeadersPreview(
+        SignedHeaders signedHeaders,
+        Dictionary<string, string> customHeaders)
+    {
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["webhook-id"] = signedHeaders.WebhookId,
+            ["webhook-timestamp"] = signedHeaders.WebhookTimestamp,
+            ["webhook-signature"] = signedHeaders.WebhookSignature,
+            ["User-Agent"] = "WebhookEngine/1.0"
+        };
+
+        foreach (var (key, value) in customHeaders)
+        {
+            headers[key] = value;
+        }
+
+        return headers;
+    }
+
+    private static string TruncateResponseBody(string? responseBody)
+    {
+        if (string.IsNullOrEmpty(responseBody))
+        {
+            return string.Empty;
+        }
+
+        return responseBody.Length <= ResponseBodyTruncateBytes
+            ? responseBody
+            : responseBody[..ResponseBodyTruncateBytes] + "... [truncated]";
+    }
+}

--- a/src/dashboard/src/api/dashboardApi.ts
+++ b/src/dashboard/src/api/dashboardApi.ts
@@ -340,17 +340,34 @@ export async function deleteDashboardEndpoint(endpointId: string): Promise<void>
   await mutate<void>(`/api/v1/dashboard/endpoints/${endpointId}`, "DELETE");
 }
 
+export interface TestEndpointRequestPreview {
+  url: string;
+  headers: Record<string, string>;
+  body: string;
+}
+
 export interface TestEndpointResult {
   success: boolean;
   statusCode: number;
   latencyMs: number;
+  responseBody: string;
   error: string | null;
+  request: TestEndpointRequestPreview;
 }
 
-export async function testDashboardEndpoint(endpointId: string): Promise<TestEndpointResult> {
+export interface TestEndpointRequest {
+  eventType?: string;
+  payload?: unknown;
+}
+
+export async function testDashboardEndpoint(
+  endpointId: string,
+  request?: TestEndpointRequest
+): Promise<TestEndpointResult> {
   const payload = await mutate<ApiEnvelope<TestEndpointResult>>(
     `/api/v1/dashboard/endpoints/${endpointId}/test`,
-    "POST"
+    "POST",
+    request ?? {}
   );
   return payload.data;
 }

--- a/src/dashboard/src/components/EndpointTestModal.tsx
+++ b/src/dashboard/src/components/EndpointTestModal.tsx
@@ -1,0 +1,270 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import CodeMirror from "@uiw/react-codemirror";
+import { json } from "@codemirror/lang-json";
+import { EditorView } from "@codemirror/view";
+import { tags as t } from "@lezer/highlight";
+import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
+import { AlertCircle, CheckCircle2, ChevronDown, ChevronUp, Loader2, Send } from "lucide-react";
+import { Modal } from "./Modal";
+import { testDashboardEndpoint } from "../api/dashboardApi";
+import type { TestEndpointResult } from "../api/dashboardApi";
+
+interface EndpointTestModalProps {
+  open: boolean;
+  endpointId: string | null;
+  endpointUrl: string | null;
+  onClose: () => void;
+}
+
+const DEFAULT_PAYLOAD = `{
+  "id": "evt_test_001",
+  "data": {
+    "message": "Hello from WebhookEngine"
+  }
+}`;
+
+const editorTheme = EditorView.theme(
+  {
+    "&": {
+      backgroundColor: "transparent",
+      color: "#fafafa",
+      fontSize: "12px",
+      fontFamily:
+        "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace"
+    },
+    ".cm-content": { padding: "8px 0", caretColor: "#22d3ee" },
+    ".cm-gutters": {
+      backgroundColor: "transparent",
+      color: "#71717a",
+      borderRight: "1px solid #1e1e22"
+    },
+    ".cm-activeLine": { backgroundColor: "transparent" },
+    ".cm-activeLineGutter": { backgroundColor: "transparent" },
+    ".cm-cursor": { borderLeftColor: "#22d3ee" },
+    "&.cm-focused": { outline: "none" },
+    "&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection":
+      { backgroundColor: "rgba(34, 211, 238, 0.18)" }
+  },
+  { dark: true }
+);
+
+const editorHighlight = HighlightStyle.define([
+  { tag: t.string, color: "#86efac" },
+  { tag: t.number, color: "#fbbf24" },
+  { tag: t.bool, color: "#f472b6" },
+  { tag: t.null, color: "#71717a" },
+  { tag: t.propertyName, color: "#22d3ee" },
+  { tag: t.keyword, color: "#c4b5fd" },
+  { tag: t.punctuation, color: "#a1a1aa" }
+]);
+
+const editorExtensions = [editorTheme, syntaxHighlighting(editorHighlight), json(), EditorView.lineWrapping];
+
+const inputClasses =
+  "w-full px-3 py-2 text-sm bg-surface-2 border border-border rounded-lg text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-1 focus:ring-accent/50 focus:border-accent/50 transition-colors";
+
+export function EndpointTestModal({ open, endpointId, endpointUrl, onClose }: EndpointTestModalProps) {
+  const [eventType, setEventType] = useState("");
+  const [payloadText, setPayloadText] = useState(DEFAULT_PAYLOAD);
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<TestEndpointResult | null>(null);
+  const [error, setError] = useState("");
+  const [showPreview, setShowPreview] = useState(false);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  // Inline JSON parse — used both for the disabled state on the Send button
+  // and for the actual request body. Empty string is treated as "no payload"
+  // so the backend's default-payload fallback can run.
+  const parsedPayload = useMemo<{ ok: true; value: unknown | undefined } | { ok: false; error: string }>(() => {
+    const trimmed = payloadText.trim();
+    if (!trimmed) return { ok: true, value: undefined };
+    try {
+      return { ok: true, value: JSON.parse(trimmed) };
+    } catch (e) {
+      return { ok: false, error: e instanceof Error ? e.message : "Invalid JSON" };
+    }
+  }, [payloadText]);
+
+  const handleClose = useCallback(() => {
+    if (submitting) return;
+    onClose();
+    // Reset on close so reopening starts fresh
+    setEventType("");
+    setPayloadText(DEFAULT_PAYLOAD);
+    setResult(null);
+    setError("");
+    setShowPreview(false);
+  }, [submitting, onClose]);
+
+  const handleSend = useCallback(async () => {
+    if (!endpointId || !parsedPayload.ok || submitting) return;
+    setSubmitting(true);
+    setError("");
+    setResult(null);
+    try {
+      const probeResult = await testDashboardEndpoint(endpointId, {
+        eventType: eventType.trim() || undefined,
+        payload: parsedPayload.value
+      });
+      if (!isMountedRef.current) return;
+      setResult(probeResult);
+    } catch (e) {
+      if (!isMountedRef.current) return;
+      setError(e instanceof Error ? e.message : "Test request failed");
+    } finally {
+      if (isMountedRef.current) setSubmitting(false);
+    }
+  }, [endpointId, eventType, parsedPayload, submitting]);
+
+  if (!endpointId) return null;
+
+  const sendDisabled = submitting || !parsedPayload.ok;
+
+  return (
+    <Modal
+      open={open}
+      onClose={handleClose}
+      title="Send test webhook"
+      description={endpointUrl ?? undefined}
+      width="max-w-2xl"
+    >
+      <div className="space-y-4">
+        {/* Event type */}
+        <div>
+          <label className="block text-xs font-medium text-text-secondary mb-1.5">Event type</label>
+          <input
+            type="text"
+            value={eventType}
+            onChange={(e) => setEventType(e.target.value)}
+            placeholder="optional, e.g. order.created"
+            className={inputClasses}
+            disabled={submitting}
+            maxLength={256}
+          />
+          <p className="text-[11px] text-text-muted mt-1">
+            Sent as the event-type identifier in the default payload. Leave empty to use the bare default body.
+          </p>
+        </div>
+
+        {/* Payload editor */}
+        <div>
+          <label className="block text-xs font-medium text-text-secondary mb-1.5">Payload (JSON)</label>
+          <div className="rounded-lg border border-border bg-surface-2 overflow-hidden">
+            <CodeMirror
+              value={payloadText}
+              height="200px"
+              extensions={editorExtensions}
+              onChange={setPayloadText}
+              basicSetup={{
+                lineNumbers: false,
+                foldGutter: false,
+                highlightActiveLine: false
+              }}
+            />
+          </div>
+          {!parsedPayload.ok && (
+            <p className="text-[11px] text-danger mt-1.5 font-mono">JSON parse error: {parsedPayload.error}</p>
+          )}
+        </div>
+
+        {/* Action row */}
+        <div className="flex items-center justify-end gap-2 pt-1">
+          <button
+            type="button"
+            onClick={handleClose}
+            disabled={submitting}
+            className="text-xs font-medium px-3 py-1.5 rounded-lg text-text-secondary hover:text-text-primary hover:bg-surface-2 disabled:opacity-50 transition-colors"
+          >
+            Close
+          </button>
+          <button
+            type="button"
+            onClick={handleSend}
+            disabled={sendDisabled}
+            className="inline-flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-lg bg-accent text-zinc-950 hover:bg-accent/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {submitting ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Send className="w-3.5 h-3.5" />}
+            {submitting ? "Sending…" : "Send"}
+          </button>
+        </div>
+
+        {/* Error from network or 4xx/5xx envelope */}
+        {error && (
+          <div className="flex items-start gap-2 text-danger text-xs bg-danger-soft border border-danger/20 rounded-lg px-3 py-2">
+            <AlertCircle className="w-3.5 h-3.5 shrink-0 mt-0.5" />
+            <span className="font-mono break-all">{error}</span>
+          </div>
+        )}
+
+        {/* Result panel */}
+        {result && (
+          <div className="rounded-lg border border-border-subtle bg-surface-2/40 overflow-hidden">
+            <div
+              className={`flex items-center gap-2 px-3 py-2 text-xs ${result.success ? "text-success" : "text-danger"} border-b border-border-subtle`}
+            >
+              {result.success ? <CheckCircle2 className="w-3.5 h-3.5" /> : <AlertCircle className="w-3.5 h-3.5" />}
+              <span className="font-mono">
+                {result.success
+                  ? `Delivered → HTTP ${result.statusCode} in ${result.latencyMs}ms`
+                  : `Failed → HTTP ${result.statusCode || "—"} ${result.error ?? ""}`.trim()}
+              </span>
+            </div>
+
+            {result.responseBody && (
+              <div className="px-3 py-2 border-b border-border-subtle">
+                <p className="text-[11px] font-medium text-text-secondary mb-1">Response body</p>
+                <pre className="text-[11px] font-mono text-text-primary bg-surface-3/40 rounded-md p-2 max-h-40 overflow-auto whitespace-pre-wrap break-all">
+                  {result.responseBody}
+                </pre>
+              </div>
+            )}
+
+            <button
+              type="button"
+              onClick={() => setShowPreview((s) => !s)}
+              className="w-full flex items-center justify-between gap-2 px-3 py-2 text-xs text-text-secondary hover:text-text-primary hover:bg-surface-3/40 transition-colors"
+            >
+              <span className="font-medium">Signed request preview</span>
+              {showPreview ? <ChevronUp className="w-3.5 h-3.5" /> : <ChevronDown className="w-3.5 h-3.5" />}
+            </button>
+
+            {showPreview && (
+              <div className="px-3 pb-3 space-y-2">
+                <div>
+                  <p className="text-[11px] font-medium text-text-secondary mb-1">URL</p>
+                  <p className="text-[11px] font-mono text-text-primary break-all bg-surface-3/40 rounded-md px-2 py-1.5">
+                    POST {result.request.url}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-[11px] font-medium text-text-secondary mb-1">Headers</p>
+                  <div className="text-[11px] font-mono bg-surface-3/40 rounded-md p-2 space-y-0.5">
+                    {Object.entries(result.request.headers).map(([k, v]) => (
+                      <div key={k} className="break-all">
+                        <span className="text-accent">{k}:</span>{" "}
+                        <span className="text-text-primary">{v}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+                <div>
+                  <p className="text-[11px] font-medium text-text-secondary mb-1">Body</p>
+                  <pre className="text-[11px] font-mono text-text-primary bg-surface-3/40 rounded-md p-2 max-h-40 overflow-auto whitespace-pre-wrap break-all">
+                    {result.request.body}
+                  </pre>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/src/dashboard/src/pages/EndpointsPage.tsx
+++ b/src/dashboard/src/pages/EndpointsPage.tsx
@@ -1,10 +1,11 @@
-import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { EndpointHealthBadge } from "../components/EndpointHealthBadge";
 import { Modal } from "../components/Modal";
 import { ConfirmModal } from "../components/ConfirmModal";
 import { Select } from "../components/Select";
 import { EventTypeSelect } from "../components/EventTypeSelect";
 import { TransformSection } from "../components/TransformSection";
+import { EndpointTestModal } from "../components/EndpointTestModal";
 import {
   createDashboardEndpoint,
   deleteDashboardEndpoint,
@@ -12,10 +13,8 @@ import {
   listDashboardEventTypes,
   listEndpoints,
   setDashboardEndpointStatus,
-  testDashboardEndpoint,
   updateDashboardEndpoint
 } from "../api/dashboardApi";
-import type { TestEndpointResult } from "../api/dashboardApi";
 import type { ApplicationRow, EndpointRow, EventTypeSummary, Pagination } from "../types";
 import {
   Plus,
@@ -25,13 +24,11 @@ import {
   ToggleRight,
   Filter,
   AlertCircle,
-  CheckCircle2,
   X,
   ChevronLeft,
   ChevronRight,
   Save,
-  Send,
-  Loader2
+  Send
 } from "lucide-react";
 import { formatLocaleDate } from "../utils/dateTime";
 
@@ -88,9 +85,9 @@ export function EndpointsPage() {
   // Confirm modal
   const [confirmState, setConfirmState] = useState<ConfirmState>(closedConfirm);
 
-  // Inline test result per endpoint id
-  const [testingId, setTestingId] = useState<string | null>(null);
-  const [testResults, setTestResults] = useState<Record<string, TestEndpointResult>>({});
+  // Test modal — opens when the row's "Send" button is pressed
+  const [testEndpointId, setTestEndpointId] = useState<string | null>(null);
+  const [testEndpointUrl, setTestEndpointUrl] = useState<string | null>(null);
 
   const editingEndpoint = useMemo(
     () => endpoints.find((e) => e.id === editingEndpointId) ?? null,
@@ -252,25 +249,15 @@ export function EndpointsPage() {
     });
   };
 
-  const handleTest = async (endpoint: EndpointRow) => {
-    setTestingId(endpoint.id);
-    try {
-      const result = await testDashboardEndpoint(endpoint.id);
-      setTestResults((prev) => ({ ...prev, [endpoint.id]: result }));
-    } catch (e) {
-      setTestResults((prev) => ({
-        ...prev,
-        [endpoint.id]: {
-          success: false,
-          statusCode: 0,
-          latencyMs: 0,
-          error: e instanceof Error ? e.message : "Test request failed"
-        }
-      }));
-    } finally {
-      setTestingId(null);
-    }
+  const handleTest = (endpoint: EndpointRow) => {
+    setTestEndpointId(endpoint.id);
+    setTestEndpointUrl(endpoint.url);
   };
+
+  const handleTestClose = useCallback(() => {
+    setTestEndpointId(null);
+    setTestEndpointUrl(null);
+  }, []);
 
   const requestDelete = (endpoint: EndpointRow) => {
     setConfirmState({
@@ -384,8 +371,7 @@ export function EndpointsPage() {
                 </thead>
                 <tbody className="text-sm">
                   {endpoints.map((ep) => (
-                  <Fragment key={ep.id}>
-                    <tr className="border-t border-border-subtle hover:bg-surface-2/50 transition-colors">
+                    <tr key={ep.id} className="border-t border-border-subtle hover:bg-surface-2/50 transition-colors">
                       <td className="px-4 py-2 font-mono text-xs text-text-secondary max-w-[260px] truncate" title={ep.url}>{ep.url}</td>
                       <td className="px-4 py-2 text-text-secondary">{ep.appName ?? "-"}</td>
                       <td className="px-4 py-2">
@@ -402,11 +388,11 @@ export function EndpointsPage() {
                         <div className="flex items-center justify-end gap-1">
                           <button
                             onClick={() => handleTest(ep)}
-                            disabled={testingId === ep.id || ep.status.toLowerCase() === "disabled"}
+                            disabled={ep.status.toLowerCase() === "disabled"}
                             className="p-1.5 rounded-md text-text-muted hover:text-accent hover:bg-accent-soft disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
                             title="Send test event"
                           >
-                            {testingId === ep.id ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Send className="w-3.5 h-3.5" />}
+                            <Send className="w-3.5 h-3.5" />
                           </button>
                           <button onClick={() => startEdit(ep)} className="p-1.5 rounded-md text-text-muted hover:text-accent hover:bg-accent-soft transition-colors" title="Edit">
                             <Pencil className="w-3.5 h-3.5" />
@@ -420,28 +406,6 @@ export function EndpointsPage() {
                         </div>
                       </td>
                     </tr>
-                    {testResults[ep.id] && (
-                      <tr className="bg-surface-2/40">
-                        <td colSpan={7} className="px-4 py-2">
-                          <div className={`flex items-center gap-2 text-xs ${testResults[ep.id].success ? "text-success" : "text-danger"}`}>
-                            {testResults[ep.id].success ? <CheckCircle2 className="w-3.5 h-3.5" /> : <AlertCircle className="w-3.5 h-3.5" />}
-                            <span className="font-mono">
-                              {testResults[ep.id].success
-                                ? `Test event delivered → HTTP ${testResults[ep.id].statusCode} in ${testResults[ep.id].latencyMs}ms`
-                                : `Test failed → HTTP ${testResults[ep.id].statusCode || "—"} ${testResults[ep.id].error ?? ""}`}
-                            </span>
-                            <button
-                              onClick={() => setTestResults((prev) => { const next = { ...prev }; delete next[ep.id]; return next; })}
-                              className="ml-auto text-text-muted hover:text-text-primary"
-                              title="Dismiss"
-                            >
-                              <X className="w-3 h-3" />
-                            </button>
-                          </div>
-                        </td>
-                      </tr>
-                    )}
-                  </Fragment>
                   ))}
                 </tbody>
               </table>
@@ -574,6 +538,14 @@ export function EndpointsPage() {
         description={confirmState.description}
         confirmLabel={confirmState.confirmLabel}
         variant={confirmState.variant}
+      />
+
+      {/* ── Test Modal ────────────────────────────── */}
+      <EndpointTestModal
+        open={testEndpointId !== null}
+        endpointId={testEndpointId}
+        endpointUrl={testEndpointUrl}
+        onClose={handleTestClose}
       />
     </div>
   );

--- a/tests/WebhookEngine.API.Tests/Integration/EndpointTestEndpointTests.cs
+++ b/tests/WebhookEngine.API.Tests/Integration/EndpointTestEndpointTests.cs
@@ -1,0 +1,258 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using WebhookEngine.API.Auth;
+using WebhookEngine.Core.Entities;
+using WebhookEngine.Core.Enums;
+using WebhookEngine.Infrastructure.Data;
+using ApplicationEntity = WebhookEngine.Core.Entities.Application;
+
+namespace WebhookEngine.API.Tests.Integration;
+
+public class EndpointTestEndpointTests : IClassFixture<TestWebApplicationFactory>
+{
+    private const string DashboardEmail = "admin@test.local";
+    private const string DashboardPassword = "P@ssw0rd-123";
+
+    // RFC 6761 reserves `.invalid` so DNS resolution is guaranteed to fail. The
+    // probe therefore exits the HTTP path at the resolver with a deterministic
+    // failure result — no real network traffic, no test flakes.
+    private const string ProbeEndpointUrl = "https://example.invalid/webhook";
+
+    private readonly TestWebApplicationFactory _factory;
+
+    public EndpointTestEndpointTests(TestWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    // ── Public API ───────────────────────────────────────
+
+    [Fact]
+    public async Task Public_Test_Endpoint_Returns_Result_With_Signed_Request_Preview()
+    {
+        await ResetDatabaseAsync();
+        using var client = CreatePublicClient();
+        var (appId, apiKey, endpointId) = await SeedAppAndEndpointAsync();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+
+        var response = await client.PostAsJsonAsync($"/api/v1/endpoints/{endpointId}/test", new
+        {
+            eventType = "order.created",
+            payload = new { id = "order_42", total = 99.95 }
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var data = (await ParseJsonAsync(response)).GetProperty("data");
+
+        // Probe is wired through the real HMAC + custom-header pipeline; the
+        // example.invalid hostname guarantees a deterministic delivery failure
+        // so we assert the failure path *and* that the preview survived round-trip.
+        data.GetProperty("success").GetBoolean().Should().BeFalse();
+        data.GetProperty("statusCode").GetInt32().Should().Be(0);
+        data.GetProperty("error").GetString().Should().NotBeNullOrWhiteSpace();
+
+        var preview = data.GetProperty("request");
+        preview.GetProperty("url").GetString().Should().Be(ProbeEndpointUrl);
+        preview.GetProperty("body").GetString().Should().Contain("order_42");
+
+        var headers = preview.GetProperty("headers");
+        headers.TryGetProperty("webhook-id", out var webhookId).Should().BeTrue();
+        webhookId.GetString().Should().StartWith("test_");
+        headers.GetProperty("webhook-signature").GetString().Should().StartWith("v1,");
+    }
+
+    [Fact]
+    public async Task Public_Test_Endpoint_Falls_Back_To_Default_Payload_When_Body_Omitted()
+    {
+        await ResetDatabaseAsync();
+        using var client = CreatePublicClient();
+        var (appId, apiKey, endpointId) = await SeedAppAndEndpointAsync();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+
+        // Empty JSON body — both EventType and Payload are optional on the wire,
+        // so the tester should fall back to its self-describing default payload.
+        var response = await client.PostAsJsonAsync($"/api/v1/endpoints/{endpointId}/test", new { });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var data = (await ParseJsonAsync(response)).GetProperty("data");
+
+        var body = data.GetProperty("request").GetProperty("body").GetString()!;
+        body.Should().Contain("\"test\":true");
+    }
+
+    [Fact]
+    public async Task Public_Test_Endpoint_Returns_404_For_Unknown_Endpoint()
+    {
+        await ResetDatabaseAsync();
+        using var client = CreatePublicClient();
+        var (_, apiKey, _) = await SeedAppAndEndpointAsync();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+
+        var response = await client.PostAsJsonAsync($"/api/v1/endpoints/{Guid.NewGuid()}/test", new { });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Public_Test_Endpoint_Rejects_Oversized_Payload_With_422()
+    {
+        await ResetDatabaseAsync();
+        using var client = CreatePublicClient();
+        var (_, apiKey, endpointId) = await SeedAppAndEndpointAsync();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+
+        // 257 KB string — one byte over the 256 KB probe cap once embedded in JSON.
+        var oversized = new string('x', 257 * 1024);
+        var response = await client.PostAsJsonAsync($"/api/v1/endpoints/{endpointId}/test", new
+        {
+            payload = new { blob = oversized }
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    // ── Dashboard API ───────────────────────────────────
+
+    [Fact]
+    public async Task Dashboard_Test_Endpoint_Returns_Result_With_Signed_Request_Preview()
+    {
+        await ResetDatabaseAsync();
+        using var client = CreateDashboardClient();
+        await AuthenticateDashboardAsync(client);
+        var (_, _, endpointId) = await SeedAppAndEndpointAsync();
+
+        var response = await client.PostAsJsonAsync($"/api/v1/dashboard/endpoints/{endpointId}/test", new
+        {
+            eventType = "order.created",
+            payload = new { hello = "world" }
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var data = (await ParseJsonAsync(response)).GetProperty("data");
+
+        data.GetProperty("success").GetBoolean().Should().BeFalse();
+        data.GetProperty("request").GetProperty("body").GetString().Should().Contain("\"hello\":\"world\"");
+    }
+
+    [Fact]
+    public async Task Dashboard_Test_Endpoint_Requires_Authentication()
+    {
+        await ResetDatabaseAsync();
+        using var client = CreateDashboardClient();
+        var (_, _, endpointId) = await SeedAppAndEndpointAsync();
+
+        var response = await client.PostAsJsonAsync($"/api/v1/dashboard/endpoints/{endpointId}/test", new { });
+
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Redirect, HttpStatusCode.Forbidden);
+    }
+
+    // ── Plumbing ───────────────────────────────────────
+
+    private HttpClient CreatePublicClient()
+    {
+        return _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            HandleCookies = false
+        });
+    }
+
+    private HttpClient CreateDashboardClient()
+    {
+        return _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            HandleCookies = true
+        });
+    }
+
+    private async Task ResetDatabaseAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+        await db.Database.EnsureDeletedAsync();
+        await db.Database.EnsureCreatedAsync();
+    }
+
+    private async Task AuthenticateDashboardAsync(HttpClient client)
+    {
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+            if (!await db.DashboardUsers.AnyAsync(u => u.Email == DashboardEmail))
+            {
+                db.DashboardUsers.Add(new DashboardUser
+                {
+                    Email = DashboardEmail,
+                    PasswordHash = PasswordHasher.HashPassword(DashboardPassword),
+                    Role = "admin"
+                });
+                await db.SaveChangesAsync();
+            }
+        }
+
+        var loginResponse = await client.PostAsJsonAsync("/api/v1/auth/login", new
+        {
+            email = DashboardEmail,
+            password = DashboardPassword
+        });
+
+        loginResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    private async Task<(Guid AppId, string ApiKey, Guid EndpointId)> SeedAppAndEndpointAsync()
+    {
+        var appId = Guid.NewGuid();
+        var appShort = appId.ToString("N")[..8];
+        var apiKey = $"whe_{appShort}_{Guid.NewGuid():N}";
+        var apiKeyPrefix = $"whe_{appShort}_";
+        var apiKeyHash = ComputeSha256(apiKey);
+        var endpointId = Guid.NewGuid();
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+
+        db.Applications.Add(new ApplicationEntity
+        {
+            Id = appId,
+            Name = $"App-{appShort}",
+            ApiKeyPrefix = apiKeyPrefix,
+            ApiKeyHash = apiKeyHash,
+            SigningSecret = "whsec_test_signing_secret_for_endpoint_probe",
+            RetryPolicyJson = "{\"maxRetries\":7,\"backoffSchedule\":[5,30,120,900,3600,21600,86400]}",
+            IsActive = true
+        });
+
+        db.Endpoints.Add(new Endpoint
+        {
+            Id = endpointId,
+            AppId = appId,
+            Url = ProbeEndpointUrl,
+            Status = EndpointStatus.Active
+        });
+
+        await db.SaveChangesAsync();
+        return (appId, apiKey, endpointId);
+    }
+
+    private static string ComputeSha256(string input)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(input));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+
+    private static async Task<JsonElement> ParseJsonAsync(HttpResponseMessage response)
+    {
+        var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        return doc.RootElement.Clone();
+    }
+}


### PR DESCRIPTION
## Summary

Rewrites the per-endpoint "Send test" path so users can specify the event type and a custom JSON payload, see the response body, and inspect the **exact signed request** the receiver got — not just status/latency. Wired through the same HMAC + custom-header + payload-transformation pipeline that `DeliveryWorker` uses, so what passes the probe will deliver identically. **F1 from the post-v0.1.5 feature plan.**

## Why

The prior implementation was a stub: hardcoded body (`{ test: true, message: "WebhookEngine test event", … }`), no payload-transformation pass, no event-type, and only `success/statusCode/latencyMs/error` echoed back. That doesn't help with the two cases users actually hit:

1. **Signature-verification failure on the receiver** — without seeing the signed headers and body that were sent, debugging is "hope and grep the receiver logs."
2. **JMESPath-transformed endpoints** — the probe sent the raw payload, not the transformed one, so any signature mismatch caused by the transform was invisible at probe time.

This PR addresses both.

## What changed

### Backend

- **New service** `IEndpointTester` (Core) + `EndpointTester` (Infrastructure). Composes `ISigningService`, `IPayloadTransformer`, and `IDeliveryService` to send a one-off, fully-signed POST. **Zero persisted side-effects**: no Message row, no MessageAttempt, no idempotency consultation, no EndpointHealth mutation, no circuit-breaker state.
- **Public API**: `POST /api/v1/endpoints/{id}/test` — Bearer-key auth, scoped to the calling app's endpoints.
- **Dashboard API**: rewrote `POST /api/v1/dashboard/endpoints/{id}/test` to delegate to the same service.
- **Request body** (both endpoints), all fields optional:
  ```json
  { "eventType": "order.created", "payload": { "id": "order_42" } }
  ```
- **Response body** now carries the response body (truncated to 1 KB) and the full request preview:
  ```json
  {
    "success": false,
    "statusCode": 0,
    "latencyMs": 12,
    "responseBody": "",
    "error": "Name or service not known",
    "request": {
      "url": "https://example.invalid/webhook",
      "headers": { "webhook-id": "test_…", "webhook-signature": "v1,…", "User-Agent": "WebhookEngine/1.0", "X-Custom": "…" },
      "body": "{\"id\":\"order_42\"}"
    }
  }
  ```
- **Validators** (FluentValidation): `eventType` ≤ 256 chars, `payload` ≤ 256 KB.

### Dashboard

- **New `<EndpointTestModal>`** component opens from the existing "Send" row action.
  - **Event-type input** (optional) — free text, used by the default-payload fallback.
  - **Payload editor** — CodeMirror 6 + `@codemirror/lang-json` (reuses the same setup the transform editor already ships with). Inline JSON-parse error message disables Send when the body isn't valid JSON.
  - **Result panel** — outcome banner (success/fail + status code + latency), response body preview (collapsible if non-empty), and a collapsible "Signed request preview" with URL, headers, and body so a signature mismatch can be diagnosed in one click.
- The old per-row inline result strip and `testResults` state are gone — the modal owns the lifecycle and resets on close so each probe is independent.

## Test plan

- [x] `dotnet build WebhookEngine.sln --configuration Release` — 0 warnings, 0 errors
- [x] `dotnet test --filter "EndpointTestEndpointTests"` — 6 / 6 pass
- [x] `bun run typecheck` (dashboard) — 0 errors
- [x] `bun run lint` (dashboard) — 0 errors
- [x] `bun run build` (dashboard) — clean
- [ ] CI green
- [ ] Smoke test in dashboard: open an endpoint, click Send, edit JSON, verify preview shows the signed headers

## Test scenarios covered

| Scenario | Status |
|---|---|
| Public API: signed request preview returned | ✅ |
| Public API: empty body → default fallback payload | ✅ |
| Public API: 404 on unknown endpoint | ✅ |
| Public API: 422 on oversized (>256 KB) payload | ✅ |
| Dashboard: cookie auth + custom payload | ✅ |
| Dashboard: 401 without auth | ✅ |