### PR TITLE
feat(api+infra): per-application rate-limit override (1-second window gate)

### DIFF
--- a/src/WebhookEngine.API/Controllers/ApplicationsController.cs
+++ b/src/WebhookEngine.API/Controllers/ApplicationsController.cs
@@ -110,6 +110,7 @@ public class ApplicationsController : ControllerBase
             idempotencyWindowMinutes = application.IdempotencyWindowMinutes,
             retentionDeliveredDays = application.RetentionDeliveredDays,
             retentionDeadLetterDays = application.RetentionDeadLetterDays,
+            rateLimitPerSecond = application.RateLimitPerSecond,
             createdAt = application.CreatedAt,
             updatedAt = application.UpdatedAt
         }));
@@ -135,6 +136,10 @@ public class ApplicationsController : ControllerBase
         {
             application.RetentionDeadLetterDays = deadLetter == 0 ? null : deadLetter;
         }
+        if (request.RateLimitPerSecond is int rateLimit)
+        {
+            application.RateLimitPerSecond = rateLimit == 0 ? null : rateLimit;
+        }
 
         await _appRepo.UpdateAsync(application, ct);
         InvalidateAuthCache(application.ApiKeyPrefix);
@@ -148,6 +153,7 @@ public class ApplicationsController : ControllerBase
             idempotencyWindowMinutes = application.IdempotencyWindowMinutes,
             retentionDeliveredDays = application.RetentionDeliveredDays,
             retentionDeadLetterDays = application.RetentionDeadLetterDays,
+            rateLimitPerSecond = application.RateLimitPerSecond,
             createdAt = application.CreatedAt,
             updatedAt = application.UpdatedAt
         }));
@@ -226,4 +232,8 @@ public class UpdateApplicationRequest
     // Send a positive integer to override per-app. Send null to leave unchanged.
     public int? RetentionDeliveredDays { get; set; }
     public int? RetentionDeadLetterDays { get; set; }
+
+    // Send 0 to clear the per-app rate limit (unlimited at the app gate).
+    // Send a positive integer to set messages-per-second cap. null = unchanged.
+    public int? RateLimitPerSecond { get; set; }
 }

--- a/src/WebhookEngine.API/Program.cs
+++ b/src/WebhookEngine.API/Program.cs
@@ -127,6 +127,7 @@ builder.Services.AddScoped<IDeliveryService, HttpDeliveryService>();
 builder.Services.AddSingleton<ISigningService, HmacSigningService>();
 builder.Services.AddScoped<IEndpointHealthTracker, EndpointHealthTracker>();
 builder.Services.AddSingleton<IEndpointRateLimiter, EndpointRateLimiter>();
+builder.Services.AddSingleton<IApplicationRateLimiter, ApplicationRateLimiter>();
 builder.Services.AddSingleton<IMessageStateMachine, MessageStateMachine>();
 builder.Services.AddSingleton<IDeliveryNotifier, SignalRDeliveryNotifier>();
 builder.Services.AddSingleton<IDevTrafficGenerator, DevTrafficGenerator>();

--- a/src/WebhookEngine.API/Validators/RequestValidators.cs
+++ b/src/WebhookEngine.API/Validators/RequestValidators.cs
@@ -36,12 +36,21 @@ public class UpdateApplicationRequestValidator : AbstractValidator<UpdateApplica
             .InclusiveBetween(0, 365)
             .When(x => x.RetentionDeadLetterDays.HasValue);
 
+        // 0 = clear (no app-level cap). 1..100000 sets the per-second budget.
+        // 100k/s is well above the largest deployments we expect to host on
+        // a single Postgres queue and serves as a sanity guard against a
+        // typo'd limit translating to "unlimited" by integer overflow.
+        RuleFor(x => x.RateLimitPerSecond)
+            .InclusiveBetween(0, 100_000)
+            .When(x => x.RateLimitPerSecond.HasValue);
+
         RuleFor(x => x)
             .Must(x => x.Name is not null
                 || x.IsActive.HasValue
                 || x.IdempotencyWindowMinutes.HasValue
                 || x.RetentionDeliveredDays.HasValue
-                || x.RetentionDeadLetterDays.HasValue)
+                || x.RetentionDeadLetterDays.HasValue
+                || x.RateLimitPerSecond.HasValue)
             .WithMessage("At least one field must be provided.");
     }
 }

--- a/src/WebhookEngine.Core/Entities/Application.cs
+++ b/src/WebhookEngine.Core/Entities/Application.cs
@@ -16,6 +16,13 @@ public class Application
     public int? RetentionDeliveredDays { get; set; }
     public int? RetentionDeadLetterDays { get; set; }
 
+    /// <summary>
+    /// Optional per-application rate limit, in messages-per-second across all
+    /// endpoints. Null = no application-level cap (the per-endpoint limit, if
+    /// set, still applies). Useful for tier-gating ("free=10/s, pro=1000/s").
+    /// </summary>
+    public int? RateLimitPerSecond { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 

--- a/src/WebhookEngine.Core/Interfaces/IApplicationRateLimiter.cs
+++ b/src/WebhookEngine.Core/Interfaces/IApplicationRateLimiter.cs
@@ -1,0 +1,20 @@
+namespace WebhookEngine.Core.Interfaces;
+
+/// <summary>
+/// Application-wide deliverability cap, enforced as a 1-second window.
+/// Applies before <see cref="IEndpointRateLimiter"/> in the delivery worker
+/// so a noisy app cannot drown its sibling apps' fair share.
+/// </summary>
+public interface IApplicationRateLimiter
+{
+    /// <summary>
+    /// Acquire one slot for <paramref name="appId"/> against the per-second
+    /// limit. Returns true and burns a slot when the window has room. Returns
+    /// false with <paramref name="retryAtUtc"/> set to the next window start
+    /// when the cap is full.
+    /// </summary>
+    /// <param name="limitPerSecond">
+    /// Effective cap. <c>&lt;= 0</c> disables the limiter and always allows.
+    /// </param>
+    bool TryAcquire(Guid appId, int limitPerSecond, out DateTime retryAtUtc);
+}

--- a/src/WebhookEngine.Infrastructure/Data/WebhookDbContext.cs
+++ b/src/WebhookEngine.Infrastructure/Data/WebhookDbContext.cs
@@ -43,6 +43,8 @@ public class WebhookDbContext : DbContext
                 .HasColumnName("retention_delivered_days");
             entity.Property(e => e.RetentionDeadLetterDays)
                 .HasColumnName("retention_dead_letter_days");
+            entity.Property(e => e.RateLimitPerSecond)
+                .HasColumnName("rate_limit_per_second");
 
             entity.HasIndex(e => e.ApiKeyPrefix).IsUnique();
         });

--- a/src/WebhookEngine.Infrastructure/Migrations/20260508065900_AddPerAppRateLimit.Designer.cs
+++ b/src/WebhookEngine.Infrastructure/Migrations/20260508065900_AddPerAppRateLimit.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WebhookEngine.Infrastructure.Data;
@@ -11,9 +12,11 @@ using WebhookEngine.Infrastructure.Data;
 namespace WebhookEngine.Infrastructure.Migrations
 {
     [DbContext(typeof(WebhookDbContext))]
-    partial class WebhookDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260508065900_AddPerAppRateLimit")]
+    partial class AddPerAppRateLimit
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/WebhookEngine.Infrastructure/Migrations/20260508065900_AddPerAppRateLimit.cs
+++ b/src/WebhookEngine.Infrastructure/Migrations/20260508065900_AddPerAppRateLimit.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WebhookEngine.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPerAppRateLimit : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "rate_limit_per_second",
+                table: "applications",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "rate_limit_per_second",
+                table: "applications");
+        }
+    }
+}

--- a/src/WebhookEngine.Infrastructure/Services/ApplicationRateLimiter.cs
+++ b/src/WebhookEngine.Infrastructure/Services/ApplicationRateLimiter.cs
@@ -1,0 +1,84 @@
+using System.Collections.Concurrent;
+using WebhookEngine.Core.Interfaces;
+
+namespace WebhookEngine.Infrastructure.Services;
+
+/// <summary>
+/// Singleton 1-second window-counter for application-level rate limiting.
+/// Mirrors the structure of <see cref="EndpointRateLimiter"/> so the two
+/// limiters compose predictably in the worker. Idle entries (apps that
+/// haven't dequeued anything in 15 minutes) are pruned periodically so the
+/// dictionary cannot grow without bound.
+/// </summary>
+public class ApplicationRateLimiter : IApplicationRateLimiter
+{
+    private static readonly TimeSpan Window = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan IdleAfter = TimeSpan.FromMinutes(15);
+    private static readonly TimeSpan SweepInterval = TimeSpan.FromMinutes(5);
+
+    private readonly ConcurrentDictionary<Guid, WindowState> _windows = new();
+    private DateTime _lastSweepUtc = DateTime.UtcNow;
+
+    public bool TryAcquire(Guid appId, int limitPerSecond, out DateTime retryAtUtc)
+    {
+        var now = DateTime.UtcNow;
+
+        if (now - _lastSweepUtc > SweepInterval)
+        {
+            SweepIdleEntries(now);
+            _lastSweepUtc = now;
+        }
+
+        if (limitPerSecond <= 0)
+        {
+            retryAtUtc = now;
+            return true;
+        }
+
+        var state = _windows.GetOrAdd(appId, _ => new WindowState
+        {
+            WindowStartUtc = now,
+            Count = 0
+        });
+
+        lock (state.Lock)
+        {
+            if (now - state.WindowStartUtc >= Window)
+            {
+                state.WindowStartUtc = now;
+                state.Count = 0;
+            }
+
+            state.LastUsedUtc = now;
+
+            if (state.Count < limitPerSecond)
+            {
+                state.Count++;
+                retryAtUtc = now;
+                return true;
+            }
+
+            retryAtUtc = state.WindowStartUtc.Add(Window);
+            return false;
+        }
+    }
+
+    private void SweepIdleEntries(DateTime now)
+    {
+        foreach (var (appId, state) in _windows)
+        {
+            if (now - state.LastUsedUtc > IdleAfter)
+            {
+                _windows.TryRemove(appId, out _);
+            }
+        }
+    }
+
+    private sealed class WindowState
+    {
+        public DateTime WindowStartUtc { get; set; }
+        public DateTime LastUsedUtc { get; set; } = DateTime.UtcNow;
+        public int Count { get; set; }
+        public object Lock { get; } = new();
+    }
+}

--- a/src/WebhookEngine.Worker/DeliveryWorker.cs
+++ b/src/WebhookEngine.Worker/DeliveryWorker.cs
@@ -21,6 +21,7 @@ public class DeliveryWorker : BackgroundService
     private readonly RetryPolicyOptions _retryPolicy;
     private readonly TransformationOptions _transformationOptions;
     private readonly IEndpointRateLimiter _endpointRateLimiter;
+    private readonly IApplicationRateLimiter _applicationRateLimiter;
     private readonly IPayloadTransformer _payloadTransformer;
     private readonly WebhookMetrics? _metrics;
     private readonly string _workerId = $"worker_{Environment.MachineName}_{Guid.NewGuid().ToString("N")[..8]}";
@@ -32,6 +33,7 @@ public class DeliveryWorker : BackgroundService
         IOptions<RetryPolicyOptions> retryPolicy,
         IOptions<TransformationOptions> transformationOptions,
         IEndpointRateLimiter endpointRateLimiter,
+        IApplicationRateLimiter applicationRateLimiter,
         IPayloadTransformer payloadTransformer,
         WebhookMetrics? metrics = null)
     {
@@ -41,6 +43,7 @@ public class DeliveryWorker : BackgroundService
         _retryPolicy = retryPolicy.Value;
         _transformationOptions = transformationOptions.Value;
         _endpointRateLimiter = endpointRateLimiter;
+        _applicationRateLimiter = applicationRateLimiter;
         _payloadTransformer = payloadTransformer;
         _metrics = metrics;
     }
@@ -152,6 +155,29 @@ public class DeliveryWorker : BackgroundService
                 _logger.LogWarning("Endpoint {EndpointId} not found for message {MessageId}", message.EndpointId, message.Id);
                 await messageRepo.MarkDeadLetterAsync(message.Id, message.AttemptCount, _workerId, ct);
                 return;
+            }
+
+            // Application-level cap runs BEFORE the endpoint-level cap so a
+            // hot endpoint cannot drain the app's per-second budget for its
+            // sibling endpoints, and so we never burn an endpoint slot on a
+            // message we'll reject at the app gate anyway.
+            var appLimitPerSecond = endpoint.Application?.RateLimitPerSecond ?? 0;
+            if (appLimitPerSecond > 0)
+            {
+                if (!_applicationRateLimiter.TryAcquire(endpoint.AppId, appLimitPerSecond, out var appRetryAtUtc))
+                {
+                    var nextAttemptAt = appRetryAtUtc > DateTime.UtcNow ? appRetryAtUtc : DateTime.UtcNow.AddSeconds(1);
+                    await messageRepo.ReschedulePendingAsync(message.Id, nextAttemptAt, ct);
+
+                    _logger.LogInformation(
+                        "App rate limit reached for application {AppId} (limit: {LimitPerSecond}/s). Message {MessageId} rescheduled to {NextAttemptAt}.",
+                        endpoint.AppId,
+                        appLimitPerSecond,
+                        message.Id,
+                        nextAttemptAt);
+
+                    return;
+                }
             }
 
             var rateLimitPerMinute = RateLimitResolver.ResolveRateLimitPerMinute(endpoint.MetadataJson);

--- a/src/dashboard/src/api/dashboardApi.ts
+++ b/src/dashboard/src/api/dashboardApi.ts
@@ -172,6 +172,9 @@ export interface ApplicationUpdate {
   // 0 clears the per-app override (falls back to global RetentionOptions).
   retentionDeliveredDays?: number;
   retentionDeadLetterDays?: number;
+  // 0 clears the per-app rate limit (no application-level cap). 1..100000 sets
+  // the messages-per-second budget across all endpoints.
+  rateLimitPerSecond?: number;
 }
 
 export async function updateApplication(

--- a/src/dashboard/src/types.ts
+++ b/src/dashboard/src/types.ts
@@ -50,6 +50,8 @@ export interface ApplicationRow {
   // null/undefined = falling back to global RetentionOptions.
   retentionDeliveredDays?: number | null;
   retentionDeadLetterDays?: number | null;
+  // null/undefined = no application-level rate limit (only per-endpoint cap, if any).
+  rateLimitPerSecond?: number | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/tests/WebhookEngine.Infrastructure.Tests/EndToEnd/DeliveryFlowEndToEndTests.cs
+++ b/tests/WebhookEngine.Infrastructure.Tests/EndToEnd/DeliveryFlowEndToEndTests.cs
@@ -154,6 +154,54 @@ public class DeliveryFlowEndToEndTests : IClassFixture<PostgresFixture>
     }
 
     [Fact]
+    public async Task App_Rate_Limited_Application_Defers_Excess_Messages_To_Pending()
+    {
+        await _fixture.ResetAsync();
+
+        var deliveryService = Substitute.For<IDeliveryService>();
+        deliveryService
+            .DeliverAsync(Arg.Any<DeliveryRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new DeliveryResult { Success = true, StatusCode = 200, LatencyMs = 10 });
+
+        await using var sp = BuildServiceProvider(deliveryService);
+
+        // App's per-second cap is 1; we enqueue three messages back-to-back.
+        // The first one drains through the limiter; the next two should be
+        // rescheduled (Pending + future ScheduledAt) without ever calling the
+        // delivery service. This proves the app-level gate runs *before* the
+        // endpoint-level gate (and before signing). The worker spins for only
+        // 500 ms so we don't accidentally cross into the next 1-second window
+        // and burn a second token before the assertion.
+        var seed = await SeedAsync(sp, appRateLimitPerSecond: 1);
+        var messageIds = await EnqueueMessagesAsync(sp, seed, count: 3);
+
+        var worker = sp.GetRequiredService<DeliveryWorker>();
+        using var cts = new CancellationTokenSource();
+        await worker.StartAsync(cts.Token);
+        await Task.Delay(500);
+        await cts.CancelAsync();
+        await worker.StopAsync(CancellationToken.None);
+
+        using var scope = sp.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+        var messages = await db.Messages.AsNoTracking()
+            .Where(m => messageIds.Contains(m.Id))
+            .ToListAsync();
+
+        var delivered = messages.Where(m => m.Status == MessageStatus.Delivered).ToList();
+        var deferred = messages.Where(m => m.Status == MessageStatus.Pending).ToList();
+
+        delivered.Should().HaveCount(1);
+        deferred.Should().HaveCount(2);
+
+        deferred.Should().OnlyContain(m => m.ScheduledAt > DateTime.UtcNow);
+        deferred.Should().OnlyContain(m => m.LockedAt == null && m.LockedBy == null);
+        deferred.Should().OnlyContain(m => m.AttemptCount == 0);
+
+        await deliveryService.Received(1).DeliverAsync(Arg.Any<DeliveryRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task Repeated_Failures_Open_Endpoint_Circuit()
     {
         await _fixture.ResetAsync();
@@ -203,6 +251,7 @@ public class DeliveryFlowEndToEndTests : IClassFixture<PostgresFixture>
         services.AddSingleton<ISigningService, HmacSigningService>();
         services.AddScoped<IEndpointHealthTracker, EndpointHealthTracker>();
         services.AddSingleton<IEndpointRateLimiter, EndpointRateLimiter>();
+        services.AddSingleton<IApplicationRateLimiter, ApplicationRateLimiter>();
         services.AddSingleton<IMessageStateMachine, MessageStateMachine>();
 
         services.AddSingleton<IDeliveryService>(deliveryServiceMock);
@@ -239,7 +288,7 @@ public class DeliveryFlowEndToEndTests : IClassFixture<PostgresFixture>
         await worker.StopAsync(CancellationToken.None);
     }
 
-    private static async Task<SeedIds> SeedAsync(IServiceProvider sp, int? rateLimitPerMinute = null)
+    private static async Task<SeedIds> SeedAsync(IServiceProvider sp, int? rateLimitPerMinute = null, int? appRateLimitPerSecond = null)
     {
         using var scope = sp.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
@@ -250,7 +299,8 @@ public class DeliveryFlowEndToEndTests : IClassFixture<PostgresFixture>
             Name = "E2E App",
             ApiKeyPrefix = "whe_e2e_",
             ApiKeyHash = "hash",
-            SigningSecret = "whsec_e2e_secret_for_signing_messages_in_tests"
+            SigningSecret = "whsec_e2e_secret_for_signing_messages_in_tests",
+            RateLimitPerSecond = appRateLimitPerSecond
         };
 
         var metadataJson = rateLimitPerMinute is int rl

--- a/tests/WebhookEngine.Infrastructure.Tests/Services/ApplicationRateLimiterTests.cs
+++ b/tests/WebhookEngine.Infrastructure.Tests/Services/ApplicationRateLimiterTests.cs
@@ -1,0 +1,83 @@
+using System.Reflection;
+using FluentAssertions;
+using WebhookEngine.Infrastructure.Services;
+
+namespace WebhookEngine.Infrastructure.Tests.Services;
+
+public class ApplicationRateLimiterTests
+{
+    [Fact]
+    public void TryAcquire_Allows_Requests_Until_Limit_Then_Rejects()
+    {
+        var limiter = new ApplicationRateLimiter();
+        var appId = Guid.NewGuid();
+
+        limiter.TryAcquire(appId, 2, out _).Should().BeTrue();
+        limiter.TryAcquire(appId, 2, out _).Should().BeTrue();
+
+        var allowed = limiter.TryAcquire(appId, 2, out var retryAtUtc);
+
+        allowed.Should().BeFalse();
+        // Retry must land within the next-second window — well under 30s, very far
+        // from "never," and notably tighter than the per-endpoint per-minute clock.
+        retryAtUtc.Should().BeBefore(DateTime.UtcNow.AddSeconds(2));
+        retryAtUtc.Should().BeAfter(DateTime.UtcNow.AddMilliseconds(-100));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-1000)]
+    public void TryAcquire_With_NonPositive_Limit_Always_Allows(int limitPerSecond)
+    {
+        var limiter = new ApplicationRateLimiter();
+        var appId = Guid.NewGuid();
+
+        limiter.TryAcquire(appId, limitPerSecond, out _).Should().BeTrue();
+        limiter.TryAcquire(appId, limitPerSecond, out _).Should().BeTrue();
+        limiter.TryAcquire(appId, limitPerSecond, out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public void TryAcquire_Resets_Window_After_Window_Expires()
+    {
+        var limiter = new ApplicationRateLimiter();
+        var appId = Guid.NewGuid();
+
+        limiter.TryAcquire(appId, 1, out _).Should().BeTrue();
+        limiter.TryAcquire(appId, 1, out _).Should().BeFalse();
+
+        // Backdate the window start by 2 seconds so the next call enters
+        // the fresh-window branch.
+        ForceWindowStart(limiter, appId, DateTime.UtcNow.AddSeconds(-2));
+
+        limiter.TryAcquire(appId, 1, out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public void TryAcquire_Tracks_Different_Apps_Independently()
+    {
+        var limiter = new ApplicationRateLimiter();
+        var appA = Guid.NewGuid();
+        var appB = Guid.NewGuid();
+
+        limiter.TryAcquire(appA, 1, out _).Should().BeTrue();
+        limiter.TryAcquire(appA, 1, out _).Should().BeFalse();
+
+        // App-B's bucket is independent — A burning its slot does not
+        // prevent B from acquiring its first.
+        limiter.TryAcquire(appB, 1, out _).Should().BeTrue();
+    }
+
+    private static void ForceWindowStart(ApplicationRateLimiter limiter, Guid appId, DateTime windowStartUtc)
+    {
+        var windowsField = typeof(ApplicationRateLimiter).GetField("_windows", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var windows = windowsField.GetValue(limiter)!;
+
+        var indexer = windows.GetType().GetProperty("Item");
+        var state = indexer!.GetValue(windows, [appId])!;
+
+        var windowStartProperty = state.GetType().GetProperty("WindowStartUtc", BindingFlags.Instance | BindingFlags.Public)!;
+        windowStartProperty.SetValue(state, windowStartUtc);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `Application.RateLimitPerSecond` plus an `IApplicationRateLimiter` singleton that gates the **whole application** against a per-second cap before the existing per-endpoint limiter even gets a look. Closes the multi-endpoint runaway-producer hole and gives tier-gating a single integer column to drive. **F6 from the post-v0.1.5 plan. Third migration in the F3-F10 batch.**

## Why

Per-endpoint rate-limiting (already in `metadataJson.rateLimitPerMinute`) protects an individual destination from being hammered, but it doesn't protect the **engine** from a single application that has many endpoints. A free-tier app with 50 endpoints, each at the default per-minute cap, can still flood the queue and saturate the worker's HTTP pool. This PR adds an application-level gate so the deployment can say "this app gets 10 deliveries/s across everything" without manually fanning that limit across every endpoint.

The two limiters compose in this order inside `DeliveryWorker`:

1. **App-level limiter** (new) — `endpoint.Application?.RateLimitPerSecond`. If we'd reject here, we must reject *before* the endpoint limiter so a hot endpoint cannot drain the app's budget for its quieter siblings.
2. **Endpoint-level limiter** (existing) — `metadataJson.rateLimitPerMinute`.
3. Sign + deliver.

Both gates use the same reschedule semantics as F1: rejected messages flip back to `Pending` with a future `ScheduledAt` and dropped lock; the delivery service is never called.

## What changed

### Schema (migration: `AddPerAppRateLimit`)
- `applications.rate_limit_per_second` `integer NULL`
- NULL = no app-level cap (only per-endpoint, if set, applies). Existing rows behave identically to before.

### Limiter (`IApplicationRateLimiter` + `ApplicationRateLimiter`)
- Singleton, `ConcurrentDictionary<Guid, WindowState>`.
- 1-second fixed window with the same idle-sweep prune (15-minute idle threshold, 5-minute sweep cadence) as `EndpointRateLimiter` so the dictionary cannot grow without bound.
- `<= 0 limit` short-circuits to allow — gives the worker a clean "no cap configured" path without a separate branch.

### `DeliveryWorker`
- Constructor gained `IApplicationRateLimiter` (singleton).
- New rate-limit check runs **before** the existing endpoint check, reading `endpoint.Application?.RateLimitPerSecond`. On rejection it logs at info level and reschedules through `MessageRepository.ReschedulePendingAsync`, mirroring the endpoint path.

### API (`ApplicationsController`)
- `PUT /api/v1/applications/{id}` accepts `rateLimitPerSecond`.
- **`0` is the documented "clear the cap" sentinel** — translated to `NULL` at the DB layer.
- `1..100_000` sets the per-second budget. The 100k upper bound is well beyond any realistic single-Postgres deployment and serves as a sanity guard against a typo evaluating to "unlimited" via overflow.
- `null` (omitted) leaves the existing value unchanged.
- Both `GET` and `PUT` responses now include the field.

### Dashboard (contract only — UI follow-up)
- `types.ts::ApplicationRow` and `dashboardApi.ts::ApplicationUpdate` gained the optional `rateLimitPerSecond` field.

### Tests
- **`ApplicationRateLimiterTests`** (4 unit): allow-then-reject under cap, non-positive limit always allows, window resets after expiry, apps tracked independently.
- **`DeliveryFlowEndToEndTests::App_Rate_Limited_Application_Defers_Excess_Messages_To_Pending`** (1 e2e): cap=1/s, three messages enqueued back-to-back. Worker spins for **500 ms** (deliberately tighter than the 1.2 s used by the per-minute endpoint test so the assertion does not cross into a fresh second window) and asserts:
  - 1 delivered, 2 deferred (`Pending`, future `ScheduledAt`, lock cleared, attempt count 0).
  - `IDeliveryService` was called exactly once.

## Test plan

- [x] `dotnet build WebhookEngine.sln --configuration Release` — 0 warnings, 0 errors
- [x] `dotnet test WebhookEngine.sln --configuration Release` — 192 / 192 pass
- [x] `bun run typecheck && bun run lint` (dashboard) — clean
- [ ] CI green