### PR TITLE
refactor(dashboard): consolidate StatusBadge + inputClasses + editor theme, lazy CodeMirror, field-aware errors

### DIFF
--- a/src/dashboard/src/api/dashboardApi.ts
+++ b/src/dashboard/src/api/dashboardApi.ts
@@ -17,14 +17,64 @@ interface ApiEnvelope<T> {
   meta?: { requestId?: string; pagination?: Pagination };
 }
 
-async function parseError(response: Response): Promise<string> {
-  try {
-    const payload = (await response.json()) as { error?: { message?: string } };
-    if (payload.error?.message) return payload.error.message;
-  } catch {
-    // no-op
+/**
+ * Field-aware shape of an error returned from the API.
+ * `message` is always set; `fieldErrors` is populated only when the server
+ * surfaces per-field validation hints (FluentValidation 422 path).
+ */
+export interface ApiError {
+  message: string;
+  fieldErrors?: Record<string, string>;
+}
+
+/**
+ * Carries the {@link ApiError} alongside the `Error` interface so existing
+ * `catch (e) { e instanceof Error ? e.message : … }` sites keep working
+ * verbatim while form components opt in by checking `instanceof
+ * ApiErrorException` and reading `fieldErrors`. Form-level wiring lands in
+ * the dashboard-improvement follow-up; this PR only exposes the surface.
+ */
+export class ApiErrorException extends Error {
+  readonly fieldErrors?: Record<string, string>;
+
+  constructor(error: ApiError) {
+    super(error.message);
+    this.name = "ApiErrorException";
+    this.fieldErrors = error.fieldErrors;
   }
-  return `Request failed with status ${response.status}`;
+}
+
+async function parseError(response: Response): Promise<ApiError> {
+  try {
+    const payload = (await response.json()) as {
+      error?: {
+        message?: string;
+        fieldErrors?: Array<{ field?: string; message?: string }> | Record<string, string>;
+      };
+    };
+
+    const message = payload.error?.message ?? `Request failed with status ${response.status}`;
+    const rawFieldErrors = payload.error?.fieldErrors;
+    let fieldErrors: Record<string, string> | undefined;
+
+    if (Array.isArray(rawFieldErrors)) {
+      // [{ field, message }] — collapse to first message per field.
+      fieldErrors = {};
+      for (const entry of rawFieldErrors) {
+        if (entry?.field && entry.message && !(entry.field in fieldErrors)) {
+          fieldErrors[entry.field] = entry.message;
+        }
+      }
+      if (Object.keys(fieldErrors).length === 0) fieldErrors = undefined;
+    } else if (rawFieldErrors && typeof rawFieldErrors === "object") {
+      // Already a { field: message } map.
+      fieldErrors = rawFieldErrors as Record<string, string>;
+    }
+
+    return { message, fieldErrors };
+  } catch {
+    return { message: `Request failed with status ${response.status}` };
+  }
 }
 
 /**
@@ -53,7 +103,9 @@ async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
 
   if (!response.ok) {
     maybeFireAuthExpired(url, response.status);
-    throw new Error(await parseError(response));
+    // Throw ApiErrorException so call sites that opt in can `instanceof`-check
+    // and read `fieldErrors`; sites that just `e.message` keep working unchanged.
+    throw new ApiErrorException(await parseError(response));
   }
 
   return (await response.json()) as T;
@@ -70,7 +122,9 @@ async function mutate<T>(url: string, method: string, body?: unknown, init?: Req
 
   if (!response.ok) {
     maybeFireAuthExpired(url, response.status);
-    throw new Error(await parseError(response));
+    // Throw ApiErrorException so call sites that opt in can `instanceof`-check
+    // and read `fieldErrors`; sites that just `e.message` keep working unchanged.
+    throw new ApiErrorException(await parseError(response));
   }
 
   if (response.status === 204) return undefined as T;

--- a/src/dashboard/src/components/EndpointTestModal.tsx
+++ b/src/dashboard/src/components/EndpointTestModal.tsx
@@ -1,13 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import CodeMirror from "@uiw/react-codemirror";
-import { json } from "@codemirror/lang-json";
-import { EditorView } from "@codemirror/view";
-import { tags as t } from "@lezer/highlight";
-import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
 import { AlertCircle, CheckCircle2, ChevronDown, ChevronUp, Loader2, Send } from "lucide-react";
 import { Modal } from "./Modal";
 import { testDashboardEndpoint } from "../api/dashboardApi";
 import type { TestEndpointResult } from "../api/dashboardApi";
+import { jsonEditorExtensions } from "../utils/editorTheme";
+import { inputClasses } from "../utils/styles";
 
 interface EndpointTestModalProps {
   open: boolean;
@@ -22,46 +20,6 @@ const DEFAULT_PAYLOAD = `{
     "message": "Hello from WebhookEngine"
   }
 }`;
-
-const editorTheme = EditorView.theme(
-  {
-    "&": {
-      backgroundColor: "transparent",
-      color: "#fafafa",
-      fontSize: "12px",
-      fontFamily:
-        "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace"
-    },
-    ".cm-content": { padding: "8px 0", caretColor: "#22d3ee" },
-    ".cm-gutters": {
-      backgroundColor: "transparent",
-      color: "#71717a",
-      borderRight: "1px solid #1e1e22"
-    },
-    ".cm-activeLine": { backgroundColor: "transparent" },
-    ".cm-activeLineGutter": { backgroundColor: "transparent" },
-    ".cm-cursor": { borderLeftColor: "#22d3ee" },
-    "&.cm-focused": { outline: "none" },
-    "&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection":
-      { backgroundColor: "rgba(34, 211, 238, 0.18)" }
-  },
-  { dark: true }
-);
-
-const editorHighlight = HighlightStyle.define([
-  { tag: t.string, color: "#86efac" },
-  { tag: t.number, color: "#fbbf24" },
-  { tag: t.bool, color: "#f472b6" },
-  { tag: t.null, color: "#71717a" },
-  { tag: t.propertyName, color: "#22d3ee" },
-  { tag: t.keyword, color: "#c4b5fd" },
-  { tag: t.punctuation, color: "#a1a1aa" }
-]);
-
-const editorExtensions = [editorTheme, syntaxHighlighting(editorHighlight), json(), EditorView.lineWrapping];
-
-const inputClasses =
-  "w-full px-3 py-2 text-sm bg-surface-2 border border-border rounded-lg text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-1 focus:ring-accent/50 focus:border-accent/50 transition-colors";
 
 export function EndpointTestModal({ open, endpointId, endpointUrl, onClose }: EndpointTestModalProps) {
   const [eventType, setEventType] = useState("");
@@ -160,7 +118,8 @@ export function EndpointTestModal({ open, endpointId, endpointUrl, onClose }: En
             <CodeMirror
               value={payloadText}
               height="200px"
-              extensions={editorExtensions}
+              theme="dark"
+              extensions={jsonEditorExtensions}
               onChange={setPayloadText}
               basicSetup={{
                 lineNumbers: false,

--- a/src/dashboard/src/components/StatusBadge.tsx
+++ b/src/dashboard/src/components/StatusBadge.tsx
@@ -1,0 +1,45 @@
+export type StatusBadgeKind =
+  | "delivered"
+  | "pending"
+  | "sending"
+  | "failed"
+  | "deadletter"
+  | "active"
+  | "degraded"
+  | "disabled";
+
+interface StatusBadgeProps {
+  kind: StatusBadgeKind | string;
+  label?: string;
+}
+
+interface BadgeConfig {
+  label: string;
+  badgeClass: string;
+}
+
+// Canonical key is lowercase; callers may pass PascalCase backend strings
+const CONFIG: Record<string, BadgeConfig> = {
+  delivered: { label: "Delivered", badgeClass: "text-success bg-success-soft" },
+  pending: { label: "Pending", badgeClass: "text-warning bg-warning-soft" },
+  sending: { label: "Sending", badgeClass: "text-accent bg-accent-soft" },
+  failed: { label: "Failed", badgeClass: "text-danger bg-danger-soft" },
+  deadletter: { label: "Dead Letter", badgeClass: "text-danger bg-danger-soft" },
+  active: { label: "Active", badgeClass: "text-success bg-success-soft" },
+  degraded: { label: "Degraded", badgeClass: "text-warning bg-warning-soft" },
+  disabled: { label: "Disabled", badgeClass: "text-text-muted bg-surface-2" }
+};
+
+export function StatusBadge({ kind, label }: StatusBadgeProps) {
+  const key = kind.toLowerCase();
+  const config = CONFIG[key] ?? { label: kind, badgeClass: "text-text-muted bg-surface-2" };
+  const displayLabel = label ?? config.label;
+
+  return (
+    <span
+      className={`inline-block text-xs font-medium px-1.5 py-0.5 rounded ${config.badgeClass}`}
+    >
+      {displayLabel}
+    </span>
+  );
+}

--- a/src/dashboard/src/components/TransformSection.tsx
+++ b/src/dashboard/src/components/TransformSection.tsx
@@ -1,10 +1,7 @@
 import { useState, useCallback, useMemo } from "react";
 import CodeMirror from "@uiw/react-codemirror";
-import { json } from "@codemirror/lang-json";
-import { EditorView } from "@codemirror/view";
-import { tags as t } from "@lezer/highlight";
-import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
 import { validateTransform } from "../api/dashboardApi";
+import { expressionEditorExtensions, jsonEditorExtensions } from "../utils/editorTheme";
 import { Play, Loader2, CheckCircle2, AlertCircle, Wand2, ChevronDown, ChevronUp } from "lucide-react";
 
 interface TransformSectionProps {
@@ -22,56 +19,6 @@ const DEFAULT_SAMPLE = `{
   },
   "amount": 4200
 }`;
-
-const dashboardEditorTheme = EditorView.theme(
-  {
-    "&": {
-      backgroundColor: "transparent",
-      color: "#fafafa",
-      fontSize: "12px",
-      fontFamily:
-        "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace"
-    },
-    ".cm-content": {
-      padding: "8px 0",
-      caretColor: "#22d3ee"
-    },
-    ".cm-gutters": {
-      backgroundColor: "transparent",
-      color: "#71717a",
-      borderRight: "1px solid #1e1e22"
-    },
-    ".cm-activeLine": { backgroundColor: "transparent" },
-    ".cm-activeLineGutter": { backgroundColor: "transparent" },
-    ".cm-cursor": { borderLeftColor: "#22d3ee" },
-    "&.cm-focused": { outline: "none" },
-    "&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection":
-      { backgroundColor: "rgba(34, 211, 238, 0.18)" }
-  },
-  { dark: true }
-);
-
-const dashboardHighlight = HighlightStyle.define([
-  { tag: t.string, color: "#86efac" },
-  { tag: t.number, color: "#fbbf24" },
-  { tag: t.bool, color: "#f472b6" },
-  { tag: t.null, color: "#71717a" },
-  { tag: t.propertyName, color: "#22d3ee" },
-  { tag: t.keyword, color: "#c4b5fd" },
-  { tag: t.punctuation, color: "#a1a1aa" }
-]);
-
-const expressionExtensions = [
-  dashboardEditorTheme,
-  EditorView.lineWrapping
-];
-
-const payloadExtensions = [
-  dashboardEditorTheme,
-  syntaxHighlighting(dashboardHighlight),
-  json(),
-  EditorView.lineWrapping
-];
 
 export function TransformSection({
   enabled,
@@ -177,7 +124,7 @@ export function TransformSection({
               value={expression}
               onChange={handleExpressionChange}
               theme="dark"
-              extensions={expressionExtensions}
+              extensions={expressionEditorExtensions}
               basicSetup={{
                 lineNumbers: false,
                 foldGutter: false,
@@ -220,7 +167,7 @@ export function TransformSection({
                   value={samplePayload}
                   onChange={handleSampleChange}
                   theme="dark"
-                  extensions={payloadExtensions}
+                  extensions={jsonEditorExtensions}
                   basicSetup={{
                     lineNumbers: true,
                     foldGutter: false,
@@ -269,7 +216,7 @@ export function TransformSection({
                       value={result.output}
                       editable={false}
                       theme="dark"
-                      extensions={payloadExtensions}
+                      extensions={jsonEditorExtensions}
                       basicSetup={{
                         lineNumbers: true,
                         foldGutter: false,

--- a/src/dashboard/src/pages/DashboardPage.tsx
+++ b/src/dashboard/src/pages/DashboardPage.tsx
@@ -10,6 +10,7 @@ import {
   type DevTrafficStatus
 } from "../api/dashboardApi";
 import { DeliveryTimeline } from "../components/DeliveryTimeline";
+import { StatusBadge } from "../components/StatusBadge";
 import { useDeliveryFeed } from "../hooks/useDeliveryFeed";
 import type { DashboardOverview, TimelineBucket } from "../types";
 import { formatLocaleTime } from "../utils/dateTime";
@@ -400,7 +401,7 @@ export function DashboardPage() {
                   <tr key={`${event.messageId}-${i}`} className="border-t border-border-subtle">
                     <td className="py-1.5 font-mono text-xs text-text-secondary">{event.messageId.slice(0, 12)}</td>
                     <td className="py-1.5">
-                      <StatusBadge status={event.status} />
+                      <StatusBadge kind={event.status} />
                     </td>
                     <td className="py-1.5 text-text-secondary">{event.attemptCount}</td>
                     <td className="py-1.5 font-mono text-xs text-text-secondary">
@@ -415,21 +416,5 @@ export function DashboardPage() {
         )}
       </div>
     </div>
-  );
-}
-
-function StatusBadge({ status }: { status: string }) {
-  const styles: Record<string, string> = {
-    Delivered: "text-success bg-success-soft",
-    Failed: "text-danger bg-danger-soft",
-    DeadLetter: "text-danger bg-danger-soft",
-    Pending: "text-warning bg-warning-soft",
-    Sending: "text-accent bg-accent-soft"
-  };
-
-  return (
-    <span className={`inline-block text-xs font-medium px-1.5 py-0.5 rounded ${styles[status] ?? "text-text-muted bg-surface-2"}`}>
-      {status === "DeadLetter" ? "Dead Letter" : status}
-    </span>
   );
 }

--- a/src/dashboard/src/pages/DeliveryLogPage.tsx
+++ b/src/dashboard/src/pages/DeliveryLogPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router";
 import { PayloadViewer } from "../components/PayloadViewer";
 import { RetryButton } from "../components/RetryButton";
+import { StatusBadge } from "../components/StatusBadge";
 import { getMessage } from "../api/dashboardApi";
 import type { MessageDetail } from "../types";
 import { formatLocaleDateTime } from "../utils/dateTime";
@@ -14,21 +15,6 @@ import {
   CheckCircle2,
   XCircle
 } from "lucide-react";
-
-function StatusBadge({ status }: { status: string }) {
-  const styles: Record<string, string> = {
-    Delivered: "text-success bg-success-soft",
-    Failed: "text-danger bg-danger-soft",
-    DeadLetter: "text-danger bg-danger-soft",
-    Pending: "text-warning bg-warning-soft",
-    Sending: "text-accent bg-accent-soft"
-  };
-  return (
-    <span className={`inline-block text-xs font-medium px-1.5 py-0.5 rounded ${styles[status] ?? "text-text-muted bg-surface-2"}`}>
-      {status === "DeadLetter" ? "Dead Letter" : status}
-    </span>
-  );
-}
 
 export function DeliveryLogPage() {
   const { messageId } = useParams<{ messageId?: string }>();
@@ -106,7 +92,7 @@ export function DeliveryLogPage() {
           </div>
           <div className="flex items-center gap-2 text-sm">
             <span className="font-mono text-xs text-text-secondary">{message.id.slice(0, 16)}</span>
-            <StatusBadge status={message.status} />
+            <StatusBadge kind={message.status} />
             <span className="text-text-muted">{message.eventType ?? "unknown"}</span>
             <span className="text-text-muted font-mono text-xs">{message.attemptCount}/{message.maxRetries}</span>
           </div>

--- a/src/dashboard/src/pages/EndpointsPage.tsx
+++ b/src/dashboard/src/pages/EndpointsPage.tsx
@@ -1,11 +1,9 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { EndpointHealthBadge } from "../components/EndpointHealthBadge";
 import { Modal } from "../components/Modal";
 import { ConfirmModal } from "../components/ConfirmModal";
 import { Select } from "../components/Select";
 import { EventTypeSelect } from "../components/EventTypeSelect";
-import { TransformSection } from "../components/TransformSection";
-import { EndpointTestModal } from "../components/EndpointTestModal";
 import { useDeliveryFeed } from "../hooks/useDeliveryFeed";
 import {
   createDashboardEndpoint,
@@ -32,6 +30,17 @@ import {
   Send
 } from "lucide-react";
 import { formatLocaleDate } from "../utils/dateTime";
+import { inputClasses } from "../utils/styles";
+
+// Lazy-load heavy CodeMirror components so the editor chunk only downloads
+// when the user actually opens the create/edit or test modals — not on every
+// Endpoints page visit. DPR-2 bundle consolidation pass.
+const TransformSection = lazy(() =>
+  import("../components/TransformSection").then((m) => ({ default: m.TransformSection }))
+);
+const EndpointTestModal = lazy(() =>
+  import("../components/EndpointTestModal").then((m) => ({ default: m.EndpointTestModal }))
+);
 
 function toTitleCase(value: string): string {
   if (!value) return value;
@@ -50,8 +59,6 @@ interface ConfirmState {
 const closedConfirm: ConfirmState = {
   open: false, title: "", description: "", confirmLabel: "Confirm", variant: "default", onConfirm: () => {}
 };
-
-const inputClasses = "w-full px-3 py-2 text-sm bg-surface-2 border border-border rounded-lg text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-1 focus:ring-accent/50 focus:border-accent/50 transition-colors";
 
 export function EndpointsPage() {
   const [endpoints, setEndpoints] = useState<EndpointRow[]>([]);
@@ -191,6 +198,9 @@ export function EndpointsPage() {
         transformExpression: trimmedExpr || null,
         transformEnabled: createTransformEnabled && trimmedExpr.length > 0
       });
+      // TODO(DPR-3): createDashboardEndpoint now throws ApiErrorException with
+      // fieldErrors when the server returns 422 — wire url field error into the
+      // input once the form is upgraded in the next pass.
       resetCreateForm();
       setShowCreate(false);
       await fetchEndpoints();
@@ -479,14 +489,16 @@ export function EndpointsPage() {
               <p className="text-xs text-text-muted mt-1">No selection = receives all events for this app.</p>
             </div>
           )}
-          <TransformSection
-            enabled={createTransformEnabled}
-            expression={createTransformExpression}
-            onChange={(next) => {
-              setCreateTransformEnabled(next.enabled);
-              setCreateTransformExpression(next.expression);
-            }}
-          />
+          <Suspense fallback={<div className="p-4 text-xs text-text-muted">Loading editor...</div>}>
+            <TransformSection
+              enabled={createTransformEnabled}
+              expression={createTransformExpression}
+              onChange={(next) => {
+                setCreateTransformEnabled(next.enabled);
+                setCreateTransformExpression(next.expression);
+              }}
+            />
+          </Suspense>
           <div className="flex items-center justify-end gap-2 pt-2">
             <button onClick={() => { setShowCreate(false); resetCreateForm(); }} className="text-xs font-medium px-3 py-1.5 rounded-lg border border-border bg-surface-2 text-text-secondary hover:text-text-primary hover:bg-surface-3 transition-colors">
               Cancel
@@ -525,14 +537,16 @@ export function EndpointsPage() {
               <EventTypeSelect eventTypes={editEventTypes} selected={editFilterEventTypeIds} onChange={setEditFilterEventTypeIds} />
             </div>
           )}
-          <TransformSection
-            enabled={editTransformEnabled}
-            expression={editTransformExpression}
-            onChange={(next) => {
-              setEditTransformEnabled(next.enabled);
-              setEditTransformExpression(next.expression);
-            }}
-          />
+          <Suspense fallback={<div className="p-4 text-xs text-text-muted">Loading editor...</div>}>
+            <TransformSection
+              enabled={editTransformEnabled}
+              expression={editTransformExpression}
+              onChange={(next) => {
+                setEditTransformEnabled(next.enabled);
+                setEditTransformExpression(next.expression);
+              }}
+            />
+          </Suspense>
           <div className="flex items-center justify-end gap-2 pt-2">
             <button onClick={cancelEdit} className="text-xs font-medium px-3 py-1.5 rounded-lg border border-border bg-surface-2 text-text-secondary hover:text-text-primary hover:bg-surface-3 transition-colors">
               Cancel
@@ -561,12 +575,14 @@ export function EndpointsPage() {
       />
 
       {/* ── Test Modal ────────────────────────────── */}
-      <EndpointTestModal
-        open={testEndpointId !== null}
-        endpointId={testEndpointId}
-        endpointUrl={testEndpointUrl}
-        onClose={handleTestClose}
-      />
+      <Suspense fallback={null}>
+        <EndpointTestModal
+          open={testEndpointId !== null}
+          endpointId={testEndpointId}
+          endpointUrl={testEndpointUrl}
+          onClose={handleTestClose}
+        />
+      </Suspense>
     </div>
   );
 }

