### PR TITLE
fix(dashboard): a11y on Modal, reconnect-safe SignalR cache, loading skeleton, no flash, awaited refetches

### DIFF
--- a/src/dashboard/src/components/Modal.tsx
+++ b/src/dashboard/src/components/Modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type ReactNode } from "react";
+import { useEffect, useId, useRef, type ReactNode } from "react";
 import { X } from "lucide-react";
 
 interface ModalProps {
@@ -11,9 +11,24 @@ interface ModalProps {
   width?: string;
 }
 
+// Selectors that match every focusable element a screen-reader user can land
+// on inside a dialog. Used by the Tab / Shift+Tab focus trap below.
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "textarea:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])"
+].join(",");
+
 export function Modal({ open, onClose, title, description, children, width = "max-w-lg" }: ModalProps) {
   const overlayRef = useRef<HTMLDivElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
+  // Stable IDs so aria-labelledby / aria-describedby actually point at our
+  // rendered nodes — useId is the right primitive for this in React 19.
+  const titleId = useId();
+  const descriptionId = useId();
 
   // Close on Escape
   useEffect(() => {
@@ -33,9 +48,49 @@ export function Modal({ open, onClose, title, description, children, width = "ma
     return () => { document.body.style.overflow = prev; };
   }, [open]);
 
-  // Focus trap — focus panel on open
+  // Focus the panel on open so screen readers immediately announce the dialog
+  // title (paired with role="dialog" + aria-labelledby below).
   useEffect(() => {
     if (open) panelRef.current?.focus();
+  }, [open]);
+
+  // Tab / Shift+Tab focus trap. Without this a keyboard user can tab right
+  // out of the modal and into the page underneath, which fails the screen-
+  // reader contract for role="dialog" with aria-modal="true".
+  useEffect(() => {
+    if (!open) return;
+    const handleTab = (e: KeyboardEvent) => {
+      if (e.key !== "Tab") return;
+      const panel = panelRef.current;
+      if (!panel) return;
+
+      const focusable = Array.from(
+        panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+      ).filter((el) => !el.hasAttribute("disabled") && el.offsetParent !== null);
+
+      if (focusable.length === 0) {
+        // Nothing focusable inside the modal — keep focus pinned to the panel
+        // itself so Tab doesn't leak out to the document.
+        e.preventDefault();
+        panel.focus();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+
+      if (e.shiftKey && (active === first || active === panel)) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleTab);
+    return () => document.removeEventListener("keydown", handleTab);
   }, [open]);
 
   if (!open) return null;
@@ -53,17 +108,24 @@ export function Modal({ open, onClose, title, description, children, width = "ma
     >
       <div
         ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={description ? descriptionId : undefined}
         tabIndex={-1}
         className={`${width} w-full rounded-xl border border-border bg-surface-1 shadow-2xl outline-none`}
       >
         {/* Header */}
         <div className="flex items-start justify-between gap-3 px-5 pt-4 pb-3 border-b border-border-subtle">
           <div className="min-w-0">
-            <h2 className="text-sm font-semibold text-text-primary">{title}</h2>
-            {description && <p className="text-xs text-text-muted mt-0.5">{description}</p>}
+            <h2 id={titleId} className="text-sm font-semibold text-text-primary">{title}</h2>
+            {description && (
+              <p id={descriptionId} className="text-xs text-text-muted mt-0.5">{description}</p>
+            )}
           </div>
           <button
             onClick={onClose}
+            aria-label="Close dialog"
             className="shrink-0 p-1 rounded-md text-text-muted hover:text-text-primary hover:bg-surface-3 transition-colors"
           >
             <X className="w-4 h-4" />

--- a/src/dashboard/src/hooks/useDeliveryFeed.ts
+++ b/src/dashboard/src/hooks/useDeliveryFeed.ts
@@ -95,9 +95,13 @@ export function useDeliveryFeed(maxEvents = 50) {
     };
 
     const handleReconnected = () => {
-      if (isMounted) {
-        setConnected(true);
-      }
+      if (!isMounted) return;
+      setConnected(true);
+      // Drop any cached health change so the consumer sees a clean slate.
+      // Otherwise an EndpointsPage that resubscribes after a reconnect would
+      // re-apply a stale snapshot from before the disconnect, masking the
+      // server's authoritative state from the next overview/list refetch.
+      setLastHealthChange(null);
     };
 
     connection.on("DeliverySuccess", handleSuccess);

--- a/src/dashboard/src/pages/ApplicationsPage.tsx
+++ b/src/dashboard/src/pages/ApplicationsPage.tsx
@@ -197,7 +197,9 @@ export function ApplicationsPage() {
       setCreateResult({ apiKey: result.apiKey, signingSecret: result.signingSecret });
       setCreateName("");
       setShowCreate(false);
-      fetchApps();
+      // Await the refetch so any failure surfaces as a real error in this
+      // try-block rather than as an unhandled promise rejection.
+      await fetchApps();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to create application");
     } finally {
@@ -215,7 +217,7 @@ export function ApplicationsPage() {
       onConfirm: async () => {
         try {
           await deleteApplication(id);
-          fetchApps();
+          await fetchApps();
         } catch (e) {
           setError(e instanceof Error ? e.message : "Failed to delete application");
         }

--- a/src/dashboard/src/pages/DeliveryLogPage.tsx
+++ b/src/dashboard/src/pages/DeliveryLogPage.tsx
@@ -47,10 +47,24 @@ export function DeliveryLogPage() {
 
   if (loading) {
     return (
-      <div className="space-y-4 animate-fade-in-up">
+      <div className="space-y-4 animate-fade-in-up" aria-busy="true">
         <div>
           <h1 className="text-lg font-semibold">Delivery Log</h1>
-          <p className="text-sm text-text-muted mt-0.5">Loading...</p>
+          <p className="text-sm text-text-muted mt-0.5">Loading delivery details…</p>
+        </div>
+        {/* Skeleton card mirroring the rendered shape so the layout doesn't
+            shift on completion — header strip + two attempt blocks. */}
+        <div className="rounded-xl border border-border bg-surface-1 p-4 space-y-3">
+          <div className="h-5 w-1/3 bg-surface-2 rounded animate-pulse" />
+          <div className="h-3 w-2/3 bg-surface-2 rounded animate-pulse" />
+          <div className="grid grid-cols-2 gap-3 pt-2">
+            <div className="h-12 bg-surface-2 rounded animate-pulse" />
+            <div className="h-12 bg-surface-2 rounded animate-pulse" />
+          </div>
+        </div>
+        <div className="rounded-xl border border-border bg-surface-1 p-4 space-y-2">
+          <div className="h-4 w-1/4 bg-surface-2 rounded animate-pulse" />
+          <div className="h-20 bg-surface-2 rounded animate-pulse" />
         </div>
       </div>
     );

--- a/src/dashboard/src/pages/EndpointsPage.tsx
+++ b/src/dashboard/src/pages/EndpointsPage.tsx
@@ -63,6 +63,10 @@ const closedConfirm: ConfirmState = {
 export function EndpointsPage() {
   const [endpoints, setEndpoints] = useState<EndpointRow[]>([]);
   const [applications, setApplications] = useState<ApplicationRow[]>([]);
+  // Tracks the applications-list fetch separately from the endpoints fetch so
+  // we don't flash "Create an application first" before the apps response
+  // lands on first render — which read as confusing on a fresh page load.
+  const [applicationsLoading, setApplicationsLoading] = useState(true);
   const [eventTypesByApp, setEventTypesByApp] = useState<Record<string, EventTypeSummary[]>>({});
   const [pagination, setPagination] = useState<Pagination | null>(null);
   const [page, setPage] = useState(1);
@@ -141,6 +145,7 @@ export function EndpointsPage() {
         setApplications(result.data);
         if (result.data.length > 0) setCreateAppId((c) => c || result.data[0].id);
       } catch { /* no-op */ }
+      finally { setApplicationsLoading(false); }
     };
     fetchApplications();
   }, []);
@@ -376,7 +381,11 @@ export function EndpointsPage() {
           <span className="text-xs text-text-muted">{pagination ? `${pagination.totalCount} total` : ""}</span>
         </div>
 
-        {applications.length === 0 ? (
+        {applicationsLoading ? (
+          <div className="flex items-center justify-center py-12">
+            <span className="text-sm text-text-muted">Loading...</span>
+          </div>
+        ) : applications.length === 0 ? (
           <p className="text-sm text-text-muted px-4 py-8 text-center">Create an application first before adding endpoints.</p>
         ) : loading ? (
           <div className="flex items-center justify-center py-12">


### PR DESCRIPTION
## Summary

Six findings from the dashboard-expert audit, batched as the **correctness + accessibility pass before F12**. The Modal a11y items are real screen-reader blockers (the dialog was unlabelled and focus-leaky); the rest are UX polish that compound. **DPR-1 from the dashboard-improvement plan.**

## What changed

### Modal a11y — the focus-leaky, unlabelled dialog (audit #9 + #10) — **🔴 a11y blocker**

Before: panel had `tabIndex={-1}` and that was it. No `role="dialog"`, no `aria-modal`, no `aria-labelledby`, and Tab/Shift+Tab would walk straight out of the modal into the document underneath. Screen readers couldn't even announce that they were inside a dialog.

Fixed all four:
- Panel carries `role="dialog"` + `aria-modal="true"` with `useId`-stable `aria-labelledby` (and `aria-describedby` when a description is passed).
- Close button got `aria-label="Close dialog"`.
- New `keydown` handler implements a Tab / Shift+Tab focus trap that walks the panel's focusable descendants (`a[href], button:not([disabled]), input:not([disabled]), …`) and wraps focus between first/last. When nothing inside is focusable, focus pins to the panel itself rather than escaping.

### `useDeliveryFeed` reconnect cleanup (audit #19)

`onreconnected` now resets `lastHealthChange` to `null`. Without this, an `EndpointsPage` that re-subscribed after a transient disconnect would re-apply the pre-disconnect snapshot from cache, masking whatever the server may have transitioned to during the gap. The next overview / list refetch is now the source of truth on reconnect.

### `DeliveryLogPage` loading skeleton (audit #22)

Replaced the bare `<p>Loading...</p>` with a layout-preserving skeleton card (header strip + two attempt blocks) plus `aria-busy` on the wrapper. No layout shift on completion.

### `EndpointsPage` "Create an application first" flash (audit #23)

The page was checking `applications.length === 0` **before** the apps fetch had returned, briefly flashing the empty-state message on every cold load. New `applicationsLoading` state gates that branch so the spinner shows until the apps fetch completes; only then does the empty / endpoints branch render.

### `ApplicationsPage` floating promise (audit #26)

Both `handleCreate` and the delete-confirm `onConfirm` called `fetchApps()` without awaiting it, so any refetch rejection became an unhandled promise. Both now await, so failures land inside the surrounding `try…catch` / `setError` flow where they belong.

## Test plan

- [x] `bun run typecheck && bun run lint && bun run build` — clean
- [ ] CI green
- [ ] Smoke (manual):
  - Tab into a modal — focus stays inside; Shift+Tab from the first input lands on the close button.
  - Open a modal with a screen reader — title is announced via `aria-labelledby`.
  - On a fresh page load, `EndpointsPage` shows a spinner instead of "Create an application first" before the apps response lands.

## Follow-ups (not in this PR)

- **F12** (TanStack Query): replaces the manual debounce in `DashboardPage` (PR #66) and the `useEffect` Promise-microtask workarounds across the six pages.
- **DPR-3** (UX polish): wires the new `ApiErrorException.fieldErrors` from PR #67 into form-level field routing + smaller polish items.