### PR TITLE
feat(api+infra): per-app retention overrides for delivered + dead-letter messages

### DIFF
--- a/src/WebhookEngine.API/Controllers/ApplicationsController.cs
+++ b/src/WebhookEngine.API/Controllers/ApplicationsController.cs
@@ -107,6 +107,9 @@ public class ApplicationsController : ControllerBase
             name = application.Name,
             apiKeyPrefix = application.ApiKeyPrefix,
             isActive = application.IsActive,
+            idempotencyWindowMinutes = application.IdempotencyWindowMinutes,
+            retentionDeliveredDays = application.RetentionDeliveredDays,
+            retentionDeadLetterDays = application.RetentionDeadLetterDays,
             createdAt = application.CreatedAt,
             updatedAt = application.UpdatedAt
         }));
@@ -123,6 +126,16 @@ public class ApplicationsController : ControllerBase
         application.IsActive = request.IsActive ?? application.IsActive;
         application.IdempotencyWindowMinutes = request.IdempotencyWindowMinutes ?? application.IdempotencyWindowMinutes;
 
+        // 0 = clear the override (fall back to global). > 0 = override. null = leave unchanged.
+        if (request.RetentionDeliveredDays is int delivered)
+        {
+            application.RetentionDeliveredDays = delivered == 0 ? null : delivered;
+        }
+        if (request.RetentionDeadLetterDays is int deadLetter)
+        {
+            application.RetentionDeadLetterDays = deadLetter == 0 ? null : deadLetter;
+        }
+
         await _appRepo.UpdateAsync(application, ct);
         InvalidateAuthCache(application.ApiKeyPrefix);
 
@@ -133,6 +146,8 @@ public class ApplicationsController : ControllerBase
             apiKeyPrefix = application.ApiKeyPrefix,
             isActive = application.IsActive,
             idempotencyWindowMinutes = application.IdempotencyWindowMinutes,
+            retentionDeliveredDays = application.RetentionDeliveredDays,
+            retentionDeadLetterDays = application.RetentionDeadLetterDays,
             createdAt = application.CreatedAt,
             updatedAt = application.UpdatedAt
         }));
@@ -206,4 +221,9 @@ public class UpdateApplicationRequest
     public string? Name { get; set; }
     public bool? IsActive { get; set; }
     public int? IdempotencyWindowMinutes { get; set; }
+
+    // Send 0 to clear an override and fall back to the global RetentionOptions.
+    // Send a positive integer to override per-app. Send null to leave unchanged.
+    public int? RetentionDeliveredDays { get; set; }
+    public int? RetentionDeadLetterDays { get; set; }
 }

--- a/src/WebhookEngine.API/Validators/RequestValidators.cs
+++ b/src/WebhookEngine.API/Validators/RequestValidators.cs
@@ -26,8 +26,22 @@ public class UpdateApplicationRequestValidator : AbstractValidator<UpdateApplica
             .InclusiveBetween(1, 10080)
             .When(x => x.IdempotencyWindowMinutes.HasValue);
 
+        // 0 is allowed and means "clear the override / fall back to global RetentionOptions";
+        // 1..365 sets a per-app override. Any other value is rejected.
+        RuleFor(x => x.RetentionDeliveredDays)
+            .InclusiveBetween(0, 365)
+            .When(x => x.RetentionDeliveredDays.HasValue);
+
+        RuleFor(x => x.RetentionDeadLetterDays)
+            .InclusiveBetween(0, 365)
+            .When(x => x.RetentionDeadLetterDays.HasValue);
+
         RuleFor(x => x)
-            .Must(x => x.Name is not null || x.IsActive.HasValue || x.IdempotencyWindowMinutes.HasValue)
+            .Must(x => x.Name is not null
+                || x.IsActive.HasValue
+                || x.IdempotencyWindowMinutes.HasValue
+                || x.RetentionDeliveredDays.HasValue
+                || x.RetentionDeadLetterDays.HasValue)
             .WithMessage("At least one field must be provided.");
     }
 }

