### PR TITLE
feat(dashboard): migrate ApplicationsPage and MessagesPage to TanStack Query (F12-PR-2)

### DIFF
--- a/src/dashboard/src/pages/ApplicationsPage.tsx
+++ b/src/dashboard/src/pages/ApplicationsPage.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState, useCallback } from "react";
+import { useMemo, useState } from "react";
+import { useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   listApplications,
   createApplication,
@@ -9,7 +10,7 @@ import {
 } from "../api/dashboardApi";
 import { Modal } from "../components/Modal";
 import { ConfirmModal } from "../components/ConfirmModal";
-import type { ApplicationRow, EndpointRow, Pagination } from "../types";
+import type { EndpointRow } from "../types";
 import { formatLocaleDate } from "../utils/dateTime";
 import {
   Plus,
@@ -100,20 +101,73 @@ function summarizeEndpoints(total: number, endpoints: EndpointRow[]): Applicatio
   return { total, disabled, healthy, degraded, failed };
 }
 
+// Walks every endpoint page for a given app and returns the summary tuple.
+// Pulled out of the component so useQueries can keep its queryFn pure.
+async function loadAppEndpointStats(appId: string): Promise<ApplicationEndpointStats> {
+  const endpoints: EndpointRow[] = [];
+  let currentPage = 1;
+  let totalPages = 1;
+  let totalCount = 0;
+
+  do {
+    const result = await listEndpoints({ appId, page: currentPage, pageSize: 200 });
+    endpoints.push(...result.data);
+    if (currentPage === 1) {
+      totalPages = result.pagination.totalPages;
+      totalCount = result.pagination.totalCount;
+    }
+    currentPage++;
+  } while (currentPage <= totalPages);
+
+  return summarizeEndpoints(totalCount, endpoints);
+}
+
 export function ApplicationsPage() {
-  const [apps, setApps] = useState<ApplicationRow[]>([]);
-  const [appStats, setAppStats] = useState<Record<string, ApplicationEndpointStats>>({});
-  const [pagination, setPagination] = useState<Pagination | null>(null);
+  const queryClient = useQueryClient();
   const [page, setPage] = useState(1);
-  const [loading, setLoading] = useState(true);
-  const [loadingStats, setLoadingStats] = useState(false);
+  // Mutation errors land here; query errors collapse into displayError below.
   const [error, setError] = useState("");
+
+  const applicationsQuery = useQuery({
+    queryKey: ["applications", page],
+    queryFn: () => listApplications(page, 20)
+  });
+
+  const apps = useMemo(() => applicationsQuery.data?.data ?? [], [applicationsQuery.data]);
+  const pagination = applicationsQuery.data?.pagination ?? null;
+  const loading = applicationsQuery.isLoading;
+
+  // Fan-out per-app endpoint stats. useQueries dedup-caches each app's
+  // result independently so refreshing the apps list doesn't re-walk every
+  // endpoint page when most apps haven't changed.
+  const appStatsQueries = useQueries({
+    queries: apps.map((app) => ({
+      queryKey: ["app-stats", app.id],
+      queryFn: () => loadAppEndpointStats(app.id)
+    }))
+  });
+
+  const appStats = useMemo(() => {
+    const map: Record<string, ApplicationEndpointStats> = {};
+    appStatsQueries.forEach((q, idx) => {
+      const app = apps[idx];
+      if (app && q.data) map[app.id] = q.data;
+    });
+    return map;
+  }, [appStatsQueries, apps]);
+
+  const loadingStats = appStatsQueries.some((q) => q.isLoading);
+
+  const fetchError =
+    applicationsQuery.error instanceof Error ? applicationsQuery.error.message : "";
+  const displayError = error || fetchError;
+
+  const invalidateApplications = () => queryClient.invalidateQueries({ queryKey: ["applications"] });
 
   // Create modal
   const [showCreate, setShowCreate] = useState(false);
   const [createName, setCreateName] = useState("");
   const [createResult, setCreateResult] = useState<{ apiKey: string; signingSecret: string } | null>(null);
-  const [creating, setCreating] = useState(false);
 
   // Secret reveal
   const [revealedKey, setRevealedKey] = useState<{ id: string; apiKey: string } | null>(null);
@@ -122,89 +176,41 @@ export function ApplicationsPage() {
   // Confirm modal
   const [confirm, setConfirm] = useState<ConfirmState>(closedConfirm);
 
-  const fetchAppStats = useCallback(async (rows: ApplicationRow[]) => {
-    if (rows.length === 0) {
-      setAppStats({});
-      return;
-    }
-
-    setLoadingStats(true);
-    try {
-      const entries = await Promise.all(rows.map(async (app) => {
-        const endpoints: EndpointRow[] = [];
-        let currentPage = 1;
-        let totalPages = 1;
-        let totalCount = 0;
-
-        do {
-          const result = await listEndpoints({ appId: app.id, page: currentPage, pageSize: 200 });
-          endpoints.push(...result.data);
-
-          if (currentPage === 1) {
-            totalPages = result.pagination.totalPages;
-            totalCount = result.pagination.totalCount;
-          }
-
-          currentPage++;
-        } while (currentPage <= totalPages);
-
-        return [app.id, summarizeEndpoints(totalCount, endpoints)] as const;
-      }));
-
-      setAppStats(Object.fromEntries(entries));
-    } catch {
-      setAppStats({});
-    } finally {
-      setLoadingStats(false);
-    }
-  }, []);
-
-  const fetchApps = useCallback(async () => {
-    setLoading(true);
-    setError("");
-    try {
-      const result = await listApplications(page, 20);
-      setApps(result.data);
-      setPagination(result.pagination);
-      await fetchAppStats(result.data);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to load applications");
-    } finally {
-      setLoading(false);
-    }
-  }, [fetchAppStats, page]);
-
-  useEffect(() => {
-    let cancelled = false;
-    Promise.resolve()
-      .then(() => fetchApps())
-      .catch(() => { /* surfaced via fetchApps' setError */ })
-      .finally(() => {
-        if (cancelled) {
-          /* component unmounted before fetch settled */
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [fetchApps]);
-
-  const handleCreate = async () => {
-    if (!createName.trim()) return;
-    setCreating(true);
-    try {
-      const result = await createApplication(createName.trim());
+  const createMutation = useMutation({
+    mutationFn: (name: string) => createApplication(name),
+    onSuccess: (result) => {
       setCreateResult({ apiKey: result.apiKey, signingSecret: result.signingSecret });
       setCreateName("");
       setShowCreate(false);
-      // Await the refetch so any failure surfaces as a real error in this
-      // try-block rather than as an unhandled promise rejection.
-      await fetchApps();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to create application");
-    } finally {
-      setCreating(false);
-    }
+      invalidateApplications();
+    },
+    onError: (e: unknown) => setError(e instanceof Error ? e.message : "Failed to create application")
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteApplication(id),
+    onSuccess: () => invalidateApplications(),
+    onError: (e: unknown) => setError(e instanceof Error ? e.message : "Failed to delete application")
+  });
+
+  const rotateKeyMutation = useMutation({
+    mutationFn: (id: string) => rotateApiKey(id),
+    onSuccess: (result, id) => setRevealedKey({ id, apiKey: result.apiKey }),
+    onError: (e: unknown) => setError(e instanceof Error ? e.message : "Failed to rotate key")
+  });
+
+  const rotateSecretMutation = useMutation({
+    mutationFn: (id: string) => rotateSigningSecret(id),
+    onSuccess: (result, id) => setRevealedSecret({ id, signingSecret: result.signingSecret }),
+    onError: (e: unknown) => setError(e instanceof Error ? e.message : "Failed to rotate secret")
+  });
+
+  const creating = createMutation.isPending;
+
+  const handleCreate = () => {
+    if (!createName.trim()) return;
+    setError("");
+    createMutation.mutate(createName.trim());
   };
 
   const requestDelete = (id: string, name: string) => {
@@ -214,13 +220,9 @@ export function ApplicationsPage() {
       description: `Delete "${name}"? This will also delete all its endpoints and messages. This action cannot be undone.`,
       confirmLabel: "Delete",
       variant: "danger",
-      onConfirm: async () => {
-        try {
-          await deleteApplication(id);
-          await fetchApps();
-        } catch (e) {
-          setError(e instanceof Error ? e.message : "Failed to delete application");
-        }
+      onConfirm: () => {
+        setError("");
+        deleteMutation.mutate(id);
       }
     });
   };
@@ -232,13 +234,9 @@ export function ApplicationsPage() {
       description: "The current API key will stop working immediately. Make sure your integrations are ready for the new key.",
       confirmLabel: "Rotate Key",
       variant: "default",
-      onConfirm: async () => {
-        try {
-          const result = await rotateApiKey(id);
-          setRevealedKey({ id, apiKey: result.apiKey });
-        } catch (e) {
-          setError(e instanceof Error ? e.message : "Failed to rotate key");
-        }
+      onConfirm: () => {
+        setError("");
+        rotateKeyMutation.mutate(id);
       }
     });
   };
@@ -250,13 +248,9 @@ export function ApplicationsPage() {
       description: "Webhook consumers will need the new secret to verify signatures. Update all consumers before rotating.",
       confirmLabel: "Rotate Secret",
       variant: "default",
-      onConfirm: async () => {
-        try {
-          const result = await rotateSigningSecret(id);
-          setRevealedSecret({ id, signingSecret: result.signingSecret });
-        } catch (e) {
-          setError(e instanceof Error ? e.message : "Failed to rotate secret");
-        }
+      onConfirm: () => {
+        setError("");
+        rotateSecretMutation.mutate(id);
       }
     });
   };
@@ -279,10 +273,10 @@ export function ApplicationsPage() {
       </div>
 
       {/* Error */}
-      {error && (
+      {displayError && (
         <div className="flex items-center gap-2 text-danger text-xs bg-danger-soft border border-danger/20 rounded-lg px-3 py-2 animate-fade-in-up">
           <AlertCircle className="w-3.5 h-3.5 shrink-0" />
-          {error}
+          {displayError}
           <button onClick={() => setError("")} className="ml-auto text-danger/60 hover:text-danger"><X className="w-3 h-3" /></button>
         </div>
       )}

--- a/src/dashboard/src/pages/MessagesPage.tsx
+++ b/src/dashboard/src/pages/MessagesPage.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router";
 import { RetryButton } from "../components/RetryButton";
 import { Modal } from "../components/Modal";
@@ -6,7 +7,6 @@ import { Select } from "../components/Select";
 import { StatusBadge } from "../components/StatusBadge";
 import { useDeliveryFeed } from "../hooks/useDeliveryFeed";
 import { listApplications, listEndpoints, listMessages, sendDashboardMessage } from "../api/dashboardApi";
-import type { ApplicationRow, MessageRow, Pagination } from "../types";
 import { formatLocaleDateTime } from "../utils/dateTime";
 import { inputClasses } from "../utils/styles";
 import {
@@ -38,10 +38,8 @@ function toIsoOrUndefined(localDateTime: string): string | undefined {
 }
 
 export function MessagesPage() {
-  const [messages, setMessages] = useState<MessageRow[]>([]);
-  const [pagination, setPagination] = useState<Pagination | null>(null);
+  const queryClient = useQueryClient();
   const [page, setPage] = useState(1);
-  const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
   const [eventTypeFilter, setEventTypeFilter] = useState("");
@@ -51,97 +49,103 @@ export function MessagesPage() {
   const [afterFilter, setAfterFilter] = useState("");
   const [beforeFilter, setBeforeFilter] = useState("");
 
-  const [applications, setApplications] = useState<ApplicationRow[]>([]);
-  const [endpointOptions, setEndpointOptions] = useState<Array<{ value: string; label: string }>>([]);
   const [sendAppId, setSendAppId] = useState("");
   const [sendEventType, setSendEventType] = useState("");
   const [sendPayload, setSendPayload] = useState("{}");
   const [sendIdempotencyKey, setSendIdempotencyKey] = useState("");
-  const [sending, setSending] = useState(false);
   const [lastSendAt, setLastSendAt] = useState(0);
   const [sendResult, setSendResult] = useState("");
   const [showSend, setShowSend] = useState(false);
   const { events, connected } = useDeliveryFeed(20);
 
-  const fetchMessages = useCallback(async (showSpinner = true) => {
-    if (showSpinner) setLoading(true);
-    try {
-      const result = await listMessages({
-        appId: appFilter || undefined,
-        endpointId: endpointFilter || undefined,
-        eventType: eventTypeFilter || undefined,
-        status: statusFilter || undefined,
-        after: toIsoOrUndefined(afterFilter),
-        before: toIsoOrUndefined(beforeFilter),
-        page,
-        pageSize: 20
-      });
-      setMessages(result.data);
-      setPagination(result.pagination);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to load messages");
-    } finally {
-      if (showSpinner) setLoading(false);
-    }
-  }, [afterFilter, appFilter, beforeFilter, endpointFilter, eventTypeFilter, page, statusFilter]);
+  const messagesQuery = useQuery({
+    queryKey: ["messages", { page, appFilter, endpointFilter, eventTypeFilter, statusFilter, afterFilter, beforeFilter }],
+    queryFn: () => listMessages({
+      appId: appFilter || undefined,
+      endpointId: endpointFilter || undefined,
+      eventType: eventTypeFilter || undefined,
+      status: statusFilter || undefined,
+      after: toIsoOrUndefined(afterFilter),
+      before: toIsoOrUndefined(beforeFilter),
+      page,
+      pageSize: 20
+    })
+  });
+  const messages = useMemo(() => messagesQuery.data?.data ?? [], [messagesQuery.data]);
+  const pagination = messagesQuery.data?.pagination ?? null;
+  const loading = messagesQuery.isLoading;
 
+  const applicationsQuery = useQuery({
+    queryKey: ["applications-all"],
+    queryFn: () => listApplications(1, 200)
+  });
+  const applications = useMemo(() => applicationsQuery.data?.data ?? [], [applicationsQuery.data]);
+
+  // Default the "send message" form to the first available app once it lands.
   useEffect(() => {
-    Promise.resolve()
-      .then(() => fetchMessages())
-      .catch(() => { /* surfaced via fetchMessages' setError */ });
-  }, [fetchMessages]);
+    if (applications.length === 0) return;
+    void Promise.resolve().then(() => {
+      setSendAppId((c) => c || applications[0].id);
+    });
+  }, [applications]);
 
+  const endpointsQuery = useQuery({
+    queryKey: ["endpoints-for-app", appFilter],
+    queryFn: () => listEndpoints({ appId: appFilter, page: 1, pageSize: 200 }),
+    enabled: !!appFilter
+  });
+  const endpointOptions = useMemo(() => {
+    if (!appFilter || !endpointsQuery.data) return [];
+    return endpointsQuery.data.data.map((endpoint) => ({ value: endpoint.id, label: endpoint.url }));
+  }, [appFilter, endpointsQuery.data]);
+
+  // Drop the endpoint filter when its app context changes / clears so we
+  // don't carry a stale endpointId across an app filter swap.
+  useEffect(() => {
+    if (!appFilter) {
+      void Promise.resolve().then(() => setEndpointFilter(""));
+      return;
+    }
+    if (endpointOptions.length === 0) return;
+    void Promise.resolve().then(() => {
+      setEndpointFilter((current) => (endpointOptions.some((o) => o.value === current) ? current : ""));
+    });
+  }, [appFilter, endpointOptions]);
+
+  const fetchError = messagesQuery.error instanceof Error ? messagesQuery.error.message : "";
+  const displayError = error || fetchError;
+
+  const invalidateMessages = () => queryClient.invalidateQueries({ queryKey: ["messages"] });
+
+  // SignalR delivery events trigger a background invalidation rather than a
+  // direct refetch — TanStack's staleTime + dedup makes the actual network
+  // call only when the cache is stale, so a flood of events coalesces. The
+  // 7-second setInterval poll is gone; staleTime + invalidate replaces it.
   useEffect(() => {
     if (events.length === 0) return;
-    Promise.resolve()
-      .then(() => fetchMessages(false))
-      .catch(() => { /* no-op — silent refresh on real-time event */ });
-  }, [events.length, fetchMessages]);
+    void Promise.resolve().then(() => invalidateMessages());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [events.length]);
 
-  useEffect(() => {
-    const interval = window.setInterval(() => { fetchMessages(false).catch(() => { /* no-op */ }); }, 7000);
-    return () => window.clearInterval(interval);
-  }, [fetchMessages]);
+  const sendMutation = useMutation({
+    mutationFn: (payload: { appId: string; eventType: string; payload: unknown; idempotencyKey?: string }) =>
+      sendDashboardMessage(payload),
+    onSuccess: (result) => {
+      setLastSendAt(Date.now());
+      setSendResult(`Queued ${result.messageIds.length} message(s) for ${result.endpointCount} endpoint(s).`);
+      invalidateMessages();
+    },
+    onError: (e: unknown) => setError(e instanceof Error ? e.message : "Failed to send message")
+  });
+  const sending = sendMutation.isPending;
 
-  useEffect(() => {
-    const fetchApplications = async () => {
-      try {
-        const result = await listApplications(1, 200);
-        setApplications(result.data);
-        if (result.data.length > 0) setSendAppId((c) => c || result.data[0].id);
-      } catch { /* no-op */ }
-    };
-    fetchApplications();
-  }, []);
+  const applyFilters = () => {
+    // setPage triggers a key change on messagesQuery, which re-fetches
+    // automatically. No direct fetch call needed.
+    setPage(1);
+  };
 
-  useEffect(() => {
-    const fetchEndpoints = async () => {
-      if (!appFilter) {
-        setEndpointOptions([]);
-        setEndpointFilter("");
-        return;
-      }
-
-      try {
-        const result = await listEndpoints({ appId: appFilter, page: 1, pageSize: 200 });
-        const options = result.data.map((endpoint) => ({
-          value: endpoint.id,
-          label: endpoint.url
-        }));
-        setEndpointOptions(options);
-        setEndpointFilter((current) => (options.some((option) => option.value === current) ? current : ""));
-      } catch {
-        setEndpointOptions([]);
-        setEndpointFilter("");
-      }
-    };
-
-    fetchEndpoints();
-  }, [appFilter]);
-
-  const applyFilters = () => { setPage(1); fetchMessages(); };
-
-  const handleSendMessage = async () => {
+  const handleSendMessage = () => {
     if (!sendAppId || !sendEventType.trim()) return;
     const now = Date.now();
     if (now - lastSendAt < 800) return;
@@ -149,24 +153,14 @@ export function MessagesPage() {
     let parsedPayload: unknown;
     try { parsedPayload = JSON.parse(sendPayload); } catch { setError("Payload must be valid JSON"); return; }
 
-    setSending(true);
     setError("");
     setSendResult("");
-    try {
-      const result = await sendDashboardMessage({
-        appId: sendAppId,
-        eventType: sendEventType.trim(),
-        payload: parsedPayload,
-        idempotencyKey: sendIdempotencyKey.trim() || undefined
-      });
-      setLastSendAt(now);
-      setSendResult(`Queued ${result.messageIds.length} message(s) for ${result.endpointCount} endpoint(s).`);
-      await fetchMessages();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to send message");
-    } finally {
-      setSending(false);
-    }
+    sendMutation.mutate({
+      appId: sendAppId,
+      eventType: sendEventType.trim(),
+      payload: parsedPayload,
+      idempotencyKey: sendIdempotencyKey.trim() || undefined
+    });
   };
 
   const appOptions = applications.map((a) => ({ value: a.id, label: a.name }));
@@ -190,10 +184,10 @@ export function MessagesPage() {
       </div>
 
       {/* Error */}
-      {error && (
+      {displayError && (
         <div className="flex items-center gap-2 text-danger text-xs bg-danger-soft border border-danger/20 rounded-lg px-3 py-2 animate-fade-in-up">
           <AlertCircle className="w-3.5 h-3.5 shrink-0" />
-          {error}
+          {displayError}
           <button onClick={() => setError("")} className="ml-auto text-danger/60 hover:text-danger"><X className="w-3 h-3" /></button>
         </div>
       )}
@@ -309,7 +303,7 @@ export function MessagesPage() {
                             <ExternalLink className="w-3.5 h-3.5" />
                           </Link>
                           {(msg.status === "Failed" || msg.status === "DeadLetter") && (
-                            <RetryButton messageId={msg.id} onRetried={fetchMessages} />
+                            <RetryButton messageId={msg.id} onRetried={() => invalidateMessages()} />
                           )}
                         </div>
                       </td>


### PR DESCRIPTION
## Summary

Second slice of the F12 refactor. Removes the manual fetch + state + cancellation rigs from `ApplicationsPage` and `MessagesPage` and replaces them with `useQuery` / `useQueries` / `useMutation`. Net **-12 lines** even with mutation handlers added, and the 7-second `setInterval` poll on `MessagesPage` is gone. The two remaining pages (`EndpointsPage`, `DashboardPage`) land in **F12-PR-3**.

## What changed

### `ApplicationsPage.tsx`

- **`listApplications`** → single `useQuery` keyed on `page`.
- **Per-app endpoint stats fan-out** — the `Promise.all`'d `fetchAppStats` rig is now `useQueries`: one query per app id with its own cache entry, so refreshing the apps list doesn't re-walk every endpoint page when most apps haven't changed. The walker function (`loadAppEndpointStats`) is pulled out of the component to keep the `queryFn` pure.
- **Four mutations** (`createApplication`, `deleteApplication`, `rotateApiKey`, `rotateSigningSecret`) replace the in-place `try/catch`es. Each one's `onSuccess` invalidates the applications query; rotate-key / rotate-secret stash the revealed credential into local state for the once-only reveal banner.
- The floating-promise fix from PR #68 is gone by construction — `mutate()` is fire-and-forget by design; `onError` routes to `setError` instead.

### `MessagesPage.tsx`

- **`listMessages`** → `useQuery` keyed on the entire filter object so changing any filter triggers a clean refetch instead of a manual `fetchMessages()` call. `applyFilters()` reduces to `setPage(1)`.
- **`listEndpoints` (per-app)** → its own keyed query, gated on `appFilter`. The endpoint filter is dropped to `""` when its app context changes via a small effect that microtask-defers the `setState` (existing codebase workaround).
- **The 7-second `setInterval` poll is gone.** SignalR delivery events now call `queryClient.invalidateQueries({ queryKey: ["messages"] })`; the 30-second `staleTime` configured in `App.tsx` coalesces a flood of events into one refetch. Manual cadence is unnecessary.
- **`sendDashboardMessage`** → `useMutation`. `onSuccess` invalidates messages and writes the success banner.

Both pages collapse list-error and mutation-error into a single `displayError` string so the existing banner markup is unchanged.

## Migration progress

1. ✅ F12-PR-1 (PR #69): setup + DeliveryLogPage + EventTypesPage.
2. ✅ **F12-PR-2 (this PR)**: ApplicationsPage + MessagesPage.
3. F12-PR-3 (next): EndpointsPage + DashboardPage. The DashboardPage migration deletes PR #66's manual debounce rig — `queryClient.invalidateQueries(["overview", "timeline"])` from the SignalR feed replaces the timer-based debounce.

## Test plan

- [x] `bun run typecheck && bun run lint && bun run build` — clean
- [ ] CI green
- [ ] Smoke:
  - Applications: create + delete + rotate-key + rotate-secret all reflect immediately, per-app endpoint stats render.
  - Messages: change a filter → table refetches; trigger a delivery event → table refreshes within ~30s without a manual reload; sending a test message via the modal pushes a row to the top.