### PR TITLE
fix(worker): retry transient DNS failures in the allowlist gate instead of dead-lettering

### DIFF
--- a/src/WebhookEngine.Worker/DeliveryWorker.cs
+++ b/src/WebhookEngine.Worker/DeliveryWorker.cs
@@ -224,8 +224,44 @@ public class DeliveryWorker : BackgroundService
                 }
                 catch (Exception ex) when (ex is SocketException or ArgumentException)
                 {
-                    _logger.LogWarning(ex, "Allowlist DNS lookup failed for endpoint {EndpointId}, message {MessageId}; treating as denied.", message.EndpointId, message.Id);
-                    await messageRepo.MarkDeadLetterAsync(message.Id, message.AttemptCount, _workerId, ct);
+                    // A thrown resolver call is "we don't know yet," not "denied" — a
+                    // transient CoreDNS / resolv.conf hiccup must not permanently
+                    // dead-letter every in-flight message for a healthy endpoint.
+                    // Treat it like any other transient delivery failure: bump the
+                    // attempt counter, re-schedule with the standard backoff, and
+                    // only escalate to dead-letter once we've exhausted the retry
+                    // budget on this very message.
+                    var attemptAfterDnsFailure = message.AttemptCount + 1;
+
+                    if (attemptAfterDnsFailure >= message.MaxRetries)
+                    {
+                        _logger.LogWarning(
+                            ex,
+                            "Allowlist DNS lookup failed for endpoint {EndpointId}, message {MessageId}; retry budget exhausted at attempt {AttemptCount}, dead-lettering.",
+                            message.EndpointId,
+                            message.Id,
+                            attemptAfterDnsFailure);
+
+                        if (await messageRepo.MarkDeadLetterAsync(message.Id, attemptAfterDnsFailure, _workerId, ct))
+                        {
+                            _metrics?.RecordDeadLetter();
+                        }
+                        return;
+                    }
+
+                    var nextRetryAt = CalculateNextRetryAt(attemptAfterDnsFailure);
+                    _logger.LogInformation(
+                        ex,
+                        "Allowlist DNS lookup failed for endpoint {EndpointId}, message {MessageId}; rescheduling for retry at {NextRetryAt} (attempt {AttemptCount}).",
+                        message.EndpointId,
+                        message.Id,
+                        nextRetryAt,
+                        attemptAfterDnsFailure);
+
+                    if (await messageRepo.MarkFailedForRetryAsync(message.Id, attemptAfterDnsFailure, nextRetryAt, _workerId, ct))
+                    {
+                        _metrics?.RecordRetryScheduled();
+                    }
                     return;
                 }
 

--- a/tests/WebhookEngine.Infrastructure.Tests/EndToEnd/DeliveryFlowEndToEndTests.cs
+++ b/tests/WebhookEngine.Infrastructure.Tests/EndToEnd/DeliveryFlowEndToEndTests.cs
@@ -202,7 +202,7 @@ public class DeliveryFlowEndToEndTests : IClassFixture<PostgresFixture>
     }
 
     [Fact]
-    public async Task Allowlist_Mismatch_Sends_Message_To_DeadLetter_Without_Calling_Delivery()
+    public async Task Allowlist_Lookup_Failure_Reschedules_For_Retry_Within_Budget()
     {
         await _fixture.ResetAsync();
 
@@ -213,11 +213,11 @@ public class DeliveryFlowEndToEndTests : IClassFixture<PostgresFixture>
 
         await using var sp = BuildServiceProvider(deliveryService);
 
-        // The endpoint hostname (example.invalid) cannot resolve at all under
-        // RFC 6761, so AllAddressesAllowed returns false on an empty resolved
-        // set with a non-empty allowlist. Either way (resolution failure or
-        // resolved IP outside the list), the worker takes the DeadLetter path
-        // before signing, so DeliverAsync is never called.
+        // example.invalid (RFC 6761) deterministically throws on Dns.GetHostAddressesAsync.
+        // A thrown resolver call is "we don't know yet," not "denied" — the worker
+        // must reschedule the message for retry, NOT dead-letter it on the first
+        // failure. A transient CoreDNS / resolv.conf hiccup would otherwise
+        // permanently kill every in-flight message for a healthy endpoint.
         var seed = await SeedAsync(sp, allowedIps: ["203.0.113.0/24"]);
         var messageIds = await EnqueueMessagesAsync(sp, seed, count: 1);
 
@@ -227,7 +227,36 @@ public class DeliveryFlowEndToEndTests : IClassFixture<PostgresFixture>
         var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
         var message = await db.Messages.AsNoTracking().SingleAsync(m => m.Id == messageIds[0]);
 
+        message.Status.Should().Be(MessageStatus.Failed, "DNS resolver failure under retry budget is transient");
+        message.AttemptCount.Should().Be(1, "the failed lookup itself counts as one attempt");
+        message.ScheduledAt.Should().BeAfter(DateTime.UtcNow, "next retry is scheduled for the future");
+        await deliveryService.DidNotReceiveWithAnyArgs().DeliverAsync(default!, default);
+    }
+
+    [Fact]
+    public async Task Allowlist_Lookup_Failure_DeadLetters_When_Retry_Budget_Is_Exhausted()
+    {
+        await _fixture.ResetAsync();
+
+        var deliveryService = Substitute.For<IDeliveryService>();
+        deliveryService
+            .DeliverAsync(Arg.Any<DeliveryRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new DeliveryResult { Success = true, StatusCode = 200, LatencyMs = 10 });
+
+        await using var sp = BuildServiceProvider(deliveryService);
+
+        // Enqueue at the last allowed attempt so the next failure pushes the
+        // counter across MaxRetries and dead-letters the row. Same DNS-failure
+        // shape as the previous test, just with the attempt accounting set up
+        // so we can assert the dead-letter branch.
+        var seed = await SeedAsync(sp, allowedIps: ["203.0.113.0/24"]);
+        await EnqueueMessageAsync(sp, seed, attemptCount: 6, maxRetries: 7);
+
+        await RunWorkerOnceAsync(sp);
+
+        var message = await GetMessageAsync(sp, seed.MessageId);
         message.Status.Should().Be(MessageStatus.DeadLetter);
+        message.AttemptCount.Should().Be(7);
         await deliveryService.DidNotReceiveWithAnyArgs().DeliverAsync(default!, default);
     }
 


