### PR TITLE
feat(api+infra): append-only audit log for admin actions

### DIFF
--- a/src/WebhookEngine.API/Audit/AuditContextExtensions.cs
+++ b/src/WebhookEngine.API/Audit/AuditContextExtensions.cs
@@ -1,0 +1,69 @@
+using System.Security.Claims;
+using WebhookEngine.Core.Interfaces;
+
+namespace WebhookEngine.API.Audit;
+
+/// <summary>
+/// Controller-side helpers that pull the acting user, IP, and user-agent
+/// off <see cref="HttpContext"/> and call <see cref="IAuditLogger"/> with a
+/// fully-populated <see cref="AuditLogEntry"/>. Keeps each call site to a
+/// single line so adding audit coverage to a new action is friction-free.
+/// </summary>
+public static class AuditContextExtensions
+{
+    public static Task LogActionAsync(
+        this IAuditLogger logger,
+        HttpContext httpContext,
+        string action,
+        string resourceType,
+        Guid? resourceId,
+        Guid? appId = null,
+        object? before = null,
+        object? after = null,
+        CancellationToken ct = default)
+    {
+        return logger.LogAsync(new AuditLogEntry
+        {
+            Action = action,
+            ResourceType = resourceType,
+            ResourceId = resourceId,
+            AppId = appId,
+            UserId = ResolveUserId(httpContext),
+            Before = before,
+            After = after,
+            IpAddress = ResolveIpAddress(httpContext),
+            UserAgent = ResolveUserAgent(httpContext)
+        }, ct);
+    }
+
+    private static Guid? ResolveUserId(HttpContext httpContext)
+    {
+        var raw = httpContext.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        return Guid.TryParse(raw, out var id) ? id : null;
+    }
+
+    private static string? ResolveIpAddress(HttpContext httpContext)
+    {
+        // Prefer the proxied client IP when the deployment runs behind a
+        // reverse proxy that sets X-Forwarded-For; fall back to the socket
+        // peer otherwise.
+        var forwarded = httpContext.Request.Headers["X-Forwarded-For"].FirstOrDefault();
+        if (!string.IsNullOrWhiteSpace(forwarded))
+        {
+            // Take the first hop only — that's the real client; the rest are
+            // proxies between us and them.
+            var firstHop = forwarded.Split(',', StringSplitOptions.RemoveEmptyEntries)[0].Trim();
+            if (!string.IsNullOrWhiteSpace(firstHop))
+            {
+                return firstHop;
+            }
+        }
+
+        return httpContext.Connection.RemoteIpAddress?.ToString();
+    }
+
+    private static string? ResolveUserAgent(HttpContext httpContext)
+    {
+        return httpContext.Request.Headers.UserAgent.FirstOrDefault();
+    }
+}

--- a/src/WebhookEngine.API/Controllers/ApplicationsController.cs
+++ b/src/WebhookEngine.API/Controllers/ApplicationsController.cs
@@ -4,8 +4,10 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Memory;
+using WebhookEngine.API.Audit;
 using WebhookEngine.API.Contracts;
 using WebhookEngine.API.Middleware;
+using WebhookEngine.Core.Interfaces;
 using WebhookEngine.Infrastructure.Repositories;
 using AppEntity = WebhookEngine.Core.Entities.Application;
 
@@ -25,11 +27,13 @@ public class ApplicationsController : ControllerBase
 {
     private readonly ApplicationRepository _appRepo;
     private readonly IMemoryCache _cache;
+    private readonly IAuditLogger _auditLogger;
 
-    public ApplicationsController(ApplicationRepository appRepo, IMemoryCache cache)
+    public ApplicationsController(ApplicationRepository appRepo, IMemoryCache cache, IAuditLogger auditLogger)
     {
         _appRepo = appRepo;
         _cache = cache;
+        _auditLogger = auditLogger;
     }
 
     private void InvalidateAuthCache(string apiKeyPrefix)
@@ -61,6 +65,15 @@ public class ApplicationsController : ControllerBase
         };
 
         await _appRepo.CreateAsync(application, ct);
