### PR TITLE
feat(api): hoist endpoint URL DNS resolution into the validator chain

### DIFF
--- a/src/WebhookEngine.API/Controllers/DashboardEndpointController.cs
+++ b/src/WebhookEngine.API/Controllers/DashboardEndpointController.cs
@@ -33,7 +33,6 @@ public class DashboardEndpointController : ControllerBase
     private readonly ApplicationRepository _applicationRepository;
     private readonly IPayloadTransformer _payloadTransformer;
     private readonly IEndpointTester _endpointTester;
-    private readonly EndpointUrlPolicy _urlPolicy;
 
     public DashboardEndpointController(
         WebhookDbContext dbContext,
@@ -41,8 +40,7 @@ public class DashboardEndpointController : ControllerBase
         EventTypeRepository eventTypeRepository,
         ApplicationRepository applicationRepository,
         IPayloadTransformer payloadTransformer,
-        IEndpointTester endpointTester,
-        EndpointUrlPolicy urlPolicy)
+        IEndpointTester endpointTester)
     {
         _dbContext = dbContext;
         _endpointRepository = endpointRepository;
@@ -50,7 +48,6 @@ public class DashboardEndpointController : ControllerBase
         _applicationRepository = applicationRepository;
         _payloadTransformer = payloadTransformer;
         _endpointTester = endpointTester;
-        _urlPolicy = urlPolicy;
     }
 
     // ──────────────────────────────────────────────────
@@ -96,11 +93,8 @@ public class DashboardEndpointController : ControllerBase
             return NotFound(ApiEnvelope.Error(HttpContext, "NOT_FOUND", "Application not found."));
         }
 
-        var dnsError = await _urlPolicy.CheckHostSafeAsync(request.Url, ct);
-        if (dnsError is not null)
-        {
-            return UnprocessableEntity(ApiEnvelope.Error(HttpContext, "UNPROCESSABLE", dnsError));
-        }
+        // DNS resolve + SSRF classification now run inside the request validator's
+        // DependentRules chain — see DashboardCreateEndpointRequestValidator.
 
         var endpoint = new Endpoint
         {
@@ -166,11 +160,7 @@ public class DashboardEndpointController : ControllerBase
 
         if (request.Url is not null)
         {
-            var dnsError = await _urlPolicy.CheckHostSafeAsync(request.Url, ct);
-            if (dnsError is not null)
-            {
-                return UnprocessableEntity(ApiEnvelope.Error(HttpContext, "UNPROCESSABLE", dnsError));
-            }
+            // DNS resolve + SSRF classification run in DashboardUpdateEndpointRequestValidator.
             endpoint.Url = request.Url;
         }
 

--- a/src/WebhookEngine.API/Validators/EndpointUrlPolicy.cs
+++ b/src/WebhookEngine.API/Validators/EndpointUrlPolicy.cs
@@ -17,6 +17,11 @@ namespace WebhookEngine.API.Validators;
 /// </summary>
 public sealed class EndpointUrlPolicy
 {
+    // Hard ceiling for the DNS lookup so a misbehaving resolver can't stall
+    // request validation. Three seconds covers every healthy public DNS path
+    // with margin while staying short enough to keep form submission snappy.
+    private static readonly TimeSpan DnsTimeout = TimeSpan.FromSeconds(3);
+
     private readonly bool _allowHttp;
     private readonly bool _allowLoopback;
     private readonly bool _ssrfGuardEnabled;
@@ -66,10 +71,17 @@ public sealed class EndpointUrlPolicy
             return null;
         }
 
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(DnsTimeout);
+
         IPAddress[] addresses;
         try
         {
-            addresses = await Dns.GetHostAddressesAsync(uri.Host, ct);
+            addresses = await Dns.GetHostAddressesAsync(uri.Host, timeoutCts.Token);
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !ct.IsCancellationRequested)
+        {
+            return $"DNS lookup for host '{uri.Host}' timed out after {DnsTimeout.TotalSeconds:0}s.";
         }
         catch (SocketException)
         {

--- a/src/WebhookEngine.API/Validators/RequestValidators.cs
+++ b/src/WebhookEngine.API/Validators/RequestValidators.cs
@@ -71,7 +71,18 @@ public class CreateEndpointRequestValidator : AbstractValidator<CreateEndpointRe
         RuleFor(x => x.Url)
             .NotEmpty()
             .Must(urlPolicy.IsValid)
-            .WithMessage(urlPolicy.ValidationMessage);
+            .WithMessage(urlPolicy.ValidationMessage)
+            .DependentRules(() =>
+            {
+                // Resolve the host eagerly so an unreachable webhook target fails the
+                // form submission instead of surfacing five minutes later as a delivery
+                // failure. SSRF-classification piggybacks on the same DNS lookup.
+                RuleFor(x => x.Url).CustomAsync(async (url, ctx, ct) =>
+                {
+                    var error = await urlPolicy.CheckHostSafeAsync(url, ct);
+                    if (error is not null) ctx.AddFailure(error);
+                });
+            });
 
         RuleFor(x => x.Description)
             .MaximumLength(500)
@@ -96,7 +107,15 @@ public class UpdateEndpointRequestValidator : AbstractValidator<UpdateEndpointRe
         RuleFor(x => x.Url)
             .Must(urlPolicy.IsValid)
             .When(x => x.Url is not null)
-            .WithMessage(urlPolicy.ValidationMessage);
+            .WithMessage(urlPolicy.ValidationMessage)
+            .DependentRules(() =>
+            {
+                RuleFor(x => x.Url!).CustomAsync(async (url, ctx, ct) =>
+                {
+                    var error = await urlPolicy.CheckHostSafeAsync(url, ct);
+                    if (error is not null) ctx.AddFailure(error);
+                }).When(x => x.Url is not null);
+            });
 
         RuleFor(x => x.Description)
             .MaximumLength(500)
@@ -135,7 +154,15 @@ public class DashboardCreateEndpointRequestValidator : AbstractValidator<Dashboa
         RuleFor(x => x.Url)
             .NotEmpty()
             .Must(urlPolicy.IsValid)
-            .WithMessage(urlPolicy.ValidationMessage);
+            .WithMessage(urlPolicy.ValidationMessage)
+            .DependentRules(() =>
+            {
+                RuleFor(x => x.Url).CustomAsync(async (url, ctx, ct) =>
+                {
+                    var error = await urlPolicy.CheckHostSafeAsync(url, ct);
+                    if (error is not null) ctx.AddFailure(error);
+                });
+            });
 
         RuleFor(x => x.Description)
             .MaximumLength(500)
@@ -160,7 +187,15 @@ public class DashboardUpdateEndpointRequestValidator : AbstractValidator<Dashboa
         RuleFor(x => x.Url)
             .Must(urlPolicy.IsValid)
             .When(x => x.Url is not null)
-            .WithMessage(urlPolicy.ValidationMessage);
+            .WithMessage(urlPolicy.ValidationMessage)
+            .DependentRules(() =>
+            {
+                RuleFor(x => x.Url!).CustomAsync(async (url, ctx, ct) =>
+                {
+                    var error = await urlPolicy.CheckHostSafeAsync(url, ct);
+                    if (error is not null) ctx.AddFailure(error);
+                }).When(x => x.Url is not null);
+            });
 
         RuleFor(x => x.Description)
             .MaximumLength(500)

--- a/tests/WebhookEngine.API.Tests/Integration/EndpointDnsCheckTests.cs
+++ b/tests/WebhookEngine.API.Tests/Integration/EndpointDnsCheckTests.cs
@@ -1,0 +1,191 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using WebhookEngine.API.Auth;
+using WebhookEngine.Core.Entities;
+using WebhookEngine.Core.Enums;
+using WebhookEngine.Infrastructure.Data;
+using ApplicationEntity = WebhookEngine.Core.Entities.Application;
+
+namespace WebhookEngine.API.Tests.Integration;
+
+public class EndpointDnsCheckTests : IClassFixture<TestWebApplicationFactory>
+{
+    // RFC 6761 reserves `.invalid` so DNS lookups against it always fail —
+    // the perfect deterministic stand-in for "this hostname does not exist".
+    private const string UnresolvableUrl = "https://does-not-exist.invalid/webhook";
+
+    private const string DashboardEmail = "admin@test.local";
+    private const string DashboardPassword = "P@ssw0rd-123";
+
+    private readonly TestWebApplicationFactory _factory;
+
+    public EndpointDnsCheckTests(TestWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task Public_Create_Endpoint_Returns_422_When_Hostname_Cannot_Be_Resolved()
+    {
+        await ResetDatabaseAsync();
+        using var client = CreatePublicClient();
+        var (_, apiKey) = await SeedApplicationAsync();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+
+        var response = await client.PostAsJsonAsync("/api/v1/endpoints", new
+        {
+            url = UnresolvableUrl
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact]
+    public async Task Public_Update_Endpoint_Returns_422_When_Hostname_Cannot_Be_Resolved()
+    {
+        await ResetDatabaseAsync();
+        using var client = CreatePublicClient();
+        var (appId, apiKey) = await SeedApplicationAsync();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+
+        // Seed a real endpoint directly so the update has a row to mutate,
+        // bypassing the create-time validator we're not exercising here.
+        var endpointId = await SeedEndpointAsync(appId);
+
+        var response = await client.PutAsJsonAsync($"/api/v1/endpoints/{endpointId}", new
+        {
+            url = UnresolvableUrl
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact]
+    public async Task Dashboard_Create_Endpoint_Returns_422_When_Hostname_Cannot_Be_Resolved()
+    {
+        await ResetDatabaseAsync();
+        using var client = CreateDashboardClient();
+        await AuthenticateDashboardAsync(client);
+        var (appId, _) = await SeedApplicationAsync();
+
+        var response = await client.PostAsJsonAsync("/api/v1/dashboard/endpoints", new
+        {
+            appId,
+            url = UnresolvableUrl
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    // ── Plumbing ───────────────────────────────────────
+
+    private HttpClient CreatePublicClient()
+    {
+        return _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            HandleCookies = false
+        });
+    }
+
+    private HttpClient CreateDashboardClient()
+    {
+        return _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            HandleCookies = true
+        });
+    }
+
+    private async Task ResetDatabaseAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+        await db.Database.EnsureDeletedAsync();
+        await db.Database.EnsureCreatedAsync();
+    }
+
+    private async Task AuthenticateDashboardAsync(HttpClient client)
+    {
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+            if (!await db.DashboardUsers.AnyAsync(u => u.Email == DashboardEmail))
+            {
+                db.DashboardUsers.Add(new DashboardUser
+                {
+                    Email = DashboardEmail,
+                    PasswordHash = PasswordHasher.HashPassword(DashboardPassword),
+                    Role = "admin"
+                });
+                await db.SaveChangesAsync();
+            }
+        }
+
+        var loginResponse = await client.PostAsJsonAsync("/api/v1/auth/login", new
+        {
+            email = DashboardEmail,
+            password = DashboardPassword
+        });
+
+        loginResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    private async Task<(Guid AppId, string ApiKey)> SeedApplicationAsync()
+    {
+        var appId = Guid.NewGuid();
+        var appShort = appId.ToString("N")[..8];
+        var apiKey = $"whe_{appShort}_{Guid.NewGuid():N}";
+        var apiKeyPrefix = $"whe_{appShort}_";
+        var apiKeyHash = ComputeSha256(apiKey);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+
+        db.Applications.Add(new ApplicationEntity
+        {
+            Id = appId,
+            Name = $"App-{appShort}",
+            ApiKeyPrefix = apiKeyPrefix,
+            ApiKeyHash = apiKeyHash,
+            SigningSecret = "secret_test_dns",
+            RetryPolicyJson = "{\"maxRetries\":7,\"backoffSchedule\":[5,30,120,900,3600,21600,86400]}",
+            IsActive = true
+        });
+
+        await db.SaveChangesAsync();
+        return (appId, apiKey);
+    }
+
+    private async Task<Guid> SeedEndpointAsync(Guid appId)
+    {
+        var endpointId = Guid.NewGuid();
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+
+        db.Endpoints.Add(new Endpoint
+        {
+            Id = endpointId,
+            AppId = appId,
+            Url = "https://example.com/webhook",
+            Status = EndpointStatus.Active
+        });
+
+        await db.SaveChangesAsync();
+        return endpointId;
+    }
+
+    private static string ComputeSha256(string input)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(input));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+}


### PR DESCRIPTION
## Summary

Moves DNS resolution + SSRF classification for endpoint URLs from a half-implemented controller-side check into the FluentValidation rule chain, so **public and dashboard endpoint create/update both fail fast on unresolvable hostnames** with a 422 carrying the bad host name. **F2 from the post-v0.1.5 plan.**

## Why

Two problems with the old wiring:

1. **Public API had no DNS check at all** — `EndpointsController.Create` / `Update` called the request validator (which only checked scheme + URI parse), then accepted the URL. A typo like `htttps://api.user.com/hook` (extra `t`) sailed past validation, sat in the queue, and only surfaced minutes later as `name resolution failure` in the worker logs.
2. **Dashboard controller did the right check, but in the wrong place** — `DashboardEndpointController.CreateEndpoint` and `UpdateEndpoint` called `EndpointUrlPolicy.CheckHostSafeAsync` directly after the validator returned, duplicating the ApiEnvelope plumbing the validator pipeline already provides.

`EndpointUrlPolicy.CheckHostSafeAsync` already does exactly what we need (DNS lookup → reject SSRF-classified addresses). It just wasn't reachable from the validator chain. This PR hooks it into all four endpoint validators (public + dashboard × create + update) via the FluentValidation `DependentRules` + `CustomAsync` combo, so:

- `IsValid()` runs first (sync scheme check). If it fails, DNS is **not** consulted — saves the lookup for already-broken inputs.
- If `IsValid()` passes, `CheckHostSafeAsync` runs and adds a failure with the dynamic host-aware message when DNS doesn't resolve or the address lands in a private range.
- The dashboard controller drops the redundant manual call sites.

The lookup also gains a **3-second linked-token timeout** — a hung public DNS resolver could otherwise stall request validation indefinitely. Three seconds is generous for any healthy resolver and short enough that form submission stays snappy when DNS misbehaves.

## What changed

### `src/WebhookEngine.API/Validators/EndpointUrlPolicy.cs`
- Added `DnsTimeout = 3s` and a linked `CancellationTokenSource` around the existing `Dns.GetHostAddressesAsync` call.
- New error message for the timeout path: *"DNS lookup for host '…' timed out after 3s."*

### `src/WebhookEngine.API/Validators/RequestValidators.cs`
- All four endpoint validators (`CreateEndpointRequestValidator`, `UpdateEndpointRequestValidator`, `DashboardCreateEndpointRequestValidator`, `DashboardUpdateEndpointRequestValidator`) now wrap their DNS step in `DependentRules` so it only runs after `IsValid()` passes.
- Update validators preserve the existing `When(x => x.Url is not null)` guard so PATCH-style updates without a URL still validate cleanly.

### `src/WebhookEngine.API/Controllers/DashboardEndpointController.cs`
- Removed the two manual `CheckHostSafeAsync` call sites (create + update). Replaced them with a one-line comment pointing readers at the validator.
- Removed the now-unused `EndpointUrlPolicy` constructor dependency and `_urlPolicy` field.

### `tests/WebhookEngine.API.Tests/Integration/EndpointDnsCheckTests.cs` (new)
Three integration tests against an RFC 6761 reserved `.invalid` host so DNS lookup is guaranteed to fail deterministically (no real network):
- `Public_Create_Endpoint_Returns_422_When_Hostname_Cannot_Be_Resolved`
- `Public_Update_Endpoint_Returns_422_When_Hostname_Cannot_Be_Resolved`
- `Dashboard_Create_Endpoint_Returns_422_When_Hostname_Cannot_Be_Resolved`

## Test plan

- [x] `dotnet build WebhookEngine.sln --configuration Release` — 0 warnings, 0 errors
- [x] `dotnet test tests/WebhookEngine.API.Tests/...` — 66 / 66 pass (3 new + all pre-existing)
- [ ] CI green