### PR DESCRIPTION
## Summary

`DeliveryWorker`'s allowlist branch was treating any `SocketException` / `ArgumentException` from `Dns.GetHostAddressesAsync` as "denied" and dead-lettering the message immediately. Reviewer flagged this as the highest-priority concern from the F1-F9 batch sweep — a transient resolver outage would have permanently killed every in-flight message for a healthy endpoint. **R1 from the post-batch review.**

## Why

A thrown resolver call is **"we don't know yet,"** not **"denied."** Realistic outage scenarios that would have triggered the bug in production:

- A CoreDNS pod restart inside the cluster.
- A 1-second `/etc/resolv.conf` rewrite during host config.
- Upstream DNS provider returning SERVFAIL for a few seconds.
- A momentary network partition between the engine pod and its resolver.

In all four, the message was a perfectly valid delivery — but the prior code dead-lettered it before the resolver had recovered. The customer's endpoint never got the webhook, the queue carried a dead-letter row, and there was no path to recovery without manual replay.

The hard-deny path **is** correct for two cases that we keep:

1. **Resolved-but-rejected**: lookup succeeded and the IP is outside the allowlist → real authorization failure → DeadLetter.
2. **URL unparseable**: config error in the row itself → DeadLetter.

## What changed

- `DeliveryWorker.cs:220-261`: catch block on the allowlist DNS lookup now:
  - bumps the attempt counter (`attemptAfterDnsFailure = message.AttemptCount + 1`)
  - if `attemptAfterDnsFailure >= MaxRetries`: dead-letters with the new attempt count + records the metric (matches the post-delivery dead-letter path)
  - otherwise: computes `nextRetryAt = CalculateNextRetryAt(attemptAfterDnsFailure)` and calls `MessageRepository.MarkFailedForRetryAsync` (the same path the HTTP-failure branch already uses for transient errors)
  - records `RecordRetryScheduled()` so retry telemetry stays consistent
- Logging shifted from "dead-lettered" warning to a retry-scheduled info / budget-exhausted warning depending on the branch.

## Tests

The existing `Allowlist_Mismatch_Sends_Message_To_DeadLetter_Without_Calling_Delivery` test was actually exercising the **resolver-throws** path (because `example.invalid` is RFC 6761-reserved and `Dns.GetHostAddressesAsync` always throws on it). It was reshaped into:

- **`Allowlist_Lookup_Failure_Reschedules_For_Retry_Within_Budget`** — DNS exception under retry budget → message ends up `Failed`, `AttemptCount=1`, `ScheduledAt > now`, delivery service was never called.
- **`Allowlist_Lookup_Failure_DeadLetters_When_Retry_Budget_Is_Exhausted`** — same DNS exception with `AttemptCount=6` / `MaxRetries=7` → message ends up `DeadLetter`, `AttemptCount=7`, delivery service still not called.

A "resolved-but-rejected" test against a real public IP would require external network access in CI; the existing matcher unit tests cover that branch deterministically.

## Test plan

- [x] `dotnet build WebhookEngine.sln --configuration Release` — 0 warnings, 0 errors
- [x] `dotnet test WebhookEngine.sln --configuration Release` — 212 / 212 pass (was 211; one existing test reshaped, one new test added)
- [ ] CI green