### PR TITLE
feat(dashboard): bring in TanStack Query, migrate DeliveryLogPage and EventTypesPage (F12-PR-1)

### DIFF
--- a/src/dashboard/bun.lock
+++ b/src/dashboard/bun.lock
@@ -11,6 +11,7 @@
         "@codemirror/view": "^6.41.1",
         "@lezer/highlight": "^1.2.3",
         "@microsoft/signalr": "^10.0.0",
+        "@tanstack/react-query": "^5.100.9",
         "@uiw/react-codemirror": "^4.25.9",
         "lucide-react": "1.14.0",
         "react": "^19.2.5",
@@ -214,6 +215,10 @@
     "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.2.4", "", { "os": "win32", "cpu": "x64" }, "sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw=="],
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.2.4", "", { "dependencies": { "@tailwindcss/node": "4.2.4", "@tailwindcss/oxide": "4.2.4", "tailwindcss": "4.2.4" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw=="],
+
+    "@tanstack/query-core": ["@tanstack/query-core@5.100.9", "", {}, "sha512-SJSFw1S8+kQ0+knv/XGfrbocWoAlT7vDKsSImtLx3ZPQmEcR46hkDjLSvynSy25N8Ms4tIEini1FuBd5k7IscQ=="],
+
+    "@tanstack/react-query": ["@tanstack/react-query@5.100.9", "", { "dependencies": { "@tanstack/query-core": "5.100.9" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-Oa44XkaI3kCNN6ME0KByU3xT3SEUNOMfZpHxL6+wFoTm+OeUFYHKdeYVe0aOXlRDm/f15sgLwEt2HDorIdW8+A=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 

--- a/src/dashboard/package.json
+++ b/src/dashboard/package.json
@@ -18,6 +18,7 @@
     "@codemirror/view": "^6.41.1",
     "@lezer/highlight": "^1.2.3",
     "@microsoft/signalr": "^10.0.0",
+    "@tanstack/react-query": "^5.100.9",
     "@uiw/react-codemirror": "^4.25.9",
     "lucide-react": "1.14.0",
     "react": "^19.2.5",

--- a/src/dashboard/src/App.tsx
+++ b/src/dashboard/src/App.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense } from "react";
 import { BrowserRouter, Navigate, Route, Routes } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AuthProvider } from "./auth/AuthContext";
 import { AppShell } from "./layout/AppShell";
 import { LoginPage } from "./pages/LoginPage";
@@ -33,11 +34,31 @@ function PageFallback() {
   );
 }
 