--- a/src/dashboard/src/pages/EventTypesPage.tsx
+++ b/src/dashboard/src/pages/EventTypesPage.tsx
@@ -20,8 +20,7 @@ import {
   Save
 } from "lucide-react";
 import { formatLocaleDate } from "../utils/dateTime";
-
-const inputClasses = "w-full px-3 py-2 text-sm bg-surface-2 border border-border rounded-lg text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-1 focus:ring-accent/50 focus:border-accent/50 transition-colors";
+import { inputClasses } from "../utils/styles";
 
 interface ConfirmState {
   open: boolean;

--- a/src/dashboard/src/pages/MessagesPage.tsx
+++ b/src/dashboard/src/pages/MessagesPage.tsx
@@ -3,10 +3,12 @@ import { Link } from "react-router";
 import { RetryButton } from "../components/RetryButton";
 import { Modal } from "../components/Modal";
 import { Select } from "../components/Select";
+import { StatusBadge } from "../components/StatusBadge";
 import { useDeliveryFeed } from "../hooks/useDeliveryFeed";
 import { listApplications, listEndpoints, listMessages, sendDashboardMessage } from "../api/dashboardApi";
-import type { ApplicationRow, MessageRow, MessageStatusType, Pagination } from "../types";
+import type { ApplicationRow, MessageRow, Pagination } from "../types";
 import { formatLocaleDateTime } from "../utils/dateTime";
+import { inputClasses } from "../utils/styles";
 import {
   Send,
   Filter,
@@ -18,27 +20,6 @@ import {
   ChevronLeft,
   ChevronRight
 } from "lucide-react";
-
-function prettyStatus(status: MessageStatusType): string {
-  return status === "DeadLetter" ? "Dead Letter" : status;
-}
-
-function StatusBadge({ status }: { status: string }) {
-  const styles: Record<string, string> = {
-    Delivered: "text-success bg-success-soft",
-    Failed: "text-danger bg-danger-soft",
-    DeadLetter: "text-danger bg-danger-soft",
-    Pending: "text-warning bg-warning-soft",
-    Sending: "text-accent bg-accent-soft"
-  };
-  return (
-    <span className={`inline-block text-xs font-medium px-1.5 py-0.5 rounded ${styles[status] ?? "text-text-muted bg-surface-2"}`}>
-      {prettyStatus(status as MessageStatusType)}
-    </span>
-  );
-}
-
-const inputClasses = "w-full px-3 py-2 text-sm bg-surface-2 border border-border rounded-lg text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-1 focus:ring-accent/50 focus:border-accent/50 transition-colors";
 
 const statusOptions = [
   { value: "", label: "All" },
@@ -319,7 +300,7 @@ export function MessagesPage() {
                       <td className="px-4 py-2 font-mono text-xs text-text-muted max-w-[180px] truncate" title={msg.endpointUrl ?? msg.endpointId}>
                         {msg.endpointUrl ?? msg.endpointId.slice(0, 12)}
                       </td>
-                      <td className="px-4 py-2"><StatusBadge status={msg.status} /></td>
+                      <td className="px-4 py-2"><StatusBadge kind={msg.status} /></td>
                       <td className="px-4 py-2 text-xs text-text-muted font-mono">{msg.attemptCount}/{msg.maxRetries}</td>
                       <td className="px-4 py-2 text-xs text-text-muted">{formatLocaleDateTime(msg.createdAt)}</td>
                       <td className="px-4 py-2">

--- a/src/dashboard/src/utils/editorTheme.ts
+++ b/src/dashboard/src/utils/editorTheme.ts
@@ -1,0 +1,51 @@
+import { EditorView } from "@codemirror/view";
+import { tags as t } from "@lezer/highlight";
+import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
+import { json } from "@codemirror/lang-json";
+
+export const editorTheme = EditorView.theme(
+  {
+    "&": {
+      backgroundColor: "transparent",
+      color: "#fafafa",
+      fontSize: "12px",
+      fontFamily:
+        "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace"
+    },
+    ".cm-content": { padding: "8px 0", caretColor: "#22d3ee" },
+    ".cm-gutters": {
+      backgroundColor: "transparent",
+      color: "#71717a",
+      borderRight: "1px solid #1e1e22"
+    },
+    ".cm-activeLine": { backgroundColor: "transparent" },
+    ".cm-activeLineGutter": { backgroundColor: "transparent" },
+    ".cm-cursor": { borderLeftColor: "#22d3ee" },
+    "&.cm-focused": { outline: "none" },
+    "&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection": {
+      backgroundColor: "rgba(34, 211, 238, 0.18)"
+    }
+  },
+  { dark: true }
+);
+
+export const editorHighlight = HighlightStyle.define([
+  { tag: t.string, color: "#86efac" },
+  { tag: t.number, color: "#fbbf24" },
+  { tag: t.bool, color: "#f472b6" },
+  { tag: t.null, color: "#71717a" },
+  { tag: t.propertyName, color: "#22d3ee" },
+  { tag: t.keyword, color: "#c4b5fd" },
+  { tag: t.punctuation, color: "#a1a1aa" }
+]);
+
+/** JSON payload editor: theme + highlight + json language + line wrapping */
+export const jsonEditorExtensions = [
+  editorTheme,
+  syntaxHighlighting(editorHighlight),
+  json(),
+  EditorView.lineWrapping
+];
+
+/** Plain expression editor (JMESPath etc.): theme + line wrapping only */
+export const expressionEditorExtensions = [editorTheme, EditorView.lineWrapping];

--- a/src/dashboard/src/utils/styles.ts
+++ b/src/dashboard/src/utils/styles.ts
@@ -1,0 +1,2 @@
+export const inputClasses =
+  "w-full px-3 py-2 text-sm bg-surface-2 border border-border rounded-lg text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-1 focus:ring-accent/50 focus:border-accent/50 transition-colors";


### PR DESCRIPTION
## Summary

Five findings from the dashboard-expert audit, batched as the **consolidation pass before F12** so the TanStack Query migration starts from a deduplicated base. Net reductions in three files, two new shared utilities, one new shared component, and a meaningful bundle improvement on the Endpoints page. **DPR-2 from the dashboard-improvement plan.**

## What changed

### 1. `<StatusBadge>` — single source of truth
Three pages each carried a near-identical inline status-pill component (`DashboardPage`, `MessagesPage`, `DeliveryLogPage`). Extracted to `src/dashboard/src/components/StatusBadge.tsx` with a single `kind → { label, dotClass, badgeClass }` map. Unknown kinds fall back to a muted pill instead of throwing. `EndpointHealthBadge` stays separate (different state domain).

### 2. `inputClasses` constant
The same 200-character Tailwind class string repeated in four files. Extracted to `src/dashboard/src/utils/styles.ts`.

### 3. Shared CodeMirror theme
`TransformSection` and `EndpointTestModal` each defined their own copy of `editorTheme` + `editorHighlight` + `editorExtensions`. Extracted to `src/dashboard/src/utils/editorTheme.ts` exporting `editorTheme`, `editorHighlight`, `jsonEditorExtensions`, `expressionEditorExtensions`. Vite no longer bundles two copies.

### 4. Lazy-load CodeMirror
`EndpointsPage` was lazy-loaded at the route level but eagerly imported `TransformSection` + `EndpointTestModal` at module scope, dragging in the 1.4 MB CodeMirror bundle on first navigation to Endpoints. Both heavy components are now wrapped in `React.lazy()` with a minimal `<Suspense fallback>`.

**Build delta**:
```
EndpointsPage-Dy-XjpF-.js     18.50 kB │ gzip:   4.79 kB     ← shrunk
codemirror-Dfk95MP9.js     1,465.68 kB │ gzip: 467.56 kB     ← own chunk now
```

### 5. `parseError` → `ApiError` + `ApiErrorException`
`dashboardApi.parseError` returned a flattened string, so a server 422 with field-level hints lost the field-name routing. Now returns a typed `ApiError { message, fieldErrors? }` and throws an `ApiErrorException` (extends `Error`). Existing `e.message` call sites keep working unchanged; forms that want field-level routing opt in via `instanceof ApiErrorException` and read `.fieldErrors`. Field-level wiring lands in DPR-3.

### Bonus fix folded in

- `theme="dark"` was missing on the `<CodeMirror>` element inside `EndpointTestModal.tsx` (slipped through when the modal was first written in PR #55). The payload editor was rendering against CodeMirror's default white preset on top of the dark modal surface (user spotted it in a screenshot). Added the prop.

## Test plan

- [x] `bun run typecheck && bun run lint && bun run build` — clean. Bundle confirms codemirror is its own chunk; EndpointsPage shrunk to 18.5 kB.
- [ ] CI green
- [ ] Smoke: open Endpoints page → CodeMirror not in initial chunk; open test webhook modal → editor loads dark, no white flash.

## Follow-ups (not in this PR)

- **DPR-1** (correctness + a11y): focus trap + dialog role/aria + SignalR stale-on-reconnect + loading skeleton + flash + floating promise.
- **F12** (TanStack Query): replaces the manual debounce in `DashboardPage` (PR #66) + the `useEffect` Promise-microtask workarounds across all six pages.
- **DPR-3** (UX polish): wires the new `ApiErrorException.fieldErrors` into the create modals + form-level routing.