### PR TITLE
perf(dashboard): smart-debounce the dashboard polling so SignalR floods don't pummel the API

### DIFF
--- a/src/dashboard/src/pages/DashboardPage.tsx
+++ b/src/dashboard/src/pages/DashboardPage.tsx
@@ -93,6 +93,14 @@ export function DashboardPage() {
   const realtimeSyncPendingRef = useRef(false);
   const realtimeSyncInFlightRef = useRef(false);
   const hasEverConnectedRef = useRef(false);
+  // Floor on how often the SignalR-driven refresh actually fires the
+  // overview/timeline GETs. The hub emits a delivery event for every single
+  // message the worker processes; without a min-interval guard a busy queue
+  // (e.g. dev-traffic seed) burns one fetch per second indefinitely. Three
+  // seconds is the rough cadence a human can perceive, so the dashboard
+  // stays "live" without pummelling the API.
+  const lastRealtimeRefreshAtRef = useRef(0);
+  const REALTIME_MIN_INTERVAL_MS = 3000;
 
   const refreshDashboardData = useCallback(async (showLoading = false) => {
     if (showLoading) setIsLoading(true);
@@ -147,12 +155,19 @@ export function DashboardPage() {
   useEffect(() => {
     if (!devToolsAvailable) return;
 
+    // Adaptive cadence: while a dev-traffic flow is actually running the
+    // status block is interesting enough to poll quickly (3 s), but once the
+    // generator is idle the same poll is just network noise — drop it to 30 s
+    // so a long-running idle dashboard doesn't churn the dev-status endpoint.
+    const isRunning = devStatus?.running === true;
+    const interval = isRunning ? 3000 : 30_000;
+
     const timer = window.setInterval(() => {
       void loadDevStatus();
-    }, 3000);
+    }, interval);
 
     return () => window.clearInterval(timer);
-  }, [devToolsAvailable, loadDevStatus]);
+  }, [devToolsAvailable, loadDevStatus, devStatus?.running]);
 
   useEffect(() => {
     const latestEvent = events[0];
@@ -173,8 +188,19 @@ export function DashboardPage() {
   }, [connected]);
 
   useEffect(() => {
+    // Tick at 5 s instead of 1 s and guard with a 3 s min-interval since the
+    // last completed refresh, so a flood of SignalR delivery events (e.g.
+    // dev-traffic seed) coalesces into at most one overview/timeline fetch
+    // every few seconds rather than one per second. This is a tactical fix
+    // ahead of F12; once TanStack Query is wired in, the queryClient's own
+    // staleTime + invalidateQueries replaces this manual debounce entirely.
     const timer = window.setInterval(() => {
       if (!realtimeSyncPendingRef.current || realtimeSyncInFlightRef.current) {
+        return;
+      }
+
+      const now = Date.now();
+      if (now - lastRealtimeRefreshAtRef.current < REALTIME_MIN_INTERVAL_MS) {
         return;
       }
 
@@ -183,8 +209,9 @@ export function DashboardPage() {
 
       void refreshDashboardData(false).finally(() => {
         realtimeSyncInFlightRef.current = false;
+        lastRealtimeRefreshAtRef.current = Date.now();
       });
-    }, 1000);
+    }, 5000);
 
     return () => window.clearInterval(timer);
   }, [refreshDashboardData]);


### PR DESCRIPTION
## Summary

The dashboard's overview/timeline GETs were firing roughly once per second whenever any messages were moving — the user saw the network tab fill with a continuous \`overview/timeline\` cadence (image included in the conversation that triggered this fix). Three small tweaks turn it into "at most one refresh every ~5s" without sacrificing the live-feel. **R6 from the post-F1-F9 punch list. Tactical fix ahead of F12.**

## Why

`DashboardPage.tsx` ran a 1-second tick that fetched overview + timeline whenever **any** SignalR delivery event flipped a pending flag. With dev-traffic seed flowing — or any production app processing real volume — every queue tick triggered the dual GET. The diagnostic image showed a continuous \`overview / timeline / overview / timeline …\` cadence in the browser's network panel, plus the 3-second `dev-status` poll on top.

The pattern works (no correctness issue) but is wasteful: SignalR coalescing only existed at the 1-second tick granularity, so the API absorbed one fetch per second indefinitely.

## What changed

`src/dashboard/src/pages/DashboardPage.tsx`:

1. **Tick interval 1s → 5s.** The pending-flag is still set instantly on every SignalR event, but the timer that drains it now ticks every 5 s instead of every 1 s.
2. **`REALTIME_MIN_INTERVAL_MS = 3000` floor.** Even when the 5-second tick fires, the refresh is skipped if `Date.now() - lastRealtimeRefreshAtRef.current < 3000`. The timestamp is updated *after* the request finishes (post-`.finally`), so a 401/timeout doesn't throw the cadence off.
3. **Adaptive dev-status poll.** Was a hard 3-second interval. Now it's 3 s while `devStatus.running === true`, 30 s when idle. A long-lived idle dashboard stops hammering the dev-status endpoint with no real loss of resolution (idle is idle).

The underlying SignalR live-feel is preserved — when an event lands the pending flag is set immediately, and the next tick (≤5s) drains it. To a human watching the dashboard, the noticeable cadence drops from "constantly refreshing" to "refreshes every few seconds" while keeping freshness within the human-perceptible window.

## Why a tactical fix and not a full SWR/TanStack-Query refactor

That's exactly what F12 is for. F12 wires `@tanstack/react-query`'s `staleTime` + `invalidateQueries` and the entire manual-debounce rig in `DashboardPage` disappears. R6 is the one-file-changed quick win to land before F12 so production deployments get relief immediately; once F12 lands, the timestamp ref + REALTIME_MIN_INTERVAL_MS go away. Inline comments point at this follow-up so a future reader knows the manual rig is deliberate but temporary.

## Test plan

- [x] `bun run typecheck && bun run lint && bun run build` — clean
- [ ] CI green
- [ ] Smoke: open dashboard with the dev-traffic flow running, network tab cadence drops from ~1/s to ~1/5s with no perceptible UX regression on the timeline / status badges