+// Single QueryClient for the whole dashboard. Defaults are tuned for an
+// authenticated long-lived dashboard, not a public site:
+// - staleTime 30 s: the SignalR feed is the live channel; HTTP fetches just
+//   refresh the static aggregates, so a 30-second stale window keeps the
+//   network cost down without hiding meaningful changes.
+// - retry 1: dashboard requests are idempotent reads; one transient retry is
+//   useful, but stacking five buys nothing the SignalR layer doesn't already.
+// - refetchOnWindowFocus false: a long-running dashboard otherwise fires a
+//   storm of refetches every time the user alt-tabs back.
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+      retry: 1,
+      refetchOnWindowFocus: false
+    }
+  }
+});
+
 export function App() {
   return (
     <RouteErrorBoundary>
-      <AuthProvider>
-        <BrowserRouter>
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <BrowserRouter>
           <Routes>
           <Route path="/login" element={<LoginPage />} />
 
@@ -97,7 +118,8 @@ export function App() {
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>
         </BrowserRouter>
-      </AuthProvider>
+        </AuthProvider>
+      </QueryClientProvider>
     </RouteErrorBoundary>
   );
 }

--- a/src/dashboard/src/pages/DeliveryLogPage.tsx
+++ b/src/dashboard/src/pages/DeliveryLogPage.tsx
@@ -1,10 +1,9 @@
-import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router";
+import { useQuery } from "@tanstack/react-query";
 import { PayloadViewer } from "../components/PayloadViewer";
 import { RetryButton } from "../components/RetryButton";
 import { StatusBadge } from "../components/StatusBadge";
 import { getMessage } from "../api/dashboardApi";
-import type { MessageDetail } from "../types";
 import { formatLocaleDateTime } from "../utils/dateTime";
 import {
   ArrowLeft,
@@ -18,32 +17,25 @@ import {
 
 export function DeliveryLogPage() {
   const { messageId } = useParams<{ messageId?: string }>();
-  const [message, setMessage] = useState<MessageDetail | null>(null);
-  const [loading, setLoading] = useState<boolean>(!!messageId);
-  const [fetchError, setFetchError] = useState("");
 
+  // First page in the F12 migration. The previous useEffect + useState +
+  // cancelled-flag rig becomes one useQuery call: TanStack handles cancellation
+  // on unmount + dedup on remount + the staleTime configured in App.tsx.
+  const messageQuery = useQuery({
+    queryKey: ["message", messageId],
+    queryFn: () => getMessage(messageId!),
+    enabled: !!messageId
+  });
+
+  const message = messageQuery.data ?? null;
+  const loading = !!messageId && messageQuery.isLoading;
   const error = !messageId
     ? "No message ID provided. Navigate here from the Messages page."
-    : fetchError;
-
-  useEffect(() => {
-    if (!messageId) return;
-
-    let cancelled = false;
-    async function load() {
-      try {
-        const data = await getMessage(messageId!);
-        if (!cancelled) setMessage(data);
-      } catch (e) {
-        if (!cancelled) setFetchError(e instanceof Error ? e.message : "Failed to load message");
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    }
-
-    void load();
-    return () => { cancelled = true; };
-  }, [messageId]);
+    : messageQuery.error instanceof Error
+      ? messageQuery.error.message
+      : messageQuery.error
+        ? "Failed to load message"
+        : "";
 
   if (loading) {
     return (

--- a/src/dashboard/src/pages/EventTypesPage.tsx
+++ b/src/dashboard/src/pages/EventTypesPage.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ConfirmModal } from "../components/ConfirmModal";
 import { Modal } from "../components/Modal";
 import { Select } from "../components/Select";
@@ -9,7 +10,7 @@ import {
   listDashboardEventTypes,
   updateDashboardEventType
 } from "../api/dashboardApi";
-import type { ApplicationRow, EventTypeSummary } from "../types";
+import type { EventTypeSummary } from "../types";
 import {
   Plus,
   Pencil,
@@ -41,22 +42,57 @@ const closedConfirm: ConfirmState = {
 };
 
 export function EventTypesPage() {
-  const [applications, setApplications] = useState<ApplicationRow[]>([]);
+  const queryClient = useQueryClient();
   const [selectedAppId, setSelectedAppId] = useState("");
   const [includeArchived, setIncludeArchived] = useState(false);
-  const [eventTypes, setEventTypes] = useState<EventTypeSummary[]>([]);
-  const [loading, setLoading] = useState(true);
+  // Mutation errors live in a local string state; the two queries below
+  // surface their own loading/error already, so we don't double-track.
   const [error, setError] = useState("");
+
+  const applicationsQuery = useQuery({
+    queryKey: ["applications"],
+    queryFn: () => listApplications(1, 200)
+  });
+  // Memoise so dependent useEffect / useMemo hooks don't re-fire on every
+  // render just because the fallback `[]` would otherwise be a fresh array.
+  const applications = useMemo(() => applicationsQuery.data?.data ?? [], [applicationsQuery.data]);
+
+  // Default to the first available application on first land. Microtask defer
+  // matches the codebase's existing pattern for set-state-in-effect.
+  useEffect(() => {
+    if (applications.length === 0) return;
+    void Promise.resolve().then(() => {
+      setSelectedAppId((current) => current || applications[0].id);
+    });
+  }, [applications]);
+
+  const eventTypesQuery = useQuery({
+    queryKey: ["eventTypes", selectedAppId, includeArchived],
+    queryFn: () => listDashboardEventTypes(selectedAppId, includeArchived),
+    enabled: !!selectedAppId
+  });
+  const eventTypes = useMemo(() => eventTypesQuery.data ?? [], [eventTypesQuery.data]);
+  const loading = eventTypesQuery.isLoading && !!selectedAppId;
+
+  const fetchError =
+    (applicationsQuery.error instanceof Error && applicationsQuery.error.message) ||
+    (eventTypesQuery.error instanceof Error && eventTypesQuery.error.message) ||
+    "";
+  const displayError = error || fetchError;
+
+  // Invalidate the eventTypes cache whenever any mutation succeeds; staleTime
+  // (30 s in App.tsx) governs background refresh, but post-mutation we want
+  // an immediate refetch so the table reflects the change.
+  const invalidateEventTypes = () =>
+    queryClient.invalidateQueries({ queryKey: ["eventTypes", selectedAppId, includeArchived] });
 
   const [showCreate, setShowCreate] = useState(false);
   const [createName, setCreateName] = useState("");
   const [createDescription, setCreateDescription] = useState("");
-  const [creating, setCreating] = useState(false);
 
   const [editingEventTypeId, setEditingEventTypeId] = useState<string | null>(null);
   const [editName, setEditName] = useState("");
   const [editDescription, setEditDescription] = useState("");
-  const [updating, setUpdating] = useState(false);
 
   const [confirm, setConfirm] = useState<ConfirmState>(closedConfirm);
 
@@ -70,46 +106,28 @@ export function EventTypesPage() {
     [editingEventTypeId, eventTypes]
   );
 
-  const fetchEventTypes = useCallback(async () => {
-    if (!selectedAppId) {
-      setEventTypes([]);
-      setLoading(false);
-      return;
-    }
+  const createMutation = useMutation({
+    mutationFn: (vars: { appId: string; name: string; description?: string }) =>
+      createDashboardEventType({ appId: vars.appId, name: vars.name, description: vars.description }),
+    onSuccess: () => invalidateEventTypes(),
+    onError: (e: unknown) => setError(e instanceof Error ? e.message : "Failed to create event type")
+  });
 
-    setLoading(true);
-    setError("");
-    try {
-      const rows = await listDashboardEventTypes(selectedAppId, includeArchived);
-      setEventTypes(rows);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to load event types");
-    } finally {
-      setLoading(false);
-    }
-  }, [includeArchived, selectedAppId]);
+  const updateMutation = useMutation({
+    mutationFn: (vars: { id: string; name: string; description?: string }) =>
+      updateDashboardEventType(vars.id, { name: vars.name, description: vars.description }),
+    onSuccess: () => invalidateEventTypes(),
+    onError: (e: unknown) => setError(e instanceof Error ? e.message : "Failed to update event type")
+  });
 
-  useEffect(() => {
-    const fetchApplications = async () => {
-      try {
-        const result = await listApplications(1, 200);
-        setApplications(result.data);
-        if (result.data.length > 0) {
-          setSelectedAppId((current) => current || result.data[0].id);
-        }
-      } catch (e) {
-        setError(e instanceof Error ? e.message : "Failed to load applications");
-      }
-    };
+  const archiveMutation = useMutation({
+    mutationFn: (id: string) => archiveDashboardEventType(id),
+    onSuccess: () => invalidateEventTypes(),
+    onError: (e: unknown) => setError(e instanceof Error ? e.message : "Failed to archive event type")
+  });
 
-    fetchApplications();
-  }, []);
-
-  useEffect(() => {
-    Promise.resolve()
-      .then(() => fetchEventTypes())
-      .catch(() => { /* surfaced via fetchEventTypes' setError */ });
-  }, [fetchEventTypes]);
+  const creating = createMutation.isPending;
+  const updating = updateMutation.isPending;
 
   const resetCreateForm = () => {
     setCreateName("");
@@ -123,26 +141,19 @@ export function EventTypesPage() {
   };
 
   const handleCreate = async () => {
-    if (!selectedAppId || !createName.trim()) {
-      return;
-    }
+    if (!selectedAppId || !createName.trim()) return;
 
-    setCreating(true);
     setError("");
     try {
-      await createDashboardEventType({
+      await createMutation.mutateAsync({
         appId: selectedAppId,
         name: createName.trim(),
         description: createDescription.trim() || undefined
       });
-
       setShowCreate(false);
       resetCreateForm();
-      await fetchEventTypes();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to create event type");
-    } finally {
-      setCreating(false);
+    } catch {
+      // Already surfaced via createMutation.onError → setError.
     }
   };
 
@@ -153,24 +164,18 @@ export function EventTypesPage() {
   };
 
   const handleUpdate = async () => {
-    if (!editingEventType || !editName.trim()) {
-      return;
-    }
+    if (!editingEventType || !editName.trim()) return;
 
-    setUpdating(true);
     setError("");
     try {
-      await updateDashboardEventType(editingEventType.id, {
+      await updateMutation.mutateAsync({
+        id: editingEventType.id,
         name: editName.trim(),
         description: editDescription.trim() || undefined
       });
-
       cancelEdit();
-      await fetchEventTypes();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to update event type");
-    } finally {
-      setUpdating(false);
+    } catch {
+      // Already surfaced via updateMutation.onError → setError.
     }
   };
 
@@ -181,13 +186,8 @@ export function EventTypesPage() {
       description: `Archive "${eventType.name}"? Existing messages stay intact, but this type cannot be used for new sends.`,
       confirmLabel: "Archive",
       variant: "danger",
-      onConfirm: async () => {
-        try {
-          await archiveDashboardEventType(eventType.id);
-          await fetchEventTypes();
-        } catch (e) {
-          setError(e instanceof Error ? e.message : "Failed to archive event type");
-        }
+      onConfirm: () => {
+        archiveMutation.mutate(eventType.id);
       }
     });
   };
@@ -209,10 +209,10 @@ export function EventTypesPage() {
         </button>
       </div>
 
-      {error && (
+      {displayError && (
         <div className="flex items-center gap-2 text-danger text-xs bg-danger-soft border border-danger/20 rounded-lg px-3 py-2 animate-fade-in-up">
           <AlertCircle className="w-3.5 h-3.5 shrink-0" />
-          {error}
+          {displayError}
           <button onClick={() => setError("")} className="ml-auto text-danger/60 hover:text-danger">
             <X className="w-3 h-3" />
           </button>


### PR DESCRIPTION
## Summary

First slice of the F12 useEffect refactor: install `@tanstack/react-query`, configure a single `QueryClientProvider` with dashboard-tuned defaults, and migrate the two smallest pages (`DeliveryLogPage`, `EventTypesPage`) so the QueryClient setup is proven before the bigger pages move in F12-PR-2 / F12-PR-3.

## Why TanStack Query (and not SWR)

Per the dashboard-expert plan: SWR is ~5 KB lighter but `queryClient.invalidateQueries(["endpoints"])` granular by key is the path forward for the F7 SignalR `lastHealthChange` hookup landing in F12-PR-3, and the per-page `Promise.resolve().then(fetchX)` workarounds collapse cleanly into `useQuery` with the right `staleTime`. SWR's `mutate(key)` covers the simple case but cascade invalidation across multiple bound queries is awkward.

## What changed

### `App.tsx` — `QueryClientProvider` setup

Wraps the tree below `RouteErrorBoundary` and above `AuthProvider`. Dashboard-tuned defaults:

```ts
staleTime: 30_000,        // SignalR is the live channel; HTTP just refreshes static aggregates
retry: 1,                 // idempotent reads, one transient retry is plenty
refetchOnWindowFocus: false  // long-running dashboard, no alt-tab refetch storm
```

### `DeliveryLogPage.tsx`

Old: `useState` (data + loading + error) + `useEffect` with a `cancelled` flag + manual `setLoading(false)`.

New: a single `useQuery({ queryKey: ["message", messageId], queryFn: () => getMessage(messageId!), enabled: !!messageId })`. TanStack handles cancellation on unmount, dedup on remount, and the configured staleTime. Rendered states collapse to `messageQuery.{data, isLoading, error}`.

### `EventTypesPage.tsx`

- **Two queries**: `["applications"]` + `["eventTypes", selectedAppId, includeArchived]`. The latter is `enabled: !!selectedAppId` so it doesn't fire before an app is picked.
- **Three mutations**: create / update / archive. Each one's `onSuccess` calls `queryClient.invalidateQueries({ queryKey: ["eventTypes", selectedAppId, includeArchived] })` so the table refreshes without a manual `fetchEventTypes()` call.
- **Error surface** unchanged: list-error + mutation-error collapse into one `displayError` string so the existing banner markup keeps working.
- The microtask defer that workarounds the `react-hooks/set-state-in-effect` lint rule still appears once, on the "default to first app" effect — that's intentional and matches the codebase's existing pattern; further pages migrate the same way in PR-2.

### Dependencies

- **`@tanstack/react-query@5.100.9`** is the only new dep in the F12 series. `bun.lock` + `package.json` updated.
- No code changes to `bun.lock` other than the install delta. Codemirror chunk unchanged.

## Migration order (rest of F12)

1. ✅ **F12-PR-1 (this PR)**: setup + DeliveryLogPage + EventTypesPage (least blast radius).
2. F12-PR-2: ApplicationsPage + MessagesPage.
3. F12-PR-3: EndpointsPage + DashboardPage. The DashboardPage migration deletes PR #66's manual debounce rig — `queryClient.invalidateQueries(["overview", "timeline"])` from the SignalR feed replaces it.

## Test plan

- [x] `bun run typecheck && bun run lint && bun run build` — clean
- [ ] CI green
- [ ] Smoke: open a delivery log entry, confirm it loads + shows skeleton during load. Open Event Types, switch apps, archive one, confirm row disappears without a manual refresh.