### PR TITLE
feat(api+infra): per-event-type idempotency window override

### DIFF
--- a/src/WebhookEngine.API/Contracts/ApiResponseDtos.cs
+++ b/src/WebhookEngine.API/Contracts/ApiResponseDtos.cs
@@ -12,6 +12,8 @@ public sealed class EventTypeResponseDto
     public string? Description { get; init; }
     public JsonElement? Schema { get; init; }
     public bool IsArchived { get; init; }
+    // null = inherit from Application.IdempotencyWindowMinutes.
+    public int? IdempotencyWindowMinutes { get; init; }
     public DateTime CreatedAt { get; init; }
 }
 
@@ -76,6 +78,7 @@ public static class ApiResponseMapper
             Description = eventType.Description,
             Schema = JsonValueParser.ParseOrNull(eventType.SchemaJson),
             IsArchived = eventType.IsArchived,
+            IdempotencyWindowMinutes = eventType.IdempotencyWindowMinutes,
             CreatedAt = eventType.CreatedAt
         };
     }

--- a/src/WebhookEngine.API/Controllers/DashboardEndpointController.cs
+++ b/src/WebhookEngine.API/Controllers/DashboardEndpointController.cs
@@ -391,7 +391,8 @@ public class DashboardEndpointController : ControllerBase
         {
             AppId = request.AppId,
             Name = request.Name,
-            Description = request.Description
+            Description = request.Description,
+            IdempotencyWindowMinutes = request.IdempotencyWindowMinutes
         };
 
         await _eventTypeRepository.CreateAsync(eventType, ct);
@@ -404,6 +405,7 @@ public class DashboardEndpointController : ControllerBase
             name = eventType.Name,
             description = eventType.Description,
             isArchived = eventType.IsArchived,
+            idempotencyWindowMinutes = eventType.IdempotencyWindowMinutes,
             createdAt = eventType.CreatedAt
         }));
     }
@@ -443,6 +445,12 @@ public class DashboardEndpointController : ControllerBase
         if (request.Description is not null)
             eventType.Description = request.Description;
 
+        // 0 = clear (fall back to per-app window). Positive = set override.
+        if (request.IdempotencyWindowMinutes is int windowMinutes)
+        {
+            eventType.IdempotencyWindowMinutes = windowMinutes == 0 ? null : windowMinutes;
+        }
+
         await _eventTypeRepository.UpdateAsync(eventType, ct);
         DeliveryLookupCache.InvalidateApplication(eventType.AppId);
 
@@ -453,6 +461,7 @@ public class DashboardEndpointController : ControllerBase
             name = eventType.Name,
             description = eventType.Description,
             isArchived = eventType.IsArchived,
+            idempotencyWindowMinutes = eventType.IdempotencyWindowMinutes,
             createdAt = eventType.CreatedAt
         }));
     }
@@ -502,12 +511,15 @@ public class DashboardCreateEventTypeRequest
     public Guid AppId { get; set; }
     public string Name { get; set; } = string.Empty;
     public string? Description { get; set; }
+    public int? IdempotencyWindowMinutes { get; set; }
 }
 
 public class DashboardUpdateEventTypeRequest
 {
     public string? Name { get; set; }
     public string? Description { get; set; }
+    // 0 clears the override (falls back to per-app window). Positive = set override. null = leave unchanged.
+    public int? IdempotencyWindowMinutes { get; set; }
 }
 
 public class ValidateTransformRequest

--- a/src/WebhookEngine.API/Controllers/DashboardMessagesController.cs
+++ b/src/WebhookEngine.API/Controllers/DashboardMessagesController.cs
@@ -134,6 +134,7 @@ public class DashboardMessagesController : ControllerBase
 
         Guid eventTypeId;
         string eventTypeName;
+        int? eventTypeIdempotencyWindowMinutes;
 
         if (request.EventTypeId.HasValue)
         {
@@ -157,6 +158,7 @@ public class DashboardMessagesController : ControllerBase
 
             eventTypeId = eventType.Id;
             eventTypeName = eventType.Name;
+            eventTypeIdempotencyWindowMinutes = eventType.IdempotencyWindowMinutes;
         }
         else
         {
@@ -175,11 +177,13 @@ public class DashboardMessagesController : ControllerBase
 
             eventTypeId = eventType.Id;
             eventTypeName = eventType.Name;
+            eventTypeIdempotencyWindowMinutes = eventType.IdempotencyWindowMinutes;
         }
 
         if (!string.IsNullOrWhiteSpace(request.IdempotencyKey))
         {
-            var windowMinutes = app.IdempotencyWindowMinutes;
+            // Per-event-type override beats the per-app window when set.
+            var windowMinutes = eventTypeIdempotencyWindowMinutes ?? app.IdempotencyWindowMinutes;
             var existingMessages = await _messageRepository.ListByIdempotencyKeyAsync(
                 request.AppId,
                 request.IdempotencyKey,

--- a/src/WebhookEngine.API/Controllers/EventTypesController.cs
+++ b/src/WebhookEngine.API/Controllers/EventTypesController.cs
@@ -41,7 +41,8 @@ public class EventTypesController : ControllerBase
             Description = request.Description,
             SchemaJson = request.Schema is not null
                 ? System.Text.Json.JsonSerializer.Serialize(request.Schema)
-                : null
+                : null,
+            IdempotencyWindowMinutes = request.IdempotencyWindowMinutes
         };
 
         await _eventTypeRepo.CreateAsync(eventType, ct);
@@ -100,6 +101,12 @@ public class EventTypesController : ControllerBase
         if (request.Schema is not null)
             eventType.SchemaJson = System.Text.Json.JsonSerializer.Serialize(request.Schema);
 
+        // 0 = clear the override (fall back to per-app window). Positive = override.
+        if (request.IdempotencyWindowMinutes is int windowMinutes)
+        {
+            eventType.IdempotencyWindowMinutes = windowMinutes == 0 ? null : windowMinutes;
+        }
+
         await _eventTypeRepo.UpdateAsync(eventType, ct);
         DeliveryLookupCache.InvalidateApplication(eventType.AppId);
 
@@ -125,6 +132,8 @@ public class CreateEventTypeRequest
     public string Name { get; set; } = string.Empty;
     public string? Description { get; set; }
     public object? Schema { get; set; }
+    // null on create = inherit per-app window. Positive value = override per event type.
+    public int? IdempotencyWindowMinutes { get; set; }
 }
 
 public class UpdateEventTypeRequest
@@ -132,4 +141,6 @@ public class UpdateEventTypeRequest
     public string? Name { get; set; }
     public string? Description { get; set; }
     public object? Schema { get; set; }
+    // 0 clears the override (falls back to per-app window). Positive = set override. null = leave unchanged.
+    public int? IdempotencyWindowMinutes { get; set; }
 }

--- a/src/WebhookEngine.API/Controllers/MessagesController.cs
+++ b/src/WebhookEngine.API/Controllers/MessagesController.cs
@@ -261,8 +261,13 @@ public class MessagesController : ControllerBase
 
         if (!string.IsNullOrWhiteSpace(request.IdempotencyKey))
         {
+            // Per-event-type override > per-app window > hard fallback. The
+            // event-type override exists so a noisy `user.activity` stream can
+            // tighten the window without dragging payment events with it.
             var app = await _appRepo.GetByIdAsync(appId, ct);
-            var windowMinutes = app?.IdempotencyWindowMinutes ?? 1440;
+            var windowMinutes = eventTypeResolution.IdempotencyWindowMinutes
+                ?? app?.IdempotencyWindowMinutes
+                ?? 1440;
             var existingMessages = await _messageRepo.ListByIdempotencyKeyAsync(
                 appId,
                 request.IdempotencyKey,
@@ -349,28 +354,29 @@ public class MessagesController : ControllerBase
                 return EventTypeResolutionResult.Failure("UNPROCESSABLE", "eventType and eventTypeId refer to different event types.");
             }
 
-            return EventTypeResolutionResult.Ok(eventType.Id, eventType.Name);
+            return EventTypeResolutionResult.Ok(eventType.Id, eventType.Name, eventType.IdempotencyWindowMinutes);
         }
 
         var resolvedByName = await _lookupCache.GetEventTypeByNameAsync(appId, eventTypeName ?? string.Empty, ct);
         if (resolvedByName is null)
             return EventTypeResolutionResult.Failure("UNPROCESSABLE", "Event type not found for this application.");
 
-        return EventTypeResolutionResult.Ok(resolvedByName.Id, resolvedByName.Name);
+        return EventTypeResolutionResult.Ok(resolvedByName.Id, resolvedByName.Name, resolvedByName.IdempotencyWindowMinutes);
     }
 
     private sealed record EventTypeResolutionResult(
         bool Success,
         Guid? EventTypeId,
         string? EventTypeName,
+        int? IdempotencyWindowMinutes,
         string? ErrorCode,
         string? ErrorMessage)
     {
-        public static EventTypeResolutionResult Ok(Guid eventTypeId, string eventTypeName)
-            => new(true, eventTypeId, eventTypeName, null, null);
+        public static EventTypeResolutionResult Ok(Guid eventTypeId, string eventTypeName, int? idempotencyWindowMinutes)
+            => new(true, eventTypeId, eventTypeName, idempotencyWindowMinutes, null, null);
 
         public static EventTypeResolutionResult Failure(string errorCode, string errorMessage)
-            => new(false, null, null, errorCode, errorMessage);
+            => new(false, null, null, null, errorCode, errorMessage);
     }
 
     private sealed record SendOperationResult(

--- a/src/WebhookEngine.API/Validators/RequestValidators.cs
+++ b/src/WebhookEngine.API/Validators/RequestValidators.cs
@@ -57,6 +57,11 @@ public class CreateEventTypeRequestValidator : AbstractValidator<CreateEventType
         RuleFor(x => x.Description)
             .MaximumLength(500)
             .When(x => x.Description is not null);
+
+        // Per-event-type override; matches the per-app upper bound of 7 days.
+        RuleFor(x => x.IdempotencyWindowMinutes)
+            .InclusiveBetween(1, 10080)
+            .When(x => x.IdempotencyWindowMinutes.HasValue);
     }
 }
 
@@ -72,8 +77,16 @@ public class UpdateEventTypeRequestValidator : AbstractValidator<UpdateEventType
             .MaximumLength(500)
             .When(x => x.Description is not null);
 
+        // 0 clears the override (per-app fallback); 1..10080 sets it.
+        RuleFor(x => x.IdempotencyWindowMinutes)
+            .InclusiveBetween(0, 10080)
+            .When(x => x.IdempotencyWindowMinutes.HasValue);
+
         RuleFor(x => x)
-            .Must(x => x.Name is not null || x.Description is not null || x.Schema is not null)
+            .Must(x => x.Name is not null
+                || x.Description is not null
+                || x.Schema is not null
+                || x.IdempotencyWindowMinutes.HasValue)
             .WithMessage("At least one field must be provided.");
     }
 }
@@ -252,6 +265,10 @@ public class DashboardCreateEventTypeRequestValidator : AbstractValidator<Dashbo
         RuleFor(x => x.Description)
             .MaximumLength(500)
             .When(x => x.Description is not null);
+
+        RuleFor(x => x.IdempotencyWindowMinutes)
+            .InclusiveBetween(1, 10080)
+            .When(x => x.IdempotencyWindowMinutes.HasValue);
     }
 }
 
@@ -267,8 +284,15 @@ public class DashboardUpdateEventTypeRequestValidator : AbstractValidator<Dashbo
             .MaximumLength(500)
             .When(x => x.Description is not null);
 
+        // 0 clears the override; 1..10080 sets it.
+        RuleFor(x => x.IdempotencyWindowMinutes)
+            .InclusiveBetween(0, 10080)
+            .When(x => x.IdempotencyWindowMinutes.HasValue);
+
         RuleFor(x => x)
-            .Must(x => x.Name is not null || x.Description is not null)
+            .Must(x => x.Name is not null
+                || x.Description is not null
+                || x.IdempotencyWindowMinutes.HasValue)
             .WithMessage("At least one field must be provided.");
     }
 }

--- a/src/WebhookEngine.Core/Entities/EventType.cs
+++ b/src/WebhookEngine.Core/Entities/EventType.cs
@@ -8,6 +8,13 @@ public class EventType
     public string? Description { get; set; }
     public string? SchemaJson { get; set; }
     public bool IsArchived { get; set; }
+
+    /// <summary>
+    /// Per-event-type override for the idempotency-key reuse window. Null
+    /// falls back to <see cref="Application.IdempotencyWindowMinutes"/>.
+    /// </summary>
+    public int? IdempotencyWindowMinutes { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
     // Navigation properties

--- a/src/WebhookEngine.Infrastructure/Data/WebhookDbContext.cs
+++ b/src/WebhookEngine.Infrastructure/Data/WebhookDbContext.cs
@@ -58,6 +58,8 @@ public class WebhookDbContext : DbContext
             entity.Property(e => e.Description).HasColumnName("description");
             entity.Property(e => e.SchemaJson).HasColumnName("schema_json").HasColumnType("jsonb");
             entity.Property(e => e.IsArchived).HasColumnName("is_archived").HasDefaultValue(false);
+            entity.Property(e => e.IdempotencyWindowMinutes)
+                .HasColumnName("idempotency_window_minutes");
             entity.Property(e => e.CreatedAt).HasColumnName("created_at").HasDefaultValueSql("NOW()");
 
             entity.HasIndex(e => e.AppId).HasDatabaseName("idx_event_types_app_id");

--- a/src/WebhookEngine.Infrastructure/Migrations/20260508064012_AddPerEventTypeIdempotencyWindow.Designer.cs
+++ b/src/WebhookEngine.Infrastructure/Migrations/20260508064012_AddPerEventTypeIdempotencyWindow.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WebhookEngine.Infrastructure.Data;
@@ -11,9 +12,11 @@ using WebhookEngine.Infrastructure.Data;
 namespace WebhookEngine.Infrastructure.Migrations
 {
     [DbContext(typeof(WebhookDbContext))]
-    partial class WebhookDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260508064012_AddPerEventTypeIdempotencyWindow")]
+    partial class AddPerEventTypeIdempotencyWindow
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/WebhookEngine.Infrastructure/Migrations/20260508064012_AddPerEventTypeIdempotencyWindow.cs
+++ b/src/WebhookEngine.Infrastructure/Migrations/20260508064012_AddPerEventTypeIdempotencyWindow.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WebhookEngine.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPerEventTypeIdempotencyWindow : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "idempotency_window_minutes",
+                table: "event_types",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "idempotency_window_minutes",
+                table: "event_types");
+        }
+    }
+}

--- a/src/WebhookEngine.Worker/RetentionCleanupWorker.cs
+++ b/src/WebhookEngine.Worker/RetentionCleanupWorker.cs
@@ -104,7 +104,14 @@ public class RetentionCleanupWorker : BackgroundService
                 ct);
         }
 
-        var nulledIdempotencyKeys = await NullifyExpiredIdempotencyKeysAsync(dbContext, apps, nowUtc, ct);
+        // Pull every event type's optional idempotency-window override in one
+        // shot; the helper does the per-event-type sweep with app fallback.
+        var eventTypes = await dbContext.EventTypes
+            .AsNoTracking()
+            .Select(e => new EventTypeIdempotencyConfig(e.Id, e.AppId, e.IdempotencyWindowMinutes))
+            .ToListAsync(ct);
+
+        var nulledIdempotencyKeys = await NullifyExpiredIdempotencyKeysAsync(dbContext, apps, eventTypes, nowUtc, ct);
 
         return new RetentionCleanupResult(deletedDelivered, deletedDeadLetter, nulledIdempotencyKeys);
     }
@@ -139,32 +146,38 @@ public class RetentionCleanupWorker : BackgroundService
 
     private sealed record AppRetentionConfig(Guid Id, int? DeliveredDays, int? DeadLetterDays, int IdempotencyWindowMinutes);
 
+    private sealed record EventTypeIdempotencyConfig(Guid Id, Guid AppId, int? OverrideMinutes);
+
     // Window-expired rows lose their idempotency_key so the same key can be
     // re-used in a fresh window without violating the unique partial index
     // on (app_id, endpoint_id, idempotency_key) WHERE idempotency_key IS NOT NULL.
-    // Stripe-style: idempotency keys are valid only inside the configured
-    // per-app window (default 24h) and the row itself is preserved.
+    // Stripe-style: keys are valid only inside the configured window. The
+    // window is resolved per-message: an event-type override beats the
+    // application-level window. We sweep per event type so each batch DELETE
+    // / UPDATE can use a single, statically-known cutoff.
     private static async Task<int> NullifyExpiredIdempotencyKeysAsync(
         WebhookDbContext dbContext,
         IReadOnlyList<AppRetentionConfig> apps,
+        IReadOnlyList<EventTypeIdempotencyConfig> eventTypes,
         DateTime nowUtc,
         CancellationToken ct)
     {
+        var appWindows = apps.ToDictionary(a => a.Id, a => a.IdempotencyWindowMinutes);
         var totalNulled = 0;
 
-        foreach (var app in apps)
+        foreach (var eventType in eventTypes)
         {
-            if (ct.IsCancellationRequested)
-            {
-                break;
-            }
+            if (ct.IsCancellationRequested) break;
+            if (!appWindows.TryGetValue(eventType.AppId, out var appWindow)) continue;
 
-            var cutoff = nowUtc.AddMinutes(-app.IdempotencyWindowMinutes);
+            // Per-event-type override > per-app window.
+            var effectiveMinutes = eventType.OverrideMinutes ?? appWindow;
+            var cutoff = nowUtc.AddMinutes(-effectiveMinutes);
 
             while (!ct.IsCancellationRequested)
             {
                 var batch = await dbContext.Messages
-                    .Where(m => m.AppId == app.Id
+                    .Where(m => m.EventTypeId == eventType.Id
                         && m.IdempotencyKey != null
                         && m.CreatedAt < cutoff)
                     .OrderBy(m => m.CreatedAt)
@@ -173,10 +186,7 @@ public class RetentionCleanupWorker : BackgroundService
                         s => s.SetProperty(m => m.IdempotencyKey, (string?)null),
                         ct);
 
-                if (batch == 0)
-                {
-                    break;
-                }
+                if (batch == 0) break;
 
                 totalNulled += batch;
             }

--- a/src/dashboard/src/api/dashboardApi.ts
+++ b/src/dashboard/src/api/dashboardApi.ts
@@ -307,11 +307,15 @@ export interface DashboardCreateEventTypeRequest {
   appId: string;
   name: string;
   description?: string;
+  // null on create = inherit per-app window. Positive = override per event type.
+  idempotencyWindowMinutes?: number;
 }
 
 export interface DashboardUpdateEventTypeRequest {
   name?: string;
   description?: string;
+  // 0 clears the override (falls back to per-app window).
+  idempotencyWindowMinutes?: number;
 }
 
 export async function createDashboardEventType(request: DashboardCreateEventTypeRequest): Promise<EventTypeSummary> {

--- a/src/dashboard/src/types.ts
+++ b/src/dashboard/src/types.ts
@@ -88,6 +88,8 @@ export interface EventTypeSummary {
   name: string;
   description: string | null;
   isArchived: boolean;
+  // null = inherit from Application.idempotencyWindowMinutes.
+  idempotencyWindowMinutes?: number | null;
   createdAt: string;
 }
 

--- a/tests/WebhookEngine.Infrastructure.Tests/EndToEnd/RetentionCleanupTests.cs
+++ b/tests/WebhookEngine.Infrastructure.Tests/EndToEnd/RetentionCleanupTests.cs
@@ -75,6 +75,37 @@ public class RetentionCleanupTests : IClassFixture<PostgresFixture>
     }
 
     [Fact]
+    public async Task Per_EventType_IdempotencyWindow_Override_Nullifies_Earlier_Than_Per_App()
+    {
+        await _fixture.ResetAsync();
+
+        // App-wide window is 1440 minutes (24h). Event type "noisy.event"
+        // tightens it to 60 minutes. A 90-minute-old idempotency-keyed message
+        // for "noisy.event" should lose its key, but a 90-minute-old message
+        // on a sibling event type without an override should keep it.
+        var appId = await SeedApplicationWithIdempotencyWindowAsync(1440);
+        var noisyEventTypeId = await SeedEventTypeAsync(appId, "noisy.event", idempotencyWindowMinutes: 60);
+        var normalEventTypeId = await SeedEventTypeAsync(appId, "normal.event", idempotencyWindowMinutes: null);
+
+        var nowUtc = DateTime.UtcNow;
+        var ninetyMinutesAgo = nowUtc.AddMinutes(-90);
+
+        var noisyMessageId = await SeedKeyedMessageAsync(appId, noisyEventTypeId, "key-1", ninetyMinutesAgo);
+        var normalMessageId = await SeedKeyedMessageAsync(appId, normalEventTypeId, "key-2", ninetyMinutesAgo);
+
+        var result = await RunCleanupAsync(nowUtc);
+
+        result.NulledIdempotencyKeys.Should().Be(1);
+
+        await using var db = NewDb();
+        var noisyMessage = await db.Messages.AsNoTracking().SingleAsync(m => m.Id == noisyMessageId);
+        var normalMessage = await db.Messages.AsNoTracking().SingleAsync(m => m.Id == normalMessageId);
+
+        noisyMessage.IdempotencyKey.Should().BeNull("the per-event-type override expired first");
+        normalMessage.IdempotencyKey.Should().Be("key-2", "no override; per-app window still covers it");
+    }
+
+    [Fact]
     public async Task Per_App_Override_Of_Zero_Days_Is_Treated_As_Fallback_Not_Reap_Everything()
     {
         // Sanity guard: if an override of 0 ever leaks through (the API
@@ -116,6 +147,80 @@ public class RetentionCleanupTests : IClassFixture<PostgresFixture>
             options: options);
 
         return await worker.RunCleanupAsync(db, nowUtc, CancellationToken.None);
+    }
+
+    private async Task<Guid> SeedApplicationWithIdempotencyWindowAsync(int idempotencyWindowMinutes)
+    {
+        var appId = Guid.NewGuid();
+
+        await using var db = NewDb();
+        db.Applications.Add(new ApplicationEntity
+        {
+            Id = appId,
+            Name = $"Idempotency App {appId.ToString("N")[..6]}",
+            ApiKeyPrefix = $"whe_{appId.ToString("N")[..6]}_",
+            ApiKeyHash = "hash",
+            SigningSecret = "whsec_idempotency_secret",
+            IdempotencyWindowMinutes = idempotencyWindowMinutes
+        });
+        await db.SaveChangesAsync();
+
+        return appId;
+    }
+
+    private async Task<Guid> SeedEventTypeAsync(Guid appId, string name, int? idempotencyWindowMinutes)
+    {
+        var eventTypeId = Guid.NewGuid();
+
+        await using var db = NewDb();
+        db.EventTypes.Add(new EventType
+        {
+            Id = eventTypeId,
+            AppId = appId,
+            Name = name,
+            IdempotencyWindowMinutes = idempotencyWindowMinutes
+        });
+        await db.SaveChangesAsync();
+
+        return eventTypeId;
+    }
+
+    private async Task<Guid> SeedKeyedMessageAsync(Guid appId, Guid eventTypeId, string idempotencyKey, DateTime createdAtUtc)
+    {
+        var messageId = Guid.NewGuid();
+
+        await using var db = NewDb();
+
+        // Key-bearing messages need a real endpoint row to satisfy the FK.
+        var existingEndpoint = await db.Endpoints.AsNoTracking().FirstOrDefaultAsync(e => e.AppId == appId);
+        var endpointId = existingEndpoint?.Id ?? Guid.NewGuid();
+        if (existingEndpoint is null)
+        {
+            db.Endpoints.Add(new Endpoint
+            {
+                Id = endpointId,
+                AppId = appId,
+                Url = "https://example.invalid/webhook",
+                Status = EndpointStatus.Active
+            });
+        }
+
+        db.Messages.Add(new Message
+        {
+            Id = messageId,
+            AppId = appId,
+            EndpointId = endpointId,
+            EventTypeId = eventTypeId,
+            EventId = $"evt_{Guid.NewGuid():N}"[..32],
+            IdempotencyKey = idempotencyKey,
+            Payload = "{}",
+            Status = MessageStatus.Delivered,
+            CreatedAt = createdAtUtc,
+            DeliveredAt = createdAtUtc
+        });
+        await db.SaveChangesAsync();
+
+        return messageId;
     }
 
     private async Task<Guid> SeedApplicationAsync(int? retentionDeliveredDays = null, int? retentionDeadLetterDays = null)


### PR DESCRIPTION
## Summary

Adds `EventType.IdempotencyWindowMinutes` (nullable) so a noisy event type can tighten or relax the idempotency reuse window without affecting siblings on the same app. **F4 from the post-v0.1.5 plan. Second migration in the F3-F10 batch.**

## Why

The reuse window was per-application: every event type sharing an app shared the same window. That's the wrong axis for tuning — a single app typically mixes:

- **`payment.completed`** — should dedupe for hours (or days), so a retry storm doesn't double-charge.
- **`user.activity`** / **`click.tracked`** — high-volume telemetry where a tight window keeps the unique-key cardinality small.

Today, splitting these requires creating a separate Application — which fragments billing, API keys, and dashboards. F4 lets one app stay one app while letting each event type pick its own window.

## What changed

### Schema (migration: `AddPerEventTypeIdempotencyWindow`)
- `event_types.idempotency_window_minutes` `integer NULL`
- NULL means "fall back to `Application.IdempotencyWindowMinutes`" (which itself defaults to 1440).

### Send path (`MessagesController` + `DashboardMessagesController`)
- `EventTypeResolutionResult` now carries the resolved override alongside the id and name, so the send path doesn't need a second lookup.
- Window precedence: `eventType.IdempotencyWindowMinutes` > `app.IdempotencyWindowMinutes` > hard 1440-minute floor.

### Retention worker (`RetentionCleanupWorker.NullifyExpiredIdempotencyKeysAsync`)
- Rewrote from a per-app loop to a per-event-type loop. Each event type computes its own `cutoff = nowUtc - (override ?? appWindow)` and runs the existing `ExecuteUpdateAsync` batch scoped to `event_type_id`. Cleaner than per-row CASE because each batch query has a single, statically-known cutoff.

### API
- **Public** `POST/PUT /api/v1/event-types`: accept and echo `idempotencyWindowMinutes` (Create: positive override or null inherit; Update: 0 clears, 1..10080 sets, null leaves unchanged).
- **Dashboard** `POST/PUT /api/v1/dashboard/event-types`: same contract.
- `EventTypeResponseDto` exposes the field on read.
- Validators: `InclusiveBetween(1, 10080)` on create, `InclusiveBetween(0, 10080)` on update (0 = clear). Range matches the per-app upper bound (7 days).

### Dashboard
- `types.ts::EventTypeSummary` and `dashboardApi.ts::DashboardCreate/UpdateEventTypeRequest` gained the optional `idempotencyWindowMinutes` field. UI input deferred to a follow-up — the contract is in place.

### Tests
One new Testcontainers test in `RetentionCleanupTests`:
- `Per_EventType_IdempotencyWindow_Override_Nullifies_Earlier_Than_Per_App`: app window = 1440m, "noisy.event" overrides to 60m. 90-minute-old keys get nullified on the noisy event type but kept on the sibling event type that inherits the per-app window.

## Test plan

- [x] `dotnet build WebhookEngine.sln --configuration Release` — 0 warnings, 0 errors
- [x] `dotnet test WebhookEngine.sln --configuration Release` — 183 / 183 pass (Core 32, API 66, Worker 46, Infrastructure 39)
- [x] `bun run typecheck && bun run lint` (dashboard) — clean
- [ ] CI green