### PR TITLE
feat(api+infra): per-endpoint IP allowlist (CIDR positive-list gate)

### DIFF
--- a/src/WebhookEngine.API/Contracts/ApiResponseDtos.cs
+++ b/src/WebhookEngine.API/Contracts/ApiResponseDtos.cs
@@ -27,6 +27,8 @@ public sealed class EndpointResponseDto
     public JsonElement CustomHeadersJson { get; init; }
     public string? SecretOverride { get; init; }
     public JsonElement MetadataJson { get; init; }
+    // Empty list = no allowlist; delivery falls back to the deployment SSRF guard only.
+    public List<string> AllowedIps { get; init; } = [];
     public string? TransformExpression { get; init; }
     public bool TransformEnabled { get; init; }
     public DateTime? TransformValidatedAt { get; init; }
@@ -95,6 +97,7 @@ public static class ApiResponseMapper
             CustomHeadersJson = JsonValueParser.ParseOrEmptyObject(endpoint.CustomHeadersJson),
             SecretOverride = endpoint.SecretOverride,
             MetadataJson = JsonValueParser.ParseOrEmptyObject(endpoint.MetadataJson),
+            AllowedIps = ParseAllowedIps(endpoint.AllowedIpsJson),
             TransformExpression = endpoint.TransformExpression,
             TransformEnabled = endpoint.TransformEnabled,
             TransformValidatedAt = endpoint.TransformValidatedAt,
@@ -102,6 +105,19 @@ public static class ApiResponseMapper
             CreatedAt = endpoint.CreatedAt,
             UpdatedAt = endpoint.UpdatedAt
         };
+    }
+
+    private static List<string> ParseAllowedIps(string? allowedIpsJson)
+    {
+        if (string.IsNullOrWhiteSpace(allowedIpsJson)) return [];
+        try
+        {
+            return System.Text.Json.JsonSerializer.Deserialize<List<string>>(allowedIpsJson) ?? [];
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            return [];
+        }
     }
 
     public static EndpointResponseDto ToDto(this EndpointListItem endpoint)

--- a/src/WebhookEngine.API/Controllers/DashboardEndpointController.cs
+++ b/src/WebhookEngine.API/Controllers/DashboardEndpointController.cs
@@ -104,6 +104,9 @@ public class DashboardEndpointController : ControllerBase
             SecretOverride = string.IsNullOrWhiteSpace(request.SecretOverride) ? null : request.SecretOverride,
             CustomHeadersJson = System.Text.Json.JsonSerializer.Serialize(request.CustomHeaders ?? new Dictionary<string, string>()),
             MetadataJson = System.Text.Json.JsonSerializer.Serialize(request.Metadata ?? new Dictionary<string, string>()),
+            AllowedIpsJson = request.AllowedIps is { Count: > 0 }
+                ? System.Text.Json.JsonSerializer.Serialize(request.AllowedIps)
+                : null,
             TransformExpression = string.IsNullOrWhiteSpace(request.TransformExpression) ? null : request.TransformExpression,
             TransformEnabled = request.TransformEnabled ?? false
         };
@@ -175,6 +178,13 @@ public class DashboardEndpointController : ControllerBase
 
         if (request.Metadata is not null)
             endpoint.MetadataJson = System.Text.Json.JsonSerializer.Serialize(request.Metadata);
+
+        if (request.AllowedIps is not null)
+        {
+            endpoint.AllowedIpsJson = request.AllowedIps.Count == 0
+                ? null
+                : System.Text.Json.JsonSerializer.Serialize(request.AllowedIps);
+        }
 
         if (request.TransformExpression is not null)
         {
@@ -490,6 +500,7 @@ public class DashboardCreateEndpointRequest
     public Dictionary<string, string>? CustomHeaders { get; set; }
     public Dictionary<string, string>? Metadata { get; set; }
     public string? SecretOverride { get; set; }
+    public List<string>? AllowedIps { get; set; }
     public string? TransformExpression { get; set; }
     public bool? TransformEnabled { get; set; }
 }