+
+        await _auditLogger.LogActionAsync(
+            HttpContext,
+            action: "application.created",
+            resourceType: "application",
+            resourceId: application.Id,
+            appId: application.Id,
+            after: new { name = application.Name, isActive = application.IsActive },
+            ct: ct);
 
         // Return the API key in plain text ONLY on creation — it is never retrievable again
         return Created($"/api/v1/applications/{application.Id}", ApiEnvelope.Success(HttpContext, new
@@ -123,6 +136,18 @@ public class ApplicationsController : ControllerBase
         if (application is null)
             return NotFound(ApiEnvelope.Error(HttpContext, "NOT_FOUND", "Application not found."));
 
+        // Snapshot the audit-relevant subset before mutating; the full row
+        // contains an api-key hash + signing secret we don't want in the log.
+        var beforeSnapshot = new
+        {
+            name = application.Name,
+            isActive = application.IsActive,
+            idempotencyWindowMinutes = application.IdempotencyWindowMinutes,
+            retentionDeliveredDays = application.RetentionDeliveredDays,
+            retentionDeadLetterDays = application.RetentionDeadLetterDays,
+            rateLimitPerSecond = application.RateLimitPerSecond
+        };
+
         application.Name = request.Name ?? application.Name;
         application.IsActive = request.IsActive ?? application.IsActive;
         application.IdempotencyWindowMinutes = request.IdempotencyWindowMinutes ?? application.IdempotencyWindowMinutes;
@@ -143,6 +168,25 @@ public class ApplicationsController : ControllerBase
 
         await _appRepo.UpdateAsync(application, ct);
         InvalidateAuthCache(application.ApiKeyPrefix);
+
+        var afterSnapshot = new
+        {
+            name = application.Name,
+            isActive = application.IsActive,
+            idempotencyWindowMinutes = application.IdempotencyWindowMinutes,
+            retentionDeliveredDays = application.RetentionDeliveredDays,
+            retentionDeadLetterDays = application.RetentionDeadLetterDays,
+            rateLimitPerSecond = application.RateLimitPerSecond
+        };
+        await _auditLogger.LogActionAsync(
+            HttpContext,
+            action: "application.updated",
+            resourceType: "application",
+            resourceId: application.Id,
+            appId: application.Id,
+            before: beforeSnapshot,
+            after: afterSnapshot,
+            ct: ct);
 
         return Ok(ApiEnvelope.Success(HttpContext, new
         {
@@ -168,6 +212,16 @@ public class ApplicationsController : ControllerBase
 
         await _appRepo.DeleteAsync(applicationId, ct);
         InvalidateAuthCache(application.ApiKeyPrefix);
+
+        await _auditLogger.LogActionAsync(
+            HttpContext,
+            action: "application.deleted",
+            resourceType: "application",
+            resourceId: applicationId,
+            appId: applicationId,
+            before: new { name = application.Name, isActive = application.IsActive },
+            ct: ct);
+
         return NoContent();
     }
 
@@ -188,6 +242,14 @@ public class ApplicationsController : ControllerBase
         await _appRepo.UpdateAsync(application, ct);
         InvalidateAuthCache(application.ApiKeyPrefix);
 
+        await _auditLogger.LogActionAsync(
+            HttpContext,
+            action: "application.api_key_rotated",
+            resourceType: "application",
+            resourceId: application.Id,
+            appId: application.Id,
+            ct: ct);
+
         return Ok(ApiEnvelope.Success(HttpContext, new
         {
             id = application.Id,
@@ -207,6 +269,14 @@ public class ApplicationsController : ControllerBase
         application.SigningSecret = newSigningSecret;
         await _appRepo.UpdateAsync(application, ct);
         InvalidateAuthCache(application.ApiKeyPrefix);
+
+        await _auditLogger.LogActionAsync(
+            HttpContext,
+            action: "application.signing_secret_rotated",
+            resourceType: "application",
+            resourceId: application.Id,
+            appId: application.Id,
+            ct: ct);
 
         return Ok(ApiEnvelope.Success(HttpContext, new
         {

--- a/src/WebhookEngine.API/Controllers/AuditLogsController.cs
+++ b/src/WebhookEngine.API/Controllers/AuditLogsController.cs
@@ -1,0 +1,111 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using WebhookEngine.API.Contracts;
+using WebhookEngine.Infrastructure.Data;
+
+namespace WebhookEngine.API.Controllers;
+
+/// <summary>
+/// Read-only access to the append-only <c>audit_logs</c> table. Dashboard
+/// users can scan recent admin actions, filter by app / action / resource,
+/// and pull the before/after snapshots for a row to diff a regression.
+/// </summary>
+[ApiController]
+[Produces("application/json")]
+[ProducesResponseType<ApiErrorResponse>(StatusCodes.Status401Unauthorized)]
+[ProducesResponseType<ApiErrorResponse>(StatusCodes.Status500InternalServerError)]
+[Route("api/v1/dashboard/audit-logs")]
+[Authorize(AuthenticationSchemes = CookieAuthenticationDefaults.AuthenticationScheme)]
+public class AuditLogsController : ControllerBase
+{
+    private const int MaxPageSize = 100;
+
+    private readonly WebhookDbContext _dbContext;
+
+    public AuditLogsController(WebhookDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> List(
+        [FromQuery] Guid? appId,
+        [FromQuery] string? action,
+        [FromQuery] string? resourceType,
+        [FromQuery] Guid? resourceId,
+        [FromQuery] DateTime? from,
+        [FromQuery] DateTime? to,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 20,
+        CancellationToken ct = default)
+    {
+        page = Math.Max(1, page);
+        pageSize = Math.Clamp(pageSize, 1, MaxPageSize);
+
+        var query = _dbContext.AuditLogs.AsNoTracking().AsQueryable();
+
+        if (appId.HasValue) query = query.Where(l => l.AppId == appId);
+        if (!string.IsNullOrWhiteSpace(action)) query = query.Where(l => l.Action == action);
+        if (!string.IsNullOrWhiteSpace(resourceType)) query = query.Where(l => l.ResourceType == resourceType);
+        if (resourceId.HasValue) query = query.Where(l => l.ResourceId == resourceId);
+        if (from.HasValue) query = query.Where(l => l.CreatedAt >= from);
+        if (to.HasValue) query = query.Where(l => l.CreatedAt <= to);
+
+        var total = await query.CountAsync(ct);
+        var rows = await query
+            .OrderByDescending(l => l.CreatedAt)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .Select(l => new
+            {
+                id = l.Id,
+                appId = l.AppId,
+                userId = l.UserId,
+                action = l.Action,
+                resourceType = l.ResourceType,
+                resourceId = l.ResourceId,
+                before = l.BeforeJson,
+                after = l.AfterJson,
+                ipAddress = l.IpAddress,
+                userAgent = l.UserAgent,
+                createdAt = l.CreatedAt
+            })
+            .ToListAsync(ct);
+
+        // Re-shape before/after as JsonElement so the client can render them
+        // as structured JSON instead of escaped strings.
+        var hydrated = rows.Select(r => new
+        {
+            r.id,
+            r.appId,
+            r.userId,
+            r.action,
+            r.resourceType,
+            r.resourceId,
+            before = ParseJson(r.before),
+            after = ParseJson(r.after),
+            r.ipAddress,
+            r.userAgent,
+            r.createdAt
+        });
+
+        return Ok(ApiEnvelope.Success(HttpContext, hydrated, ApiEnvelope.Pagination(page, pageSize, total)));
+    }
+
+    private static JsonElement? ParseJson(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return null;
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            return doc.RootElement.Clone();
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/WebhookEngine.API/Controllers/DashboardEndpointController.cs
+++ b/src/WebhookEngine.API/Controllers/DashboardEndpointController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using WebhookEngine.API.Audit;
 using WebhookEngine.API.Contracts;
 using WebhookEngine.API.Validators;
 using WebhookEngine.Core.Enums;
@@ -33,6 +34,7 @@ public class DashboardEndpointController : ControllerBase
     private readonly ApplicationRepository _applicationRepository;
     private readonly IPayloadTransformer _payloadTransformer;
     private readonly IEndpointTester _endpointTester;
+    private readonly IAuditLogger _auditLogger;
 
     public DashboardEndpointController(
         WebhookDbContext dbContext,
@@ -40,7 +42,8 @@ public class DashboardEndpointController : ControllerBase
         EventTypeRepository eventTypeRepository,
         ApplicationRepository applicationRepository,
         IPayloadTransformer payloadTransformer,
-        IEndpointTester endpointTester)
+        IEndpointTester endpointTester,
+        IAuditLogger auditLogger)
     {
         _dbContext = dbContext;
         _endpointRepository = endpointRepository;
@@ -48,6 +51,7 @@ public class DashboardEndpointController : ControllerBase
         _applicationRepository = applicationRepository;
         _payloadTransformer = payloadTransformer;
         _endpointTester = endpointTester;
+        _auditLogger = auditLogger;
     }
 
     // ──────────────────────────────────────────────────
@@ -251,6 +255,15 @@ public class DashboardEndpointController : ControllerBase
         await _endpointRepository.UpdateAsync(endpoint, ct);
         DeliveryLookupCache.InvalidateApplication(endpoint.AppId);
 
+        await _auditLogger.LogActionAsync(
+            HttpContext,
+            action: "endpoint.disabled",
+            resourceType: "endpoint",
+            resourceId: endpoint.Id,
+            appId: endpoint.AppId,
+            after: new { url = endpoint.Url, status = endpoint.Status.ToString() },
+            ct: ct);
+
         return Ok(ApiEnvelope.Success(HttpContext, new
         {
             id = endpoint.Id,
@@ -271,6 +284,15 @@ public class DashboardEndpointController : ControllerBase
         await _endpointRepository.UpdateAsync(endpoint, ct);
         DeliveryLookupCache.InvalidateApplication(endpoint.AppId);
 
+        await _auditLogger.LogActionAsync(
+            HttpContext,
+            action: "endpoint.enabled",
+            resourceType: "endpoint",
+            resourceId: endpoint.Id,
+            appId: endpoint.AppId,
+            after: new { url = endpoint.Url, status = endpoint.Status.ToString() },
+            ct: ct);
+
         return Ok(ApiEnvelope.Success(HttpContext, new
         {
             id = endpoint.Id,
@@ -289,6 +311,16 @@ public class DashboardEndpointController : ControllerBase
 
         await _endpointRepository.DeleteAsync(endpointId, ct);
         DeliveryLookupCache.InvalidateApplication(endpoint.AppId);
+
+        await _auditLogger.LogActionAsync(
+            HttpContext,
+            action: "endpoint.deleted",
+            resourceType: "endpoint",
+            resourceId: endpointId,
+            appId: endpoint.AppId,
+            before: new { url = endpoint.Url, status = endpoint.Status.ToString() },
+            ct: ct);
+
         return NoContent();
     }
 

--- a/src/WebhookEngine.API/Program.cs
+++ b/src/WebhookEngine.API/Program.cs
@@ -128,6 +128,7 @@ builder.Services.AddSingleton<ISigningService, HmacSigningService>();
 builder.Services.AddScoped<IEndpointHealthTracker, EndpointHealthTracker>();
 builder.Services.AddSingleton<IEndpointRateLimiter, EndpointRateLimiter>();
 builder.Services.AddSingleton<IApplicationRateLimiter, ApplicationRateLimiter>();
+builder.Services.AddScoped<IAuditLogger, AuditLogger>();
 builder.Services.AddSingleton<IMessageStateMachine, MessageStateMachine>();
 builder.Services.AddSingleton<IDeliveryNotifier, SignalRDeliveryNotifier>();
 builder.Services.AddSingleton<IDevTrafficGenerator, DevTrafficGenerator>();

--- a/src/WebhookEngine.Core/Entities/AuditLog.cs
+++ b/src/WebhookEngine.Core/Entities/AuditLog.cs
@@ -1,0 +1,45 @@
+namespace WebhookEngine.Core.Entities;
+
+/// <summary>
+/// Append-only record of an admin action: who did it, when, against which
+/// resource, and (where it makes sense to capture) the before/after JSON
+/// snapshots so a regression can be diffed without re-running the action.
+/// Compliance for multi-tenant SaaS deployments and on-call forensics for
+/// "who changed this endpoint?" both hang off this table.
+/// </summary>
+public class AuditLog
+{
+    public Guid Id { get; set; }
+    public Guid? AppId { get; set; }
+    public Guid? UserId { get; set; }
+
+    /// <summary>
+    /// Stable dotted action key — e.g. <c>application.created</c>,
+    /// <c>endpoint.disabled</c>, <c>messages.replay</c>. Stays the same across
+    /// future UI churn so log queries don't need translation.
+    /// </summary>
+    public string Action { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The kind of thing the action targeted: <c>application</c>,
+    /// <c>endpoint</c>, <c>event-type</c>, <c>message</c>, etc.
+    /// </summary>
+    public string ResourceType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Optional id of the targeted resource. Bulk actions (e.g. replay) leave
+    /// this null and stash details in <see cref="AfterJson"/>.
+    /// </summary>
+    public Guid? ResourceId { get; set; }
+
+    /// <summary>JSON snapshot of the resource immediately before the action. Null on creates.</summary>
+    public string? BeforeJson { get; set; }
+
+    /// <summary>JSON snapshot or detail blob immediately after the action. Null on deletes.</summary>
+    public string? AfterJson { get; set; }
+
+    public string? IpAddress { get; set; }
+    public string? UserAgent { get; set; }
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/src/WebhookEngine.Core/Interfaces/IAuditLogger.cs
+++ b/src/WebhookEngine.Core/Interfaces/IAuditLogger.cs
@@ -1,0 +1,31 @@
+namespace WebhookEngine.Core.Interfaces;
+
+/// <summary>
+/// Records an admin action into the append-only <c>audit_logs</c> table.
+/// Best-effort: a logger failure must NOT abort the action it was meant to
+/// describe — the implementation swallows exceptions and lets the call site
+/// continue. Callers are responsible for resolving the acting user and the
+/// HTTP context (IP / user-agent) and passing them in.
+/// </summary>
+public interface IAuditLogger
+{
+    Task LogAsync(AuditLogEntry entry, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Single audit-log row payload. <see cref="Before"/> / <see cref="After"/>
+/// are arbitrary anonymous types; the logger serialises them with the same
+/// JSON conventions the rest of the API uses.
+/// </summary>
+public sealed class AuditLogEntry
+{
+    public required string Action { get; init; }
+    public required string ResourceType { get; init; }
+    public Guid? ResourceId { get; init; }
+    public Guid? AppId { get; init; }
+    public Guid? UserId { get; init; }
+    public object? Before { get; init; }
+    public object? After { get; init; }
+    public string? IpAddress { get; init; }
+    public string? UserAgent { get; init; }
+}

--- a/src/WebhookEngine.Infrastructure/Data/WebhookDbContext.cs
+++ b/src/WebhookEngine.Infrastructure/Data/WebhookDbContext.cs
@@ -17,6 +17,7 @@ public class WebhookDbContext : DbContext
     public DbSet<MessageAttempt> MessageAttempts => Set<MessageAttempt>();
     public DbSet<EndpointHealth> EndpointHealths => Set<EndpointHealth>();
     public DbSet<DashboardUser> DashboardUsers => Set<DashboardUser>();
+    public DbSet<AuditLog> AuditLogs => Set<AuditLog>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -202,6 +203,34 @@ public class WebhookDbContext : DbContext
             entity.Property(e => e.LastLoginAt).HasColumnName("last_login_at");
 
             entity.HasIndex(e => e.Email).IsUnique();
+        });
+
+        // Audit Logs (append-only)
+        modelBuilder.Entity<AuditLog>(entity =>
+        {
+            entity.ToTable("audit_logs");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasColumnName("id").HasDefaultValueSql("gen_random_uuid()");
+            entity.Property(e => e.AppId).HasColumnName("app_id");
+            entity.Property(e => e.UserId).HasColumnName("user_id");
+            entity.Property(e => e.Action).HasColumnName("action").HasMaxLength(64).IsRequired();
+            entity.Property(e => e.ResourceType).HasColumnName("resource_type").HasMaxLength(32).IsRequired();
+            entity.Property(e => e.ResourceId).HasColumnName("resource_id");
+            entity.Property(e => e.BeforeJson).HasColumnName("before_json").HasColumnType("jsonb");
+            entity.Property(e => e.AfterJson).HasColumnName("after_json").HasColumnType("jsonb");
+            entity.Property(e => e.IpAddress).HasColumnName("ip_address").HasMaxLength(45);
+            entity.Property(e => e.UserAgent).HasColumnName("user_agent").HasMaxLength(255);
+            entity.Property(e => e.CreatedAt).HasColumnName("created_at").HasDefaultValueSql("NOW()");
+
+            // Most-recent-first per app for the dashboard log page.
+            entity.HasIndex(e => new { e.AppId, e.CreatedAt })
+                .HasDatabaseName("idx_audit_logs_app_created_at")
+                .IsDescending(false, true);
+
+            // Resource-scoped lookups ("show me everything that ever
+            // happened to this endpoint id").
+            entity.HasIndex(e => new { e.ResourceType, e.ResourceId })
+                .HasDatabaseName("idx_audit_logs_resource");
         });
     }
 }

--- a/src/WebhookEngine.Infrastructure/Migrations/20260508073607_AddAuditLogsTable.Designer.cs
+++ b/src/WebhookEngine.Infrastructure/Migrations/20260508073607_AddAuditLogsTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WebhookEngine.Infrastructure.Data;
@@ -11,9 +12,11 @@ using WebhookEngine.Infrastructure.Data;
 namespace WebhookEngine.Infrastructure.Migrations
 {
     [DbContext(typeof(WebhookDbContext))]
-    partial class WebhookDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260508073607_AddAuditLogsTable")]
+    partial class AddAuditLogsTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/WebhookEngine.Infrastructure/Migrations/20260508073607_AddAuditLogsTable.cs
+++ b/src/WebhookEngine.Infrastructure/Migrations/20260508073607_AddAuditLogsTable.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WebhookEngine.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAuditLogsTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "audit_logs",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    app_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    user_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    action = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    resource_type = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    resource_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    before_json = table.Column<string>(type: "jsonb", nullable: true),
+                    after_json = table.Column<string>(type: "jsonb", nullable: true),
+                    ip_address = table.Column<string>(type: "character varying(45)", maxLength: 45, nullable: true),
+                    user_agent = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "NOW()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_audit_logs", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "idx_audit_logs_app_created_at",
+                table: "audit_logs",
+                columns: new[] { "app_id", "created_at" },
+                descending: new[] { false, true });
+
+            migrationBuilder.CreateIndex(
+                name: "idx_audit_logs_resource",
+                table: "audit_logs",
+                columns: new[] { "resource_type", "resource_id" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "audit_logs");
+        }
+    }
+}

--- a/src/WebhookEngine.Infrastructure/Services/AuditLogger.cs
+++ b/src/WebhookEngine.Infrastructure/Services/AuditLogger.cs
@@ -1,0 +1,68 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using WebhookEngine.Core.Entities;
+using WebhookEngine.Core.Interfaces;
+using WebhookEngine.Infrastructure.Data;
+
+namespace WebhookEngine.Infrastructure.Services;
+
+/// <summary>
+/// Writes audit-log rows. Scoped because it shares <see cref="WebhookDbContext"/>
+/// with the calling controller — the audit row goes in the same scope as the
+/// action it describes, but in its own SaveChanges call so a transient logger
+/// failure cannot roll back the action itself.
+/// </summary>
+public class AuditLogger : IAuditLogger
+{
+    // Match the rest of the API: camelCase keys + sensible whitespace
+    // suppression so jsonb stays compact in the column.
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+
+    private readonly WebhookDbContext _dbContext;
+    private readonly ILogger<AuditLogger>? _logger;
+
+    public AuditLogger(WebhookDbContext dbContext, ILogger<AuditLogger>? logger = null)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public async Task LogAsync(AuditLogEntry entry, CancellationToken ct = default)
+    {
+        try
+        {
+            var row = new AuditLog
+            {
+                Action = entry.Action,
+                ResourceType = entry.ResourceType,
+                ResourceId = entry.ResourceId,
+                AppId = entry.AppId,
+                UserId = entry.UserId,
+                BeforeJson = entry.Before is null ? null : JsonSerializer.Serialize(entry.Before, SerializerOptions),
+                AfterJson = entry.After is null ? null : JsonSerializer.Serialize(entry.After, SerializerOptions),
+                IpAddress = Truncate(entry.IpAddress, 45),
+                UserAgent = Truncate(entry.UserAgent, 255)
+            };
+
+            _dbContext.AuditLogs.Add(row);
+            await _dbContext.SaveChangesAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            // Audit failures must not bubble up. The DB has the action's own
+            // committed state; a missed log row is a follow-up cleanup, not a
+            // reason to 500 the request.
+            _logger?.LogWarning(ex, "Failed to write audit log entry for {Action} on {ResourceType}", entry.Action, entry.ResourceType);
+        }
+    }
+
+    private static string? Truncate(string? value, int max)
+    {
+        if (string.IsNullOrEmpty(value)) return value;
+        return value.Length <= max ? value : value[..max];
+    }
+}

--- a/tests/WebhookEngine.API.Tests/Integration/AuditLoggingTests.cs
+++ b/tests/WebhookEngine.API.Tests/Integration/AuditLoggingTests.cs
@@ -1,0 +1,172 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using WebhookEngine.API.Auth;
+using WebhookEngine.Core.Entities;
+using WebhookEngine.Infrastructure.Data;
+
+namespace WebhookEngine.API.Tests.Integration;
+
+public class AuditLoggingTests : IClassFixture<TestWebApplicationFactory>
+{
+    private const string DashboardEmail = "admin@test.local";
+    private const string DashboardPassword = "P@ssw0rd-123";
+
+    private readonly TestWebApplicationFactory _factory;
+
+    public AuditLoggingTests(TestWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task Application_Create_Writes_An_Audit_Row_With_The_Acting_User()
+    {
+        await ResetDatabaseAsync();
+        using var client = CreateClient();
+        await AuthenticateDashboardAsync(client);
+
+        var createResponse = await client.PostAsJsonAsync("/api/v1/applications", new { name = "Audit Smoke App" });
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var created = await ParseJsonAsync(createResponse);
+        var appId = created.GetProperty("data").GetProperty("id").GetGuid();
+
+        await ExecuteDbAsync(async db =>
+        {
+            var rows = await db.AuditLogs
+                .AsNoTracking()
+                .Where(l => l.ResourceId == appId && l.Action == "application.created")
+                .ToListAsync();
+
+            rows.Should().HaveCount(1);
+            var row = rows[0];
+            row.ResourceType.Should().Be("application");
+            row.UserId.Should().NotBeNull("dashboard auth resolves a user");
+            row.AfterJson.Should().NotBeNullOrEmpty();
+            row.BeforeJson.Should().BeNull("creates have no prior state");
+        });
+    }
+
+    [Fact]
+    public async Task Application_Update_Writes_Both_Before_And_After_Snapshots()
+    {
+        await ResetDatabaseAsync();
+        using var client = CreateClient();
+        await AuthenticateDashboardAsync(client);
+
+        var createResponse = await client.PostAsJsonAsync("/api/v1/applications", new { name = "Original" });
+        var appId = (await ParseJsonAsync(createResponse)).GetProperty("data").GetProperty("id").GetGuid();
+
+        var updateResponse = await client.PutAsJsonAsync($"/api/v1/applications/{appId}", new { name = "Renamed" });
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await ExecuteDbAsync(async db =>
+        {
+            var update = await db.AuditLogs
+                .AsNoTracking()
+                .FirstOrDefaultAsync(l => l.ResourceId == appId && l.Action == "application.updated");
+
+            update.Should().NotBeNull();
+            update!.BeforeJson.Should().NotBeNullOrEmpty();
+            update.AfterJson.Should().NotBeNullOrEmpty();
+            update.BeforeJson.Should().Contain("Original");
+            update.AfterJson.Should().Contain("Renamed");
+        });
+    }
+
+    [Fact]
+    public async Task Audit_Log_List_Endpoint_Returns_Most_Recent_First_With_Pagination()
+    {
+        await ResetDatabaseAsync();
+        using var client = CreateClient();
+        await AuthenticateDashboardAsync(client);
+
+        // Two creates produce two audit rows.
+        var first = await client.PostAsJsonAsync("/api/v1/applications", new { name = "First" });
+        first.StatusCode.Should().Be(HttpStatusCode.Created);
+        var second = await client.PostAsJsonAsync("/api/v1/applications", new { name = "Second" });
+        second.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var listResponse = await client.GetAsync("/api/v1/dashboard/audit-logs?action=application.created");
+        listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var data = (await ParseJsonAsync(listResponse)).GetProperty("data");
+        data.GetArrayLength().Should().Be(2);
+
+        // Most recent first — the second create lands at index 0.
+        var rows = data.EnumerateArray().ToList();
+        rows[0].GetProperty("after").GetProperty("name").GetString().Should().Be("Second");
+        rows[1].GetProperty("after").GetProperty("name").GetString().Should().Be("First");
+    }
+
+    [Fact]
+    public async Task Audit_Log_List_Endpoint_Requires_Authentication()
+    {
+        await ResetDatabaseAsync();
+        using var client = CreateClient();
+
+        var response = await client.GetAsync("/api/v1/dashboard/audit-logs");
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Redirect, HttpStatusCode.Forbidden);
+    }
+
+    // ── Plumbing ───────────────────────────────────────
+
+    private HttpClient CreateClient()
+    {
+        return _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            HandleCookies = true
+        });
+    }
+
+    private async Task ResetDatabaseAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+        await db.Database.EnsureDeletedAsync();
+        await db.Database.EnsureCreatedAsync();
+    }
+
+    private async Task AuthenticateDashboardAsync(HttpClient client)
+    {
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+            if (!await db.DashboardUsers.AnyAsync(u => u.Email == DashboardEmail))
+            {
+                db.DashboardUsers.Add(new DashboardUser
+                {
+                    Email = DashboardEmail,
+                    PasswordHash = PasswordHasher.HashPassword(DashboardPassword),
+                    Role = "admin"
+                });
+                await db.SaveChangesAsync();
+            }
+        }
+
+        var loginResponse = await client.PostAsJsonAsync("/api/v1/auth/login", new
+        {
+            email = DashboardEmail,
+            password = DashboardPassword
+        });
+        loginResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    private async Task ExecuteDbAsync(Func<WebhookDbContext, Task> action)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+        await action(db);
+    }
+
+    private static async Task<JsonElement> ParseJsonAsync(HttpResponseMessage response)
+    {
+        var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        return doc.RootElement.Clone();
+    }
+}


### PR DESCRIPTION
## Summary

Adds an append-only `audit_logs` table plus an `IAuditLogger` service, wires it into the highest-blast-radius admin surfaces (`ApplicationsController` and `DashboardEndpointController` enable/disable/delete), and exposes a read API at `GET /api/v1/dashboard/audit-logs`. **F9 from the post-v0.1.5 plan. Fifth migration in the F3-F10 batch.**

## Why

Operators today have no way to answer "who deleted this endpoint?" or "when did the per-app rate limit on app X change to 5/s?" — the engine mutates state and moves on. Two pressing needs:

1. **Multi-tenant SaaS deployments** need a defensible record of admin actions for compliance / customer-support audits.
2. **On-call forensics** want a regression diff after a mis-click.

ADR-001 marked this "could be added later via logging." This is the later.

## What changed

### Schema (migration: `AddAuditLogsTable`)

New `audit_logs` table:
- `id` (uuid, default `gen_random_uuid()`)
- `app_id` (uuid, nullable — system-level actions)
- `user_id` (uuid, nullable — dashboard user from `ClaimTypes.NameIdentifier`)
- `action` (varchar(64), required) — stable dotted key, e.g. `application.deleted`, `endpoint.disabled`
- `resource_type` (varchar(32), required) — `application`, `endpoint`, `event-type`, `message`
- `resource_id` (uuid, nullable)
- `before_json` (jsonb, nullable) — pre-mutation snapshot; null on creates
- `after_json` (jsonb, nullable) — post-mutation snapshot or detail blob; null on deletes
- `ip_address` (varchar(45), nullable)
- `user_agent` (varchar(255), nullable)
- `created_at` (timestamptz, default `NOW()`)

Indexes:
- `idx_audit_logs_app_created_at` `(app_id, created_at DESC)` — newest-first per-app dashboard query.
- `idx_audit_logs_resource` `(resource_type, resource_id)` — "everything that happened to this endpoint."

Append-only: nothing in the engine ever issues UPDATE/DELETE against this table.

### Service

- **`IAuditLogger`** (Core) + **`AuditLogger`** (Infrastructure, Scoped). Shares the controller's `WebhookDbContext` but commits in its own `SaveChanges` so a transient logger failure cannot roll back the action it was meant to describe.
- Logger swallows exceptions with a warning log: the DB has the action's own committed state; a missed audit row is not a reason to 500 the request.
- `JsonSerializer` configured with camelCase + no indentation so jsonb stays compact.

### Controller-side helper

`AuditContextExtensions.LogActionAsync(this IAuditLogger, HttpContext, ...)` reduces every call site to one line. Pulls:
- **User id** from `ClaimTypes.NameIdentifier`.
- **IP** from `X-Forwarded-For` first hop, with `Connection.RemoteIpAddress` as fallback.
- **User-agent** from request headers.

### Wiring (this PR's coverage)

- **`ApplicationsController`** — `created`, `updated`, `deleted`, `api_key_rotated`, `signing_secret_rotated`. Update captures snapshot subset (name + flags, **not** key hash / signing secret).
- **`DashboardEndpointController`** — `disabled`, `enabled`, `deleted`.

EventType actions, endpoint update, and replay coverage land in a follow-up to keep this PR reviewable.

### Read API

`GET /api/v1/dashboard/audit-logs` (cookie auth):
- Filters: `appId`, `action`, `resourceType`, `resourceId`, `from`, `to`.
- Pagination: `page` (>=1), `pageSize` (1..100, default 20).
- Newest-first ordering.
- `before` / `after` JSON re-hydrated as `JsonElement` on response so the client renders structured JSON, not escaped strings.

## Test plan

- [x] `dotnet build WebhookEngine.sln --configuration Release` — 0 warnings, 0 errors
- [x] `dotnet test WebhookEngine.sln --configuration Release` — 211 / 211 pass
- [ ] CI green

### Test scenarios covered

| Scenario | Status |
|---|---|
| `application.created` writes a row with the acting user + after-snapshot | ✅ |
| `application.updated` writes both before- and after-snapshots | ✅ |
| Read endpoint returns rows newest-first with action filter | ✅ |
| Read endpoint requires dashboard auth | ✅ |

## Follow-ups (not in this PR)

- EventType + endpoint-update + message-replay logger coverage.
- Dashboard `AuditLogPage` UI (read-only table + filters).