### PR TITLE
feat(api+dashboard): push endpoint health changes over SignalR

### DIFF
--- a/src/WebhookEngine.API/Hubs/DeliveryHub.cs
+++ b/src/WebhookEngine.API/Hubs/DeliveryHub.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.SignalR;
+using WebhookEngine.Core.Enums;
 using WebhookEngine.Core.Interfaces;
 
 namespace WebhookEngine.API.Hubs;
@@ -67,6 +68,27 @@ public class SignalRDeliveryNotifier : IDeliveryNotifier
             endpointId,
             attemptCount,
             status = "DeadLetter",
+            timestamp = DateTime.UtcNow
+        }, ct);
+    }
+
+    public async Task NotifyEndpointHealthChangedAsync(
+        Guid endpointId,
+        EndpointStatus endpointStatus,
+        CircuitState circuitState,
+        int consecutiveFailures,
+        DateTime? cooldownUntilUtc,
+        CancellationToken ct = default)
+    {
+        await _hubContext.Clients.All.SendAsync("EndpointHealthChanged", new
+        {
+            endpointId,
+            // Match the dashboard's existing lowercase string convention
+            // (see DashboardEndpointController.ListEndpoints).
+            status = endpointStatus.ToString().ToLowerInvariant(),
+            circuitState = circuitState.ToString(),
+            consecutiveFailures,
+            cooldownUntilUtc,
             timestamp = DateTime.UtcNow
         }, ct);
     }

--- a/src/WebhookEngine.Core/Interfaces/IDeliveryNotifier.cs
+++ b/src/WebhookEngine.Core/Interfaces/IDeliveryNotifier.cs
@@ -1,3 +1,5 @@
+using WebhookEngine.Core.Enums;
+
 namespace WebhookEngine.Core.Interfaces;
 
 /// <summary>
@@ -8,4 +10,18 @@ public interface IDeliveryNotifier
     Task NotifyDeliverySuccessAsync(Guid messageId, Guid endpointId, int attemptCount, int latencyMs, CancellationToken ct = default);
     Task NotifyDeliveryFailureAsync(Guid messageId, Guid endpointId, int attemptCount, string? error, CancellationToken ct = default);
     Task NotifyDeadLetterAsync(Guid messageId, Guid endpointId, int attemptCount, CancellationToken ct = default);
+
+    /// <summary>
+    /// Fired when an endpoint's circuit-breaker state or visible status changes
+    /// (e.g. Closed→Open after consecutive failures, Open→HalfOpen on cooldown
+    /// expiry, HalfOpen→Closed on a probe success). Lets the dashboard refresh
+    /// the endpoint's health badge in real time without a poll.
+    /// </summary>
+    Task NotifyEndpointHealthChangedAsync(
+        Guid endpointId,
+        EndpointStatus endpointStatus,
+        CircuitState circuitState,
+        int consecutiveFailures,
+        DateTime? cooldownUntilUtc,
+        CancellationToken ct = default);
 }

--- a/src/WebhookEngine.Infrastructure/Services/EndpointHealthTracker.cs
+++ b/src/WebhookEngine.Infrastructure/Services/EndpointHealthTracker.cs
@@ -16,17 +16,20 @@ public class EndpointHealthTracker : IEndpointHealthTracker
     private readonly CircuitBreakerOptions _options;
     private readonly WebhookMetrics? _metrics;
     private readonly ILogger<EndpointHealthTracker>? _logger;
+    private readonly IDeliveryNotifier? _notifier;
 
     public EndpointHealthTracker(
         WebhookDbContext dbContext,
         IOptions<CircuitBreakerOptions> options,
         WebhookMetrics? metrics = null,
-        ILogger<EndpointHealthTracker>? logger = null)
+        ILogger<EndpointHealthTracker>? logger = null,
+        IDeliveryNotifier? notifier = null)
     {
         _dbContext = dbContext;
         _options = options.Value;
         _metrics = metrics;
         _logger = logger;
+        _notifier = notifier;
     }
 
     public Task RecordSuccessAsync(Guid endpointId, CancellationToken ct = default) =>
@@ -64,47 +67,114 @@ public class EndpointHealthTracker : IEndpointHealthTracker
             "Microsoft.EntityFrameworkCore.InMemory",
             StringComparison.Ordinal);
 
+        // We want to fire NotifyEndpointHealthChangedAsync exactly when the
+        // mutation actually changes either the circuit state or the visible
+        // endpoint status — not on every recorded success. Capture the pre-
+        // mutation values and a post-mutation snapshot so the comparison is
+        // local to this method, and so we only emit AFTER the commit lands
+        // (or, on InMemory, after SaveChanges).
+        HealthSnapshot? notifySnapshot = null;
+
         if (isInMemory)
         {
             // InMemory tests don't speak Postgres advisory locks; tests don't
             // exercise concurrent writers anyway.
             var memHealth = await GetOrCreateHealthAsync(endpointId, ct);
-            mutate(memHealth);
-            await UpdateEndpointStatusAsync(endpointId, memHealth, DateTime.UtcNow, ct);
+            var (memChanged, memAfter) = await ApplyAndCaptureChangeAsync(endpointId, memHealth, mutate, ct);
             await _dbContext.SaveChangesAsync(ct);
-            return;
+            if (memChanged) notifySnapshot = memAfter;
         }
-
-        await using var transaction = await _dbContext.Database.BeginTransactionAsync(ct);
-        try
+        else
         {
-            var endpointBytes = endpointId.ToByteArray();
-            var low = BitConverter.ToUInt32(endpointBytes, 0);
-            var lockKey = ((long)100_001 << 32) | low;
-            await _dbContext.Database
-                .ExecuteSqlInterpolatedAsync($"SELECT pg_advisory_xact_lock({lockKey})", ct);
-
-            // Re-read inside the lock so we mutate the freshest state.
-            var health = await _dbContext.EndpointHealths
-                .FirstOrDefaultAsync(h => h.EndpointId == endpointId, ct);
-
-            if (health is null)
+            await using var transaction = await _dbContext.Database.BeginTransactionAsync(ct);
+            try
             {
-                health = new EndpointHealth { EndpointId = endpointId };
-                _dbContext.EndpointHealths.Add(health);
-            }
+                var endpointBytes = endpointId.ToByteArray();
+                var low = BitConverter.ToUInt32(endpointBytes, 0);
+                var lockKey = ((long)100_001 << 32) | low;
+                await _dbContext.Database
+                    .ExecuteSqlInterpolatedAsync($"SELECT pg_advisory_xact_lock({lockKey})", ct);
 
-            mutate(health);
-            await UpdateEndpointStatusAsync(endpointId, health, DateTime.UtcNow, ct);
-            await _dbContext.SaveChangesAsync(ct);
-            await transaction.CommitAsync(ct);
+                // Re-read inside the lock so we mutate the freshest state.
+                var health = await _dbContext.EndpointHealths
+                    .FirstOrDefaultAsync(h => h.EndpointId == endpointId, ct);
+
+                if (health is null)
+                {
+                    health = new EndpointHealth { EndpointId = endpointId };
+                    _dbContext.EndpointHealths.Add(health);
+                }
+
+                var (changed, after) = await ApplyAndCaptureChangeAsync(endpointId, health, mutate, ct);
+                await _dbContext.SaveChangesAsync(ct);
+                await transaction.CommitAsync(ct);
+                if (changed) notifySnapshot = after;
+            }
+            catch
+            {
+                try { await transaction.RollbackAsync(ct); } catch { /* best-effort */ }
+                throw;
+            }
         }
-        catch
+
+        // Notification lives outside the lock + transaction so a slow client
+        // can't keep the advisory lock on the row, and so a hub failure
+        // can't roll back what we already committed.
+        if (notifySnapshot is { } snapshot && _notifier is not null)
         {
-            try { await transaction.RollbackAsync(ct); } catch { /* best-effort */ }
-            throw;
+            try
+            {
+                await _notifier.NotifyEndpointHealthChangedAsync(
+                    endpointId,
+                    snapshot.EndpointStatus,
+                    snapshot.CircuitState,
+                    snapshot.ConsecutiveFailures,
+                    snapshot.CooldownUntilUtc,
+                    ct);
+            }
+            catch (Exception ex)
+            {
+                // The DB has the truth — a missed live update is just a stale
+                // dashboard badge until the next user-driven refresh.
+                _logger?.LogWarning(ex, "Failed to push endpoint-health notification for {EndpointId}", endpointId);
+            }
         }
     }
+
+    private async Task<(bool Changed, HealthSnapshot After)> ApplyAndCaptureChangeAsync(
+        Guid endpointId,
+        EndpointHealth health,
+        Action<EndpointHealth> mutate,
+        CancellationToken ct)
+    {
+        var beforeCircuit = health.CircuitState;
+
+        // Fetch the tracked endpoint up front so the before/after read both
+        // see the same instance EF is mutating; AsNoTracking would miss the
+        // change UpdateEndpointStatusAsync makes below.
+        var endpoint = await _dbContext.Endpoints
+            .FirstOrDefaultAsync(e => e.Id == endpointId, ct);
+        var beforeStatus = endpoint?.Status ?? EndpointStatus.Active;
+
+        mutate(health);
+        await UpdateEndpointStatusAsync(endpointId, health, DateTime.UtcNow, ct);
+
+        var afterStatus = endpoint?.Status ?? beforeStatus;
+        var afterSnapshot = new HealthSnapshot(
+            afterStatus,
+            health.CircuitState,
+            health.ConsecutiveFailures,
+            health.CooldownUntil);
+
+        var changed = beforeCircuit != health.CircuitState || beforeStatus != afterStatus;
+        return (changed, afterSnapshot);
+    }
+
+    private sealed record HealthSnapshot(
+        EndpointStatus EndpointStatus,
+        CircuitState CircuitState,
+        int ConsecutiveFailures,
+        DateTime? CooldownUntilUtc);
 
     private void ApplySuccess(EndpointHealth health)
     {

--- a/src/WebhookEngine.Worker/CircuitBreakerWorker.cs
+++ b/src/WebhookEngine.Worker/CircuitBreakerWorker.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using WebhookEngine.Core.Enums;
+using WebhookEngine.Core.Interfaces;
 using WebhookEngine.Core.Options;
 using WebhookEngine.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
@@ -104,6 +105,29 @@ public class CircuitBreakerWorker : BackgroundService
                             await transaction.CommitAsync(stoppingToken);
 
                         _logger.LogInformation("Endpoint {EndpointId} circuit transitioned to HalfOpen", freshHealth.EndpointId);
+
+                        // Push the transition out so dashboard badges flip from
+                        // Failed/Open back to Degraded/HalfOpen without a poll.
+                        // Notification is best-effort and lives outside the
+                        // transaction so a hub failure can't undo the commit.
+                        var notifier = scope.ServiceProvider.GetService<IDeliveryNotifier>();
+                        if (notifier is not null)
+                        {
+                            try
+                            {
+                                await notifier.NotifyEndpointHealthChangedAsync(
+                                    freshHealth.EndpointId,
+                                    endpoint?.Status ?? EndpointStatus.Degraded,
+                                    freshHealth.CircuitState,
+                                    freshHealth.ConsecutiveFailures,
+                                    freshHealth.CooldownUntil,
+                                    stoppingToken);
+                            }
+                            catch (Exception notifyEx)
+                            {
+                                _logger.LogWarning(notifyEx, "Failed to push endpoint-health notification for {EndpointId}", freshHealth.EndpointId);
+                            }
+                        }
                     }
                     catch (Exception ex)
                     {

--- a/src/dashboard/src/hooks/useDeliveryFeed.ts
+++ b/src/dashboard/src/hooks/useDeliveryFeed.ts
@@ -11,6 +11,18 @@ export interface DeliveryEvent {
   timestamp: string;
 }
 
+export interface EndpointHealthChange {
+  endpointId: string;
+  // Lowercase enum string ("active" | "degraded" | "failed" | "disabled") to
+  // match the existing dashboard convention.
+  status: string;
+  // PascalCase enum string ("Closed" | "Open" | "HalfOpen").
+  circuitState: string;
+  consecutiveFailures: number;
+  cooldownUntilUtc: string | null;
+  timestamp: string;
+}
+
 /** Infinite retry with capped exponential backoff (max 30s). */
 const infiniteRetryPolicy: IRetryPolicy = {
   nextRetryDelayInMilliseconds(retryContext: RetryContext) {
@@ -26,6 +38,10 @@ export function useDeliveryFeed(maxEvents = 50) {
   const connectionRef = useRef<HubConnection | null>(null);
   const [events, setEvents] = useState<DeliveryEvent[]>([]);
   const [connected, setConnected] = useState(false);
+  // Single-slot state — pages watch its identity in useEffect to patch
+  // their local endpoint state. Storing only the latest change is enough
+  // because each change is idempotent against the prior badge value.
+  const [lastHealthChange, setLastHealthChange] = useState<EndpointHealthChange | null>(null);
 
   const push = useCallback(
     (event: DeliveryEvent) => {
@@ -57,6 +73,11 @@ export function useDeliveryFeed(maxEvents = 50) {
       push({ ...data, status: "DeadLetter" });
     };
 
+    const handleHealthChange = (data: EndpointHealthChange) => {
+      if (!isMounted) return;
+      setLastHealthChange(data);
+    };
+
     const handleClose = () => {
       if (!isMounted) return;
       setConnected(false);
@@ -82,6 +103,7 @@ export function useDeliveryFeed(maxEvents = 50) {
     connection.on("DeliverySuccess", handleSuccess);
     connection.on("DeliveryFailure", handleFailure);
     connection.on("DeadLetter", handleDeadLetter);
+    connection.on("EndpointHealthChanged", handleHealthChange);
     connection.onclose(handleClose);
     connection.onreconnected(handleReconnected);
 
@@ -119,6 +141,7 @@ export function useDeliveryFeed(maxEvents = 50) {
       connection.off("DeliverySuccess", handleSuccess);
       connection.off("DeliveryFailure", handleFailure);
       connection.off("DeadLetter", handleDeadLetter);
+      connection.off("EndpointHealthChanged", handleHealthChange);
 
       if (connection.state !== HubConnectionState.Disconnected) {
         void connection.stop();
@@ -126,5 +149,5 @@ export function useDeliveryFeed(maxEvents = 50) {
     };
   }, [push]);
 
-  return { events, connected };
+  return { events, connected, lastHealthChange };
 }

--- a/src/dashboard/src/pages/EndpointsPage.tsx
+++ b/src/dashboard/src/pages/EndpointsPage.tsx
@@ -6,6 +6,7 @@ import { Select } from "../components/Select";
 import { EventTypeSelect } from "../components/EventTypeSelect";
 import { TransformSection } from "../components/TransformSection";
 import { EndpointTestModal } from "../components/EndpointTestModal";
+import { useDeliveryFeed } from "../hooks/useDeliveryFeed";
 import {
   createDashboardEndpoint,
   deleteDashboardEndpoint,
@@ -136,6 +137,25 @@ export function EndpointsPage() {
     };
     fetchApplications();
   }, []);
+
+  // Live-patch the row when the engine pushes a circuit transition. The hub
+  // event already carries the new visible status; we map it onto whichever
+  // row in the current page matches the endpointId. Rows on other pages
+  // pick up the change on the next manual refresh. The microtask defer
+  // matches the codebase's existing pattern for set-state-in-effect.
+  const { lastHealthChange } = useDeliveryFeed();
+  useEffect(() => {
+    if (!lastHealthChange) return;
+    void Promise.resolve().then(() => {
+      setEndpoints((prev) => {
+        const idx = prev.findIndex((e) => e.id === lastHealthChange.endpointId);
+        if (idx < 0) return prev;
+        const next = prev.slice();
+        next[idx] = { ...next[idx], status: lastHealthChange.status };
+        return next;
+      });
+    });
+  }, [lastHealthChange]);
 
   useEffect(() => {
     if (!showCreate || !createAppId) return;


### PR DESCRIPTION
## Summary

`IDeliveryNotifier.NotifyEndpointHealthChangedAsync` + a new `EndpointHealthChanged` hub event so dashboard health badges update the moment a circuit transitions, instead of waiting for the user to refresh. **F7 from the post-v0.1.5 plan. No migration.**

## Why

Today the Endpoints page renders the endpoint's `status` (active / degraded / failed / disabled) from a list call and never re-reads it. So if the circuit-breaker flips from Closed→Open after a delivery storm — or the breaker worker brings it back to HalfOpen on cooldown expiry — the badge stays wrong until someone hits refresh. That undermines the entire point of having a real-time delivery feed already on the same page.

## What changed

### Notifier surface
- `IDeliveryNotifier` gains `NotifyEndpointHealthChangedAsync(endpointId, endpointStatus, circuitState, consecutiveFailures, cooldownUntilUtc, ct)`.
- `SignalRDeliveryNotifier` maps it to a new `"EndpointHealthChanged"` hub event. Status goes out lowercased to match the existing dashboard convention; circuit state stays PascalCase (matches the `CircuitState` enum on the wire).

### Emitting sites
1. **`EndpointHealthTracker.WithEndpointLockAsync`** — captures the pre-mutation `(circuitState, endpointStatus)` pair, applies the mutation, captures the post-mutation pair from the same tracked endpoint reference, and only emits if either changed. Notification runs **after** the transaction commits and the advisory lock is released, so a slow hub client can't keep the row locked and a notifier exception can't roll back a real DB change.
2. **`CircuitBreakerWorker`** — fires the same notification after its Open→HalfOpen transition lands, resolved through `scope.ServiceProvider.GetService<IDeliveryNotifier>()` so the worker stays test-friendly.

Both call sites swallow notifier exceptions with a warning log: the DB has the truth, a missed event is just a stale badge until the next manual refresh.

### Dashboard
- `useDeliveryFeed` surfaces a single-slot `lastHealthChange` state on the same `/hubs/deliveries` connection. New typed `EndpointHealthChange` interface mirrors the wire shape.
- `EndpointsPage` subscribes via `useEffect`, finds the matching row by `endpointId`, and patches its `status` field. Rows on other pages pick up the change on their next manual refresh — single-page stateful patch is enough for the user-facing problem.

## Test plan

- [x] `dotnet build WebhookEngine.sln --configuration Release` — 0 warnings, 0 errors
- [x] `dotnet test WebhookEngine.sln --configuration Release` — 192 / 192 pass (existing `EndpointHealthTrackerTests` + circuit-breaker tests still green; the test fixtures don't register an `IDeliveryNotifier` so the optional path is exercised too)
- [x] `bun run typecheck && bun run lint && bun run build` (dashboard) — clean
- [ ] CI green