--- a/src/WebhookEngine.Core/Entities/Application.cs
+++ b/src/WebhookEngine.Core/Entities/Application.cs
@@ -10,6 +10,12 @@ public class Application
     public string RetryPolicyJson { get; set; } = """{"maxRetries":7,"backoffSchedule":[5,30,120,900,3600,21600,86400]}""";
     public bool IsActive { get; set; } = true;
     public int IdempotencyWindowMinutes { get; set; } = 1440;
+
+    // Per-app retention overrides. Null = fall back to global RetentionOptions
+    // (DeliveredRetentionDays = 30, DeadLetterRetentionDays = 90 by default).
+    public int? RetentionDeliveredDays { get; set; }
+    public int? RetentionDeadLetterDays { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 

--- a/src/WebhookEngine.Infrastructure/Data/WebhookDbContext.cs
+++ b/src/WebhookEngine.Infrastructure/Data/WebhookDbContext.cs
@@ -39,6 +39,10 @@ public class WebhookDbContext : DbContext
             entity.Property(e => e.IdempotencyWindowMinutes)
                 .HasColumnName("idempotency_window_minutes")
                 .HasDefaultValue(1440);
+            entity.Property(e => e.RetentionDeliveredDays)
+                .HasColumnName("retention_delivered_days");
+            entity.Property(e => e.RetentionDeadLetterDays)
+                .HasColumnName("retention_dead_letter_days");
 
             entity.HasIndex(e => e.ApiKeyPrefix).IsUnique();
         });

--- a/src/WebhookEngine.Infrastructure/Migrations/20260508062656_AddPerAppRetentionOverrides.Designer.cs
+++ b/src/WebhookEngine.Infrastructure/Migrations/20260508062656_AddPerAppRetentionOverrides.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WebhookEngine.Infrastructure.Data;
@@ -11,9 +12,11 @@ using WebhookEngine.Infrastructure.Data;
 namespace WebhookEngine.Infrastructure.Migrations
 {
     [DbContext(typeof(WebhookDbContext))]
-    partial class WebhookDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260508062656_AddPerAppRetentionOverrides")]
+    partial class AddPerAppRetentionOverrides
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/WebhookEngine.Infrastructure/Migrations/20260508062656_AddPerAppRetentionOverrides.cs
+++ b/src/WebhookEngine.Infrastructure/Migrations/20260508062656_AddPerAppRetentionOverrides.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WebhookEngine.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPerAppRetentionOverrides : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "retention_dead_letter_days",
+                table: "applications",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "retention_delivered_days",
+                table: "applications",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "retention_dead_letter_days",
+                table: "applications");
+
+            migrationBuilder.DropColumn(
+                name: "retention_delivered_days",
+                table: "applications");
+        }
+    }
+}

--- a/src/WebhookEngine.Worker/RetentionCleanupWorker.cs
+++ b/src/WebhookEngine.Worker/RetentionCleanupWorker.cs
@@ -40,31 +40,13 @@ public class RetentionCleanupWorker : BackgroundService
                 using var scope = _serviceProvider.CreateScope();
                 var dbContext = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
 
-                var now = DateTime.UtcNow;
-                var deliveredCutoff = now.AddDays(-_options.DeliveredRetentionDays);
-                var deadLetterCutoff = now.AddDays(-_options.DeadLetterRetentionDays);
-
-                var deletedDelivered = await DeleteInBatchesAsync(
-                    dbContext,
-                    MessageStatus.Delivered,
-                    deliveredCutoff,
-                    stoppingToken);
-
-                var deletedDeadLetter = await DeleteInBatchesAsync(
-                    dbContext,
-                    MessageStatus.DeadLetter,
-                    deadLetterCutoff,
-                    stoppingToken);
-
-                var nulledIdempotencyKeys = await NullifyExpiredIdempotencyKeysAsync(
-                    dbContext,
-                    stoppingToken);
+                var result = await RunCleanupAsync(dbContext, DateTime.UtcNow, stoppingToken);
 
                 _logger.LogInformation(
                     "Retention cleanup completed. DeletedDelivered: {DeletedDelivered}, DeletedDeadLetter: {DeletedDeadLetter}, NulledIdempotencyKeys: {NulledIdempotencyKeys}",
-                    deletedDelivered,
-                    deletedDeadLetter,
-                    nulledIdempotencyKeys);
+                    result.DeletedDelivered,
+                    result.DeletedDeadLetter,
+                    result.NulledIdempotencyKeys);
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
@@ -80,8 +62,56 @@ public class RetentionCleanupWorker : BackgroundService
         _logger.LogInformation("RetentionCleanupWorker stopped");
     }
 
+    /// <summary>
+    /// Runs one cleanup pass over all applications. Exposed as <c>public</c>
+    /// so integration tests can drive it deterministically with a fixed
+    /// <paramref name="nowUtc"/> instead of waiting for the daily 03:00 schedule.
+    /// In production it is only invoked from <see cref="ExecuteAsync"/>.
+    /// </summary>
+    public async Task<RetentionCleanupResult> RunCleanupAsync(
+        WebhookDbContext dbContext,
+        DateTime nowUtc,
+        CancellationToken ct)
+    {
+        var apps = await dbContext.Applications
+            .AsNoTracking()
+            .Select(a => new AppRetentionConfig(a.Id, a.RetentionDeliveredDays, a.RetentionDeadLetterDays, a.IdempotencyWindowMinutes))
+            .ToListAsync(ct);
+
+        var deletedDelivered = 0;
+        var deletedDeadLetter = 0;
+
+        foreach (var app in apps)
+        {
+            if (ct.IsCancellationRequested) break;
+
+            // Per-app override or fall back to the deployment-level RetentionOptions.
+            var deliveredDays = app.DeliveredDays ?? _options.DeliveredRetentionDays;
+            var deadLetterDays = app.DeadLetterDays ?? _options.DeadLetterRetentionDays;
+
+            deletedDelivered += await DeleteInBatchesAsync(
+                dbContext,
+                app.Id,
+                MessageStatus.Delivered,
+                nowUtc.AddDays(-deliveredDays),
+                ct);
+
+            deletedDeadLetter += await DeleteInBatchesAsync(
+                dbContext,
+                app.Id,
+                MessageStatus.DeadLetter,
+                nowUtc.AddDays(-deadLetterDays),
+                ct);
+        }
+
+        var nulledIdempotencyKeys = await NullifyExpiredIdempotencyKeysAsync(dbContext, apps, nowUtc, ct);
+
+        return new RetentionCleanupResult(deletedDelivered, deletedDeadLetter, nulledIdempotencyKeys);
+    }
+
     private static async Task<int> DeleteInBatchesAsync(
         WebhookDbContext dbContext,
+        Guid appId,
         MessageStatus status,
         DateTime cutoff,
         CancellationToken ct)
@@ -91,7 +121,7 @@ public class RetentionCleanupWorker : BackgroundService
         while (!ct.IsCancellationRequested)
         {
             var deleted = await dbContext.Messages
-                .Where(m => m.Status == status && m.CreatedAt < cutoff)
+                .Where(m => m.AppId == appId && m.Status == status && m.CreatedAt < cutoff)
                 .OrderBy(m => m.CreatedAt)
                 .Take(BatchSize)
                 .ExecuteDeleteAsync(ct);
@@ -107,6 +137,8 @@ public class RetentionCleanupWorker : BackgroundService
         return totalDeleted;
     }
 
+    private sealed record AppRetentionConfig(Guid Id, int? DeliveredDays, int? DeadLetterDays, int IdempotencyWindowMinutes);
+
     // Window-expired rows lose their idempotency_key so the same key can be
     // re-used in a fresh window without violating the unique partial index
     // on (app_id, endpoint_id, idempotency_key) WHERE idempotency_key IS NOT NULL.
@@ -114,15 +146,11 @@ public class RetentionCleanupWorker : BackgroundService
     // per-app window (default 24h) and the row itself is preserved.
     private static async Task<int> NullifyExpiredIdempotencyKeysAsync(
         WebhookDbContext dbContext,
+        IReadOnlyList<AppRetentionConfig> apps,
+        DateTime nowUtc,
         CancellationToken ct)
     {
-        var apps = await dbContext.Applications
-            .AsNoTracking()
-            .Select(a => new { a.Id, a.IdempotencyWindowMinutes })
-            .ToListAsync(ct);
-
         var totalNulled = 0;
-        var nowUtc = DateTime.UtcNow;
 
         foreach (var app in apps)
         {
@@ -169,3 +197,12 @@ public class RetentionCleanupWorker : BackgroundService
         return nextRun - nowUtc;
     }
 }
+
+/// <summary>
+/// Per-pass tally of what the retention sweep removed. Returned by
+/// <see cref="RetentionCleanupWorker.RunCleanupAsync"/> for tests and logs.
+/// </summary>
+public sealed record RetentionCleanupResult(
+    int DeletedDelivered,
+    int DeletedDeadLetter,
+    int NulledIdempotencyKeys);

--- a/src/dashboard/src/api/dashboardApi.ts
+++ b/src/dashboard/src/api/dashboardApi.ts
@@ -165,9 +165,18 @@ export async function createApplication(name: string): Promise<ApplicationCreate
   return payload.data;
 }
 
+export interface ApplicationUpdate {
+  name?: string;
+  isActive?: boolean;
+  idempotencyWindowMinutes?: number;
+  // 0 clears the per-app override (falls back to global RetentionOptions).
+  retentionDeliveredDays?: number;
+  retentionDeadLetterDays?: number;
+}
+
 export async function updateApplication(
   id: string,
-  updates: { name?: string; isActive?: boolean }
+  updates: ApplicationUpdate
 ): Promise<ApplicationRow> {
   const payload = await mutate<ApiEnvelope<ApplicationRow>>(
     `/api/v1/applications/${id}`,

--- a/src/dashboard/src/types.ts
+++ b/src/dashboard/src/types.ts
@@ -46,6 +46,10 @@ export interface ApplicationRow {
   name: string;
   apiKeyPrefix: string;
   isActive: boolean;
+  idempotencyWindowMinutes?: number;
+  // null/undefined = falling back to global RetentionOptions.
+  retentionDeliveredDays?: number | null;
+  retentionDeadLetterDays?: number | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/tests/WebhookEngine.Infrastructure.Tests/EndToEnd/RetentionCleanupTests.cs
+++ b/tests/WebhookEngine.Infrastructure.Tests/EndToEnd/RetentionCleanupTests.cs
@@ -1,0 +1,225 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using WebhookEngine.Core.Entities;
+using WebhookEngine.Core.Enums;
+using WebhookEngine.Core.Options;
+using WebhookEngine.Infrastructure.Data;
+using WebhookEngine.Worker;
+using ApplicationEntity = WebhookEngine.Core.Entities.Application;
+
+namespace WebhookEngine.Infrastructure.Tests.EndToEnd;
+
+public class RetentionCleanupTests : IClassFixture<PostgresFixture>
+{
+    private readonly PostgresFixture _fixture;
+
+    public RetentionCleanupTests(PostgresFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task Per_App_RetentionDeliveredDays_Override_Trims_Earlier_Than_Global_Default()
+    {
+        await _fixture.ResetAsync();
+
+        // Global default is 30 days. App-A overrides to 7 days. Both apps
+        // get an identical 10-day-old delivered message — only App-A's
+        // copy should land outside its retention window.
+        var appAggressive = await SeedApplicationAsync(retentionDeliveredDays: 7);
+        var appDefault = await SeedApplicationAsync(retentionDeliveredDays: null);
+
+        var nowUtc = DateTime.UtcNow;
+        await SeedDeliveredMessageAsync(appAggressive, nowUtc.AddDays(-10));
+        await SeedDeliveredMessageAsync(appDefault, nowUtc.AddDays(-10));
+
+        var result = await RunCleanupAsync(nowUtc);
+
+        result.DeletedDelivered.Should().Be(1);
+
+        await using var db = NewDb();
+        var aggressiveCount = await db.Messages.CountAsync(m => m.AppId == appAggressive);
+        var defaultCount = await db.Messages.CountAsync(m => m.AppId == appDefault);
+
+        aggressiveCount.Should().Be(0);
+        defaultCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Per_App_RetentionDeadLetterDays_Override_Trims_Earlier_Than_Global_Default()
+    {
+        await _fixture.ResetAsync();
+
+        // Global default is 90 days. App-A overrides to 14 days. A 30-day-old
+        // dead-letter row falls inside the global default but outside App-A's
+        // override; only App-A's copy should be reaped.
+        var appAggressive = await SeedApplicationAsync(retentionDeadLetterDays: 14);
+        var appDefault = await SeedApplicationAsync(retentionDeadLetterDays: null);
+
+        var nowUtc = DateTime.UtcNow;
+        await SeedDeadLetterMessageAsync(appAggressive, nowUtc.AddDays(-30));
+        await SeedDeadLetterMessageAsync(appDefault, nowUtc.AddDays(-30));
+
+        var result = await RunCleanupAsync(nowUtc);
+
+        result.DeletedDeadLetter.Should().Be(1);
+
+        await using var db = NewDb();
+        var aggressiveCount = await db.Messages.CountAsync(m => m.AppId == appAggressive);
+        var defaultCount = await db.Messages.CountAsync(m => m.AppId == appDefault);
+
+        aggressiveCount.Should().Be(0);
+        defaultCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Per_App_Override_Of_Zero_Days_Is_Treated_As_Fallback_Not_Reap_Everything()
+    {
+        // Sanity guard: if an override of 0 ever leaks through (the API
+        // validator translates 0 into NULL/clear, so this is the post-DB state
+        // when the override is absent), behavior should match the global
+        // default — never "delete everything immediately".
+        await _fixture.ResetAsync();
+
+        var app = await SeedApplicationAsync(retentionDeliveredDays: null);
+
+        var nowUtc = DateTime.UtcNow;
+        await SeedDeliveredMessageAsync(app, nowUtc.AddHours(-1));
+
+        var result = await RunCleanupAsync(nowUtc);
+
+        result.DeletedDelivered.Should().Be(0);
+
+        await using var db = NewDb();
+        (await db.Messages.CountAsync(m => m.AppId == app)).Should().Be(1);
+    }
+
+    // ── Plumbing ───────────────────────────────────────
+
+    private async Task<RetentionCleanupResult> RunCleanupAsync(DateTime nowUtc)
+    {
+        var options = Options.Create(new RetentionOptions
+        {
+            DeliveredRetentionDays = 30,
+            DeadLetterRetentionDays = 90
+        });
+
+        await using var db = NewDb();
+
+        // The worker normally resolves DbContext from a scope; for the public
+        // RunCleanupAsync entry point we hand it one directly.
+        var worker = new RetentionCleanupWorker(
+            serviceProvider: null!,
+            logger: NullLogger<RetentionCleanupWorker>.Instance,
+            options: options);
+
+        return await worker.RunCleanupAsync(db, nowUtc, CancellationToken.None);
+    }
+
+    private async Task<Guid> SeedApplicationAsync(int? retentionDeliveredDays = null, int? retentionDeadLetterDays = null)
+    {
+        var appId = Guid.NewGuid();
+
+        await using var db = NewDb();
+        db.Applications.Add(new ApplicationEntity
+        {
+            Id = appId,
+            Name = $"Retention App {appId.ToString("N")[..6]}",
+            ApiKeyPrefix = $"whe_{appId.ToString("N")[..6]}_",
+            ApiKeyHash = "hash",
+            SigningSecret = "whsec_retention_secret",
+            RetentionDeliveredDays = retentionDeliveredDays,
+            RetentionDeadLetterDays = retentionDeadLetterDays
+        });
+        await db.SaveChangesAsync();
+
+        return appId;
+    }
+
+    private async Task SeedDeliveredMessageAsync(Guid appId, DateTime createdAtUtc)
+    {
+        var (endpointId, eventTypeId) = await EnsureEndpointAndEventTypeAsync(appId);
+
+        await using var db = NewDb();
+        db.Messages.Add(new Message
+        {
+            Id = Guid.NewGuid(),
+            AppId = appId,
+            EndpointId = endpointId,
+            EventTypeId = eventTypeId,
+            EventId = $"evt_{Guid.NewGuid():N}"[..32],
+            Payload = "{}",
+            Status = MessageStatus.Delivered,
+            CreatedAt = createdAtUtc,
+            DeliveredAt = createdAtUtc
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private async Task SeedDeadLetterMessageAsync(Guid appId, DateTime createdAtUtc)
+    {
+        var (endpointId, eventTypeId) = await EnsureEndpointAndEventTypeAsync(appId);
+
+        await using var db = NewDb();
+        db.Messages.Add(new Message
+        {
+            Id = Guid.NewGuid(),
+            AppId = appId,
+            EndpointId = endpointId,
+            EventTypeId = eventTypeId,
+            EventId = $"evt_{Guid.NewGuid():N}"[..32],
+            Payload = "{}",
+            Status = MessageStatus.DeadLetter,
+            CreatedAt = createdAtUtc
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private async Task<(Guid EndpointId, Guid EventTypeId)> EnsureEndpointAndEventTypeAsync(Guid appId)
+    {
+        await using var db = NewDb();
+        var existingEndpoint = await db.Endpoints.AsNoTracking().FirstOrDefaultAsync(e => e.AppId == appId);
+        var existingEventType = await db.EventTypes.AsNoTracking().FirstOrDefaultAsync(e => e.AppId == appId);
+
+        var endpointId = existingEndpoint?.Id ?? Guid.NewGuid();
+        var eventTypeId = existingEventType?.Id ?? Guid.NewGuid();
+
+        if (existingEndpoint is null)
+        {
+            db.Endpoints.Add(new Endpoint
+            {
+                Id = endpointId,
+                AppId = appId,
+                Url = "https://example.invalid/webhook",
+                Status = EndpointStatus.Active
+            });
+        }
+
+        if (existingEventType is null)
+        {
+            db.EventTypes.Add(new EventType
+            {
+                Id = eventTypeId,
+                AppId = appId,
+                Name = "test.event"
+            });
+        }
+
+        if (existingEndpoint is null || existingEventType is null)
+        {
+            await db.SaveChangesAsync();
+        }
+
+        return (endpointId, eventTypeId);
+    }
+
+    private WebhookDbContext NewDb()
+    {
+        var options = new DbContextOptionsBuilder<WebhookDbContext>()
+            .UseNpgsql(_fixture.ConnectionString)
+            .Options;
+        return new WebhookDbContext(options);
+    }
+}


### PR DESCRIPTION
## Summary

Adds two nullable integer columns to `applications` so each app can override the deployment-wide retention windows. `RetentionCleanupWorker` is rewritten to a per-app loop that respects the override or falls back to global `RetentionOptions`. **F3 from the post-v0.1.5 plan. First migration in the F3-F10 batch.**

## Why

Retention was deployment-global: every application paid the same 30-day delivered / 90-day dead-letter retention. That's wrong as soon as you have any tier diversity:

- A **free-tier app** wants delivered messages reaped at 7 days to keep volume tight.
- A **compliance-bound enterprise app** needs 365 days of dead-letter forensics.
- A **dev/test app** wants 1-day retention so the noise from CI churn doesn't pollute its log.

This PR keeps the global default for back-compat (existing apps keep their behavior since both new columns default to `NULL`) and lets any application opt into a per-app policy by writing two columns.

## What changed

### Schema (migration: `AddPerAppRetentionOverrides`)
- `applications.retention_delivered_days` `integer NULL`
- `applications.retention_dead_letter_days` `integer NULL`

Both default to `NULL`; the worker treats `NULL` as "fall back to global `RetentionOptions`."

### Worker (`RetentionCleanupWorker`)
- Cleanup body refactored into `public Task<RetentionCleanupResult> RunCleanupAsync(WebhookDbContext, DateTime nowUtc, CancellationToken)`. Tests can drive it deterministically with a fixed `nowUtc` without waiting for the 03:00 schedule.
- `RunCleanupAsync` lists every application with its overrides + idempotency window in one pass, then for each app:
  - Computes `deliveredCutoff = nowUtc - (override ?? global)`.
  - Computes `deadLetterCutoff = nowUtc - (override ?? global)`.
  - Runs the existing `ExecuteDeleteAsync` batch query scoped to `app_id`.
- The window-expired idempotency-key nullification step joins the same per-app loop, so we go from 2 `applications` reads per pass to 1.
- New `public sealed record RetentionCleanupResult(DeletedDelivered, DeletedDeadLetter, NulledIdempotencyKeys)` is the worker's per-pass summary, also used by the integration tests.

### API (`ApplicationsController`)
- `PUT /api/v1/applications/{id}` accepts:
  ```json
  { "retentionDeliveredDays": 7, "retentionDeadLetterDays": 14 }
  ```
- **`0` is the documented "clear the override" sentinel** — translated to `NULL` at the DB layer so the global default applies again.
- `1..365` sets a per-app override.
- `null` (omitted from request) leaves the existing value unchanged.
- Both `GET /applications/{id}` and `PUT` responses now include `retentionDeliveredDays` and `retentionDeadLetterDays`.
- Validator: `InclusiveBetween(0, 365)` when present.

### Dashboard
- `types.ts::ApplicationRow` gained the two optional fields so an upcoming UI extension can read them.
- `dashboardApi.ts::updateApplication` now takes a typed `ApplicationUpdate` interface that surfaces `idempotencyWindowMinutes`, `retentionDeliveredDays`, and `retentionDeadLetterDays`. (UI input is a separate follow-up; the API contract is in place.)

### Tests
Three Testcontainers integration tests in `tests/WebhookEngine.Infrastructure.Tests/EndToEnd/RetentionCleanupTests.cs`:
- `Per_App_RetentionDeliveredDays_Override_Trims_Earlier_Than_Global_Default` — App-A overrides to 7d, App-B falls back to 30d global. A 10-day-old delivered message is reaped from App-A but kept on App-B.
- `Per_App_RetentionDeadLetterDays_Override_Trims_Earlier_Than_Global_Default` — symmetric for dead-letter.
- `Per_App_Override_Of_Zero_Days_Is_Treated_As_Fallback_Not_Reap_Everything` — sanity guard against a future regression where 0 leaks through to the worker as a real cutoff.

## Test plan

- [x] `dotnet build WebhookEngine.sln --configuration Release` — 0 warnings, 0 errors
- [x] `dotnet test WebhookEngine.sln --configuration Release` — 182 / 182 pass (Core 32, API 66, Worker 46, Infrastructure 38)
- [x] `bun run typecheck && bun run lint && bun run build` (dashboard) — clean
- [ ] CI green