@@ -502,6 +513,8 @@ public class DashboardUpdateEndpointRequest
     public Dictionary<string, string>? CustomHeaders { get; set; }
     public Dictionary<string, string>? Metadata { get; set; }
     public string? SecretOverride { get; set; }
+    // Pass an empty list to clear the allowlist.
+    public List<string>? AllowedIps { get; set; }
     public string? TransformExpression { get; set; }
     public bool? TransformEnabled { get; set; }
 }

--- a/src/WebhookEngine.API/Controllers/EndpointsController.cs
+++ b/src/WebhookEngine.API/Controllers/EndpointsController.cs
@@ -51,6 +51,9 @@ public class EndpointsController : ControllerBase
             Description = request.Description,
             CustomHeadersJson = System.Text.Json.JsonSerializer.Serialize(request.CustomHeaders ?? new Dictionary<string, string>()),
             MetadataJson = System.Text.Json.JsonSerializer.Serialize(request.Metadata ?? new Dictionary<string, string>()),
+            AllowedIpsJson = request.AllowedIps is { Count: > 0 }
+                ? System.Text.Json.JsonSerializer.Serialize(request.AllowedIps)
+                : null,
             TransformExpression = string.IsNullOrWhiteSpace(request.TransformExpression) ? null : request.TransformExpression,
             TransformEnabled = request.TransformEnabled ?? false
         };
@@ -129,6 +132,15 @@ public class EndpointsController : ControllerBase
 
         if (request.SecretOverride is not null)
             endpoint.SecretOverride = string.IsNullOrWhiteSpace(request.SecretOverride) ? null : request.SecretOverride;
+
+        if (request.AllowedIps is not null)
+        {
+            // Empty list = clear the allowlist (delivery falls back to the
+            // deployment-wide SSRF guard only). Non-empty list overwrites.
+            endpoint.AllowedIpsJson = request.AllowedIps.Count == 0
+                ? null
+                : System.Text.Json.JsonSerializer.Serialize(request.AllowedIps);
+        }
 
         if (request.TransformExpression is not null)
         {
@@ -294,6 +306,9 @@ public class CreateEndpointRequest
     public List<Guid>? FilterEventTypes { get; set; }
     public Dictionary<string, string>? CustomHeaders { get; set; }
     public Dictionary<string, string>? Metadata { get; set; }
+    // Optional CIDR list. Empty/null = no allowlist (delivery falls back to
+    // the deployment-wide SSRF guard only).
+    public List<string>? AllowedIps { get; set; }
     public string? TransformExpression { get; set; }
     public bool? TransformEnabled { get; set; }
 }
@@ -306,6 +321,8 @@ public class UpdateEndpointRequest
     public Dictionary<string, string>? CustomHeaders { get; set; }
     public Dictionary<string, string>? Metadata { get; set; }
     public string? SecretOverride { get; set; }
+    // Pass an empty list to clear the allowlist.
+    public List<string>? AllowedIps { get; set; }
     public string? TransformExpression { get; set; }
     public bool? TransformEnabled { get; set; }
 }

--- a/src/WebhookEngine.API/Validators/RequestValidators.cs
+++ b/src/WebhookEngine.API/Validators/RequestValidators.cs
@@ -1,6 +1,7 @@
 using FluentValidation;
 using WebhookEngine.API.Controllers;
 using WebhookEngine.API.Services;
+using WebhookEngine.Infrastructure.Services;
 
 namespace WebhookEngine.API.Validators;
 
@@ -133,6 +134,11 @@ public class CreateEndpointRequestValidator : AbstractValidator<CreateEndpointRe
             .Must(headers => CustomHeaderPolicy.Validate(headers) is null)
             .WithMessage(x => CustomHeaderPolicy.Validate(x.CustomHeaders) ?? "Invalid custom headers.")
             .When(x => x.CustomHeaders is not null);
+
+        RuleFor(x => x.AllowedIps)
+            .Must(list => list!.All(cidr => IpAllowlistMatcher.TryParseCidr(cidr, out _)))
+            .WithMessage("AllowedIps must contain valid CIDR notations (e.g. \"203.0.113.0/24\").")
+            .When(x => x.AllowedIps is { Count: > 0 });
     }
 }
 
@@ -166,6 +172,11 @@ public class UpdateEndpointRequestValidator : AbstractValidator<UpdateEndpointRe
             .Must(headers => CustomHeaderPolicy.Validate(headers) is null)
             .WithMessage(x => CustomHeaderPolicy.Validate(x.CustomHeaders) ?? "Invalid custom headers.")
             .When(x => x.CustomHeaders is not null);
+
+        RuleFor(x => x.AllowedIps)
+            .Must(list => list!.All(cidr => IpAllowlistMatcher.TryParseCidr(cidr, out _)))
+            .WithMessage("AllowedIps must contain valid CIDR notations (e.g. \"203.0.113.0/24\").")
+            .When(x => x.AllowedIps is { Count: > 0 });
 
         RuleFor(x => x)
             .Must(x => x.Url is not null
@@ -213,6 +224,11 @@ public class DashboardCreateEndpointRequestValidator : AbstractValidator<Dashboa
             .Must(headers => CustomHeaderPolicy.Validate(headers) is null)
             .WithMessage(x => CustomHeaderPolicy.Validate(x.CustomHeaders) ?? "Invalid custom headers.")
             .When(x => x.CustomHeaders is not null);
+
+        RuleFor(x => x.AllowedIps)
+            .Must(list => list!.All(cidr => IpAllowlistMatcher.TryParseCidr(cidr, out _)))
+            .WithMessage("AllowedIps must contain valid CIDR notations (e.g. \"203.0.113.0/24\").")
+            .When(x => x.AllowedIps is { Count: > 0 });
     }
 }
 
@@ -246,6 +262,11 @@ public class DashboardUpdateEndpointRequestValidator : AbstractValidator<Dashboa
             .Must(headers => CustomHeaderPolicy.Validate(headers) is null)
             .WithMessage(x => CustomHeaderPolicy.Validate(x.CustomHeaders) ?? "Invalid custom headers.")
             .When(x => x.CustomHeaders is not null);
+
+        RuleFor(x => x.AllowedIps)
+            .Must(list => list!.All(cidr => IpAllowlistMatcher.TryParseCidr(cidr, out _)))
+            .WithMessage("AllowedIps must contain valid CIDR notations (e.g. \"203.0.113.0/24\").")
+            .When(x => x.AllowedIps is { Count: > 0 });
 
         RuleFor(x => x)
             .Must(x => x.Url is not null

--- a/src/WebhookEngine.Core/Entities/Endpoint.cs
+++ b/src/WebhookEngine.Core/Entities/Endpoint.cs
@@ -13,6 +13,15 @@ public class Endpoint
     public string? SecretOverride { get; set; }
     public string MetadataJson { get; set; } = "{}";
 
+    /// <summary>
+    /// Optional JSON array of CIDR strings. When non-empty, delivery is
+    /// allowed only when every resolved IP for the hostname lands inside
+    /// one of the listed ranges. Layered on top of the deployment-wide
+    /// SSRF guard for explicit per-endpoint hardening (e.g. enterprise
+    /// customers pinning their static egress range).
+    /// </summary>
+    public string? AllowedIpsJson { get; set; }
+
     // Payload transformation (ADR-003) — declarative JMESPath reshape applied
     // before delivery. Stored only in Phase 1; pipeline integration arrives in
     // Phase 2 (HttpDeliveryService) and the dashboard editor in Phase 3.

--- a/src/WebhookEngine.Infrastructure/Data/WebhookDbContext.cs
+++ b/src/WebhookEngine.Infrastructure/Data/WebhookDbContext.cs
@@ -83,6 +83,7 @@ public class WebhookDbContext : DbContext
             entity.Property(e => e.CustomHeadersJson).HasColumnName("custom_headers").HasColumnType("jsonb").HasDefaultValueSql("'{}'");
             entity.Property(e => e.SecretOverride).HasColumnName("secret_override").HasMaxLength(64);
             entity.Property(e => e.MetadataJson).HasColumnName("metadata").HasColumnType("jsonb").HasDefaultValueSql("'{}'");
+            entity.Property(e => e.AllowedIpsJson).HasColumnName("allowed_ips").HasColumnType("jsonb");
             entity.Property(e => e.TransformExpression).HasColumnName("transform_expression").HasMaxLength(4096);
             entity.Property(e => e.TransformEnabled).HasColumnName("transform_enabled").HasDefaultValue(false);
             entity.Property(e => e.TransformValidatedAt).HasColumnName("transform_validated_at");

--- a/src/WebhookEngine.Infrastructure/Migrations/20260508072336_AddEndpointAllowedIps.Designer.cs
+++ b/src/WebhookEngine.Infrastructure/Migrations/20260508072336_AddEndpointAllowedIps.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WebhookEngine.Infrastructure.Data;
@@ -11,9 +12,11 @@ using WebhookEngine.Infrastructure.Data;
 namespace WebhookEngine.Infrastructure.Migrations
 {
     [DbContext(typeof(WebhookDbContext))]
-    partial class WebhookDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260508072336_AddEndpointAllowedIps")]
+    partial class AddEndpointAllowedIps
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/WebhookEngine.Infrastructure/Migrations/20260508072336_AddEndpointAllowedIps.cs
+++ b/src/WebhookEngine.Infrastructure/Migrations/20260508072336_AddEndpointAllowedIps.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WebhookEngine.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEndpointAllowedIps : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "allowed_ips",
+                table: "endpoints",
+                type: "jsonb",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "allowed_ips",
+                table: "endpoints");
+        }
+    }
+}

--- a/src/WebhookEngine.Infrastructure/Services/IpAllowlistMatcher.cs
+++ b/src/WebhookEngine.Infrastructure/Services/IpAllowlistMatcher.cs
@@ -1,0 +1,105 @@
+using System.Net;
+using System.Text.Json;
+
+namespace WebhookEngine.Infrastructure.Services;
+
+/// <summary>
+/// Static helpers for parsing the per-endpoint <c>AllowedIpsJson</c> column
+/// and checking whether a resolved IP belongs to one of the listed CIDR
+/// ranges. Pure functions; the matcher is intentionally not a registered
+/// service so callers don't have to inject anything just to evaluate a
+/// list literal.
+/// </summary>
+public static class IpAllowlistMatcher
+{
+    /// <summary>
+    /// Parses the JSON array stored in <c>Endpoint.AllowedIpsJson</c>. Empty,
+    /// null, or non-array JSON returns an empty list — the caller treats that
+    /// as "no allowlist configured."
+    /// </summary>
+    public static IReadOnlyList<IPNetwork> Parse(string? allowedIpsJson)
+    {
+        if (string.IsNullOrWhiteSpace(allowedIpsJson))
+        {
+            return [];
+        }
+
+        try
+        {
+            var raw = JsonSerializer.Deserialize<string[]>(allowedIpsJson);
+            if (raw is null || raw.Length == 0)
+            {
+                return [];
+            }
+
+            var networks = new List<IPNetwork>(raw.Length);
+            foreach (var cidr in raw)
+            {
+                if (TryParseCidr(cidr, out var network))
+                {
+                    networks.Add(network);
+                }
+            }
+
+            return networks;
+        }
+        catch (JsonException)
+        {
+            // Stored JSON drifted from the validated shape (e.g. someone
+            // edited the row by hand). Treat as no allowlist rather than
+            // failing every delivery.
+            return [];
+        }
+    }
+
+    /// <summary>
+    /// Returns true when <paramref name="cidr"/> can be parsed by
+    /// <see cref="IPNetwork.TryParse(string, out IPNetwork)"/>. Used by the
+    /// request validators to reject malformed entries up front.
+    /// </summary>
+    public static bool TryParseCidr(string? cidr, out IPNetwork network)
+    {
+        if (string.IsNullOrWhiteSpace(cidr))
+        {
+            network = default;
+            return false;
+        }
+
+        return IPNetwork.TryParse(cidr.Trim(), out network);
+    }
+
+    /// <summary>
+    /// True when every address in <paramref name="resolvedAddresses"/> is
+    /// contained by at least one entry in <paramref name="allowed"/>. An
+    /// empty allowlist returns true (the gate is opt-in). An empty resolution
+    /// returns false (we will not deliver to nothing).
+    /// </summary>
+    public static bool AllAddressesAllowed(IReadOnlyList<IPNetwork> allowed, IReadOnlyList<IPAddress> resolvedAddresses)
+    {
+        if (allowed.Count == 0)
+        {
+            return true;
+        }
+
+        if (resolvedAddresses.Count == 0)
+        {
+            return false;
+        }
+
+        foreach (var address in resolvedAddresses)
+        {
+            var matched = false;
+            foreach (var network in allowed)
+            {
+                if (network.Contains(address))
+                {
+                    matched = true;
+                    break;
+                }
+            }
+            if (!matched) return false;
+        }
+
+        return true;
+    }
+}

--- a/src/WebhookEngine.Worker/DeliveryWorker.cs
+++ b/src/WebhookEngine.Worker/DeliveryWorker.cs
@@ -2,6 +2,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using System.Net;
+using System.Net.Sockets;
 using System.Text.Json;
 using WebhookEngine.Core.Enums;
 using WebhookEngine.Core.Interfaces;
@@ -10,6 +12,7 @@ using WebhookEngine.Core.Models;
 using WebhookEngine.Core.Options;
 using WebhookEngine.Core.Utilities;
 using WebhookEngine.Infrastructure.Repositories;
+using WebhookEngine.Infrastructure.Services;
 
 namespace WebhookEngine.Worker;
 
@@ -196,6 +199,43 @@ public class DeliveryWorker : BackgroundService
                         message.Id,
                         nextAttemptAt);
 
+                    return;
+                }
+            }
+
+            // Per-endpoint IP allowlist: the SSRF guard already blocked private
+            // ranges deployment-wide; this gate adds a positive-list check for
+            // customers who pin static egress (enterprise / fintech). An empty
+            // list means "unrestricted" and the matcher returns true.
+            var allowedNetworks = IpAllowlistMatcher.Parse(endpoint.AllowedIpsJson);
+            if (allowedNetworks.Count > 0)
+            {
+                if (!Uri.TryCreate(endpoint.Url, UriKind.Absolute, out var endpointUri))
+                {
+                    _logger.LogError("Endpoint URL is not parseable for {EndpointId}, message {MessageId}", message.EndpointId, message.Id);
+                    await messageRepo.MarkDeadLetterAsync(message.Id, message.AttemptCount, _workerId, ct);
+                    return;
+                }
+
+                IPAddress[] resolved;
+                try
+                {
+                    resolved = await Dns.GetHostAddressesAsync(endpointUri.Host, ct);
+                }
+                catch (Exception ex) when (ex is SocketException or ArgumentException)
+                {
+                    _logger.LogWarning(ex, "Allowlist DNS lookup failed for endpoint {EndpointId}, message {MessageId}; treating as denied.", message.EndpointId, message.Id);
+                    await messageRepo.MarkDeadLetterAsync(message.Id, message.AttemptCount, _workerId, ct);
+                    return;
+                }
+
+                if (!IpAllowlistMatcher.AllAddressesAllowed(allowedNetworks, resolved))
+                {
+                    _logger.LogWarning(
+                        "Endpoint {EndpointId} resolved to an IP outside its allowlist; message {MessageId} dead-lettered.",
+                        endpoint.Id,
+                        message.Id);
+                    await messageRepo.MarkDeadLetterAsync(message.Id, message.AttemptCount, _workerId, ct);
                     return;
                 }
             }

--- a/src/dashboard/src/api/dashboardApi.ts
+++ b/src/dashboard/src/api/dashboardApi.ts
@@ -226,6 +226,8 @@ export interface DashboardCreateEndpointRequest {
   customHeaders?: Record<string, string>;
   metadata?: Record<string, string>;
   secretOverride?: string;
+  // CIDR list. Empty/undefined = no allowlist.
+  allowedIps?: string[];
   transformExpression?: string | null;
   transformEnabled?: boolean;
 }
@@ -237,6 +239,8 @@ export interface DashboardUpdateEndpointRequest {
   customHeaders?: Record<string, string>;
   metadata?: Record<string, string>;
   secretOverride?: string;
+  // Pass an empty list to clear the allowlist.
+  allowedIps?: string[];
   transformExpression?: string | null;
   transformEnabled?: boolean;
 }

--- a/src/dashboard/src/types.ts
+++ b/src/dashboard/src/types.ts
@@ -77,6 +77,8 @@ export interface EndpointRow {
   circuitState: CircuitState;
   eventTypes: string[];
   eventTypeIds?: string[];
+  // Empty array = no allowlist; delivery falls back to the deployment SSRF guard only.
+  allowedIps?: string[];
   transformExpression?: string | null;
   transformEnabled?: boolean;
   transformValidatedAt?: string | null;

--- a/tests/WebhookEngine.Infrastructure.Tests/EndToEnd/DeliveryFlowEndToEndTests.cs
+++ b/tests/WebhookEngine.Infrastructure.Tests/EndToEnd/DeliveryFlowEndToEndTests.cs
@@ -202,6 +202,36 @@ public class DeliveryFlowEndToEndTests : IClassFixture<PostgresFixture>
     }
 
     [Fact]
+    public async Task Allowlist_Mismatch_Sends_Message_To_DeadLetter_Without_Calling_Delivery()
+    {
+        await _fixture.ResetAsync();
+
+        var deliveryService = Substitute.For<IDeliveryService>();
+        deliveryService
+            .DeliverAsync(Arg.Any<DeliveryRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new DeliveryResult { Success = true, StatusCode = 200, LatencyMs = 10 });
+
+        await using var sp = BuildServiceProvider(deliveryService);
+
+        // The endpoint hostname (example.invalid) cannot resolve at all under
+        // RFC 6761, so AllAddressesAllowed returns false on an empty resolved
+        // set with a non-empty allowlist. Either way (resolution failure or
+        // resolved IP outside the list), the worker takes the DeadLetter path
+        // before signing, so DeliverAsync is never called.
+        var seed = await SeedAsync(sp, allowedIps: ["203.0.113.0/24"]);
+        var messageIds = await EnqueueMessagesAsync(sp, seed, count: 1);
+
+        await RunWorkerOnceAsync(sp);
+
+        using var scope = sp.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+        var message = await db.Messages.AsNoTracking().SingleAsync(m => m.Id == messageIds[0]);
+
+        message.Status.Should().Be(MessageStatus.DeadLetter);
+        await deliveryService.DidNotReceiveWithAnyArgs().DeliverAsync(default!, default);
+    }
+
+    [Fact]
     public async Task Repeated_Failures_Open_Endpoint_Circuit()
     {
         await _fixture.ResetAsync();
@@ -288,7 +318,11 @@ public class DeliveryFlowEndToEndTests : IClassFixture<PostgresFixture>
         await worker.StopAsync(CancellationToken.None);
     }
 
-    private static async Task<SeedIds> SeedAsync(IServiceProvider sp, int? rateLimitPerMinute = null, int? appRateLimitPerSecond = null)
+    private static async Task<SeedIds> SeedAsync(
+        IServiceProvider sp,
+        int? rateLimitPerMinute = null,
+        int? appRateLimitPerSecond = null,
+        IReadOnlyList<string>? allowedIps = null)
     {
         using var scope = sp.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
@@ -313,7 +347,10 @@ public class DeliveryFlowEndToEndTests : IClassFixture<PostgresFixture>
             AppId = app.Id,
             Url = "https://example.invalid/webhook",
             Status = EndpointStatus.Active,
-            MetadataJson = metadataJson
+            MetadataJson = metadataJson,
+            AllowedIpsJson = allowedIps is { Count: > 0 }
+                ? System.Text.Json.JsonSerializer.Serialize(allowedIps)
+                : null
         };
 
         var eventType = new EventType

--- a/tests/WebhookEngine.Infrastructure.Tests/Services/IpAllowlistMatcherTests.cs
+++ b/tests/WebhookEngine.Infrastructure.Tests/Services/IpAllowlistMatcherTests.cs
@@ -1,0 +1,75 @@
+using System.Net;
+using FluentAssertions;
+using WebhookEngine.Infrastructure.Services;
+
+namespace WebhookEngine.Infrastructure.Tests.Services;
+
+public class IpAllowlistMatcherTests
+{
+    [Fact]
+    public void Parse_Returns_Empty_For_Null_Or_Whitespace()
+    {
+        IpAllowlistMatcher.Parse(null).Should().BeEmpty();
+        IpAllowlistMatcher.Parse("").Should().BeEmpty();
+        IpAllowlistMatcher.Parse("   ").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_Returns_Empty_For_Malformed_Json()
+    {
+        IpAllowlistMatcher.Parse("not-json").Should().BeEmpty();
+        IpAllowlistMatcher.Parse("{}").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_Skips_Invalid_Cidr_Entries_But_Keeps_Valid_Ones()
+    {
+        var parsed = IpAllowlistMatcher.Parse("""["203.0.113.0/24","not-a-cidr","192.168.1.0/24"]""");
+        parsed.Should().HaveCount(2);
+    }
+
+    [Theory]
+    [InlineData("203.0.113.0/24", true)]
+    [InlineData("203.0.113.42/32", true)]
+    [InlineData("2001:db8::/32", true)]
+    [InlineData("not-a-cidr", false)]
+    [InlineData("203.0.113.0/40", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void TryParseCidr_Recognises_Valid_Notations(string? cidr, bool expected)
+    {
+        IpAllowlistMatcher.TryParseCidr(cidr, out _).Should().Be(expected);
+    }
+
+    [Fact]
+    public void AllAddressesAllowed_Returns_True_When_Every_Address_Matches()
+    {
+        var allowed = IpAllowlistMatcher.Parse("""["203.0.113.0/24","198.51.100.0/24"]""");
+        var resolved = new[] { IPAddress.Parse("203.0.113.42"), IPAddress.Parse("198.51.100.7") };
+
+        IpAllowlistMatcher.AllAddressesAllowed(allowed, resolved).Should().BeTrue();
+    }
+
+    [Fact]
+    public void AllAddressesAllowed_Returns_False_When_One_Address_Sits_Outside_The_List()
+    {
+        var allowed = IpAllowlistMatcher.Parse("""["203.0.113.0/24"]""");
+        var resolved = new[] { IPAddress.Parse("203.0.113.42"), IPAddress.Parse("8.8.8.8") };
+
+        IpAllowlistMatcher.AllAddressesAllowed(allowed, resolved).Should().BeFalse();
+    }
+
+    [Fact]
+    public void AllAddressesAllowed_Returns_True_When_Allowlist_Is_Empty()
+    {
+        var resolved = new[] { IPAddress.Parse("8.8.8.8") };
+        IpAllowlistMatcher.AllAddressesAllowed([], resolved).Should().BeTrue();
+    }
+
+    [Fact]
+    public void AllAddressesAllowed_Returns_False_When_Resolution_Is_Empty_With_NonEmpty_List()
+    {
+        var allowed = IpAllowlistMatcher.Parse("""["203.0.113.0/24"]""");
+        IpAllowlistMatcher.AllAddressesAllowed(allowed, []).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Adds an optional CIDR allowlist to `Endpoint`. When configured, `DeliveryWorker` resolves the hostname before signing and refuses to deliver to any IP outside the list — sending the message straight to `DeadLetter`. Layered on top of the existing SSRF guard for explicit per-endpoint hardening. **F8 from the post-v0.1.5 plan. Fourth migration in the F3-F10 batch.**

## Why

The deployment-wide SSRF guard is a **negative** policy: "don't deliver to RFC1918 / loopback / metadata." Enterprise and fintech customers consistently ask for the **positive** flavour: "deliver only to *my* known egress range and nothing else." That requirement isn't covered by the existing guard, and approximating it via `metadataJson` would mean every consumer parses CIDRs by hand.

This PR makes it a first-class endpoint field. Empty / NULL = "no allowlist; the deployment-wide guard still applies." Non-empty = "every resolved IP must land inside one of these ranges."

## What changed

### Schema (migration: `AddEndpointAllowedIps`)
- `endpoints.allowed_ips` `jsonb NULL` — JSON string array of CIDR notations.
- Existing rows behave identically (NULL = no allowlist).

### Matcher (`IpAllowlistMatcher`)
- Static helper. Pure functions; not registered in DI because every consumer passes the column value in directly.
- `Parse(json)` — drops malformed JSON, drops invalid CIDR entries, returns the survivors.
- `TryParseCidr(cidr, out network)` — validator-friendly wrapper around `IPNetwork.TryParse`.
- `AllAddressesAllowed(allowed, resolved)` — empty allowlist returns true (the gate is opt-in); empty resolution with a non-empty list returns false (we will not deliver to nothing).

### `DeliveryWorker`
- After endpoint fetch + the rate-limit gates, before signing:
  1. Parse allowlist from `endpoint.AllowedIpsJson`.
  2. If non-empty → `Dns.GetHostAddressesAsync` the host.
  3. If lookup throws (`SocketException` / `ArgumentException`) or any resolved IP is outside the list → log + `MarkDeadLetterAsync`. The delivery service is never called.
- Mismatch is `DeadLetter`, **not** a retry — an unreachable / wrong-IP target is a config error, not a transient issue, so retrying buys nothing.

### API
- All four endpoint create/update paths (`EndpointsController` public + `DashboardEndpointController`) accept `allowedIps: string[]`.
- Empty list on update = clear the column (fall back to no allowlist).
- All four validators reject any entry that doesn't round-trip through `IPNetwork.TryParse`, so a typo lands as 422 at form submit.
- `EndpointResponseDto.AllowedIps` exposes the parsed list on read.

### Dashboard
- `types.ts::EndpointRow` and the dashboard endpoint create/update request types gained the optional `allowedIps` field. UI input lands in a follow-up.

### Tests
- **`IpAllowlistMatcherTests`** (8 unit) — null / empty / malformed JSON; `TryParseCidr` across IPv4/IPv6 and invalid inputs; full `AllAddressesAllowed` matrix (all-pass, one-out, empty-list, empty-resolution).
- **`DeliveryFlowEndToEndTests::Allowlist_Mismatch_Sends_Message_To_DeadLetter_Without_Calling_Delivery`** (1 e2e) — seeds an endpoint with `["203.0.113.0/24"]` against an `example.invalid` host (RFC 6761 reserved → guaranteed DNS failure), asserts `DeadLetter` and that `IDeliveryService.DeliverAsync` was never called.

## Test plan

- [x] `dotnet build WebhookEngine.sln --configuration Release` — 0 warnings, 0 errors
- [x] `dotnet test WebhookEngine.sln --configuration Release` — 207 / 207 pass
- [x] `bun run typecheck && bun run lint` (dashboard) — clean
- [ ] CI green