### PR TITLE
feat(dashboard): finish F12 — EndpointsPage + DashboardPage on TanStack Query, cursor-pointer (F12-PR-3)

### DIFF
--- a/src/dashboard/src/pages/DashboardPage.tsx
+++ b/src/dashboard/src/pages/DashboardPage.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   getDevTrafficStatus,
   getOverview,
@@ -7,7 +8,6 @@ import {
   startDevTraffic,
   stopDevTraffic,
   type DevTrafficSeedResult,
-  type DevTrafficStatus
 } from "../api/dashboardApi";
 import { DeliveryTimeline } from "../components/DeliveryTimeline";
 import { StatusBadge } from "../components/StatusBadge";
@@ -81,173 +81,83 @@ const accentMap = {
 };
 
 export function DashboardPage() {
-  const [overview, setOverview] = useState<DashboardOverview>(fallbackOverview);
-  const [timeline, setTimeline] = useState<TimelineBucket[]>(fallbackTimeline);
-  const [isLoading, setIsLoading] = useState(true);
-  const [devToolsAvailable, setDevToolsAvailable] = useState(false);
-  const [devStatus, setDevStatus] = useState<DevTrafficStatus | null>(null);
+  const queryClient = useQueryClient();
   const [devSeedResult, setDevSeedResult] = useState<DevTrafficSeedResult | null>(null);
-  const [devActionLoading, setDevActionLoading] = useState(false);
   const { events, connected } = useDeliveryFeed(20);
 
-  const isMountedRef = useRef(true);
-  const realtimeSyncPendingRef = useRef(false);
-  const realtimeSyncInFlightRef = useRef(false);
-  const hasEverConnectedRef = useRef(false);
-  // Floor on how often the SignalR-driven refresh actually fires the
-  // overview/timeline GETs. The hub emits a delivery event for every single
-  // message the worker processes; without a min-interval guard a busy queue
-  // (e.g. dev-traffic seed) burns one fetch per second indefinitely. Three
-  // seconds is the rough cadence a human can perceive, so the dashboard
-  // stays "live" without pummelling the API.
-  const lastRealtimeRefreshAtRef = useRef(0);
-  const REALTIME_MIN_INTERVAL_MS = 3000;
+  const overviewQuery = useQuery({
+    queryKey: ["overview"],
+    queryFn: () => getOverview(),
+    placeholderData: fallbackOverview
+  });
+  const timelineQuery = useQuery({
+    queryKey: ["timeline"],
+    queryFn: () => getTimeline(),
+    placeholderData: fallbackTimeline
+  });
 
-  const refreshDashboardData = useCallback(async (showLoading = false) => {
-    if (showLoading) setIsLoading(true);
-
-    try {
-      const [overviewData, timelineData] = await Promise.all([getOverview(), getTimeline()]);
-      if (!isMountedRef.current) return;
-
-      setOverview(overviewData);
-      setTimeline(timelineData);
-    } catch {
-      if (!isMountedRef.current) return;
-
-      if (showLoading) {
-        setOverview(fallbackOverview);
-        setTimeline(fallbackTimeline);
-      }
-    } finally {
-      if (showLoading && isMountedRef.current) {
-        setIsLoading(false);
-      }
-    }
-  }, []);
-
-  const loadDevStatus = useCallback(async () => {
-    try {
-      const status = await getDevTrafficStatus();
-      setDevToolsAvailable(true);
-      setDevStatus(status);
-    } catch {
-      setDevToolsAvailable(false);
-      setDevStatus(null);
-    }
-  }, []);
-
+  // R6's manual debounce rig (1 s / 5 s tick + min-interval ref + pending
+  // / in-flight flags + lastRealtimeRefreshAtRef) is replaced by this
+  // single line: SignalR events invalidate the overview + timeline cache,
+  // staleTime (30 s in App.tsx) coalesces floods, and TanStack handles
+  // dedup + cancellation. Reconnect already invalidates lastHealthChange
+  // separately (DPR-1); here we only need the delivery-event triggered
+  // refresh.
   useEffect(() => {
-    Promise.resolve()
-      .then(() => refreshDashboardData(true))
-      .catch(() => { /* surfaced via fallback state */ });
+    if (events.length === 0 && !connected) return;
+    void Promise.resolve().then(() => {
+      queryClient.invalidateQueries({ queryKey: ["overview"] });
+      queryClient.invalidateQueries({ queryKey: ["timeline"] });
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [events.length, connected]);
 
-    return () => {
-      isMountedRef.current = false;
-    };
-  }, [refreshDashboardData]);
+  const overview = overviewQuery.data ?? fallbackOverview;
+  const timeline = timelineQuery.data ?? fallbackTimeline;
+  const isLoading = overviewQuery.isLoading || timelineQuery.isLoading;
 
-  useEffect(() => {
-    Promise.resolve()
-      .then(() => loadDevStatus())
-      .catch(() => { /* dev tools optional, errors swallowed */ });
-  }, [loadDevStatus]);
+  // Dev tools availability is implied by the status query succeeding; a
+  // refetchInterval drives the adaptive 3 s / 30 s cadence based on the
+  // last-known running flag. retry: false so an unauthenticated /not-mounted
+  // dev endpoint falls cleanly into devToolsAvailable=false instead of
+  // hammering the API.
+  const devStatusQuery = useQuery({
+    queryKey: ["dev-status"],
+    queryFn: () => getDevTrafficStatus(),
+    retry: false,
+    refetchInterval: (query) => (query.state.data?.running ? 3000 : 30_000)
+  });
+  const devToolsAvailable = !devStatusQuery.isError && devStatusQuery.data !== undefined;
+  const devStatus = devStatusQuery.data ?? null;
 
-  useEffect(() => {
-    if (!devToolsAvailable) return;
-
-    // Adaptive cadence: while a dev-traffic flow is actually running the
-    // status block is interesting enough to poll quickly (3 s), but once the
-    // generator is idle the same poll is just network noise — drop it to 30 s
-    // so a long-running idle dashboard doesn't churn the dev-status endpoint.
-    const isRunning = devStatus?.running === true;
-    const interval = isRunning ? 3000 : 30_000;
-
-    const timer = window.setInterval(() => {
-      void loadDevStatus();
-    }, interval);
-
-    return () => window.clearInterval(timer);
-  }, [devToolsAvailable, loadDevStatus, devStatus?.running]);
-
-  useEffect(() => {
-    const latestEvent = events[0];
-    if (!latestEvent) return;
-
-    realtimeSyncPendingRef.current = true;
-  }, [events]);
-
-  useEffect(() => {
-    if (!connected) return;
-
-    if (!hasEverConnectedRef.current) {
-      hasEverConnectedRef.current = true;
-      return;
-    }
-
-    realtimeSyncPendingRef.current = true;
-  }, [connected]);
-
-  useEffect(() => {
-    // Tick at 5 s instead of 1 s and guard with a 3 s min-interval since the
-    // last completed refresh, so a flood of SignalR delivery events (e.g.
-    // dev-traffic seed) coalesces into at most one overview/timeline fetch
-    // every few seconds rather than one per second. This is a tactical fix
-    // ahead of F12; once TanStack Query is wired in, the queryClient's own
-    // staleTime + invalidateQueries replaces this manual debounce entirely.
-    const timer = window.setInterval(() => {
-      if (!realtimeSyncPendingRef.current || realtimeSyncInFlightRef.current) {
-        return;
-      }
-
-      const now = Date.now();
-      if (now - lastRealtimeRefreshAtRef.current < REALTIME_MIN_INTERVAL_MS) {
-        return;
-      }
-
-      realtimeSyncPendingRef.current = false;
-      realtimeSyncInFlightRef.current = true;
-
-      void refreshDashboardData(false).finally(() => {
-        realtimeSyncInFlightRef.current = false;
-        lastRealtimeRefreshAtRef.current = Date.now();
-      });
-    }, 5000);
-
-    return () => window.clearInterval(timer);
-  }, [refreshDashboardData]);
-
-  const handleSeedOnce = async () => {
-    setDevActionLoading(true);
-    try {
-      const result = await seedDevTraffic({ messages: 1 });
+  const seedMutation = useMutation({
+    mutationFn: () => seedDevTraffic({ messages: 1 }),
+    onSuccess: (result) => {
       setDevSeedResult(result);
-      await Promise.all([loadDevStatus(), refreshDashboardData(false)]);
-    } finally {
-      setDevActionLoading(false);
+      queryClient.invalidateQueries({ queryKey: ["dev-status"] });
+      queryClient.invalidateQueries({ queryKey: ["overview"] });
+      queryClient.invalidateQueries({ queryKey: ["timeline"] });
     }
-  };
-
-  const handleStartFlow = async () => {
-    setDevActionLoading(true);
-    try {
-      const status = await startDevTraffic({ intervalMs: 1200, messagesPerTick: 6 });
-      setDevStatus(status);
+  });
+  const startMutation = useMutation({
+    mutationFn: () => startDevTraffic({ intervalMs: 1200, messagesPerTick: 6 }),
+    onSuccess: (status) => {
+      queryClient.setQueryData(["dev-status"], status);
       setDevSeedResult(null);
-    } finally {
-      setDevActionLoading(false);
     }
-  };
+  });
+  const stopMutation = useMutation({
+    mutationFn: () => stopDevTraffic(),
+    onSuccess: (status) => {
+      queryClient.setQueryData(["dev-status"], status);
+    }
+  });
 
-  const handleStopFlow = async () => {
-    setDevActionLoading(true);
-    try {
-      const status = await stopDevTraffic();
-      setDevStatus(status);
-    } finally {
-      setDevActionLoading(false);
-    }
-  };
+  const devActionLoading = seedMutation.isPending || startMutation.isPending || stopMutation.isPending;
+
+  const handleSeedOnce = () => seedMutation.mutate();
+  const handleStartFlow = () => startMutation.mutate();
+  const handleStopFlow = () => stopMutation.mutate();
 
   const cards = useMemo<StatCard[]>(
     () => [

--- a/src/dashboard/src/pages/EndpointsPage.tsx
+++ b/src/dashboard/src/pages/EndpointsPage.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { EndpointHealthBadge } from "../components/EndpointHealthBadge";
 import { Modal } from "../components/Modal";
 import { ConfirmModal } from "../components/ConfirmModal";
@@ -14,7 +15,7 @@ import {
   setDashboardEndpointStatus,
   updateDashboardEndpoint
 } from "../api/dashboardApi";
-import type { ApplicationRow, EndpointRow, EventTypeSummary, Pagination } from "../types";
+import type { EndpointRow, EventTypeSummary } from "../types";
 import {
   Plus,
   Pencil,
@@ -61,19 +62,41 @@ const closedConfirm: ConfirmState = {
 };
 
 export function EndpointsPage() {
-  const [endpoints, setEndpoints] = useState<EndpointRow[]>([]);
-  const [applications, setApplications] = useState<ApplicationRow[]>([]);
-  // Tracks the applications-list fetch separately from the endpoints fetch so
-  // we don't flash "Create an application first" before the apps response
-  // lands on first render — which read as confusing on a fresh page load.
-  const [applicationsLoading, setApplicationsLoading] = useState(true);
-  const [eventTypesByApp, setEventTypesByApp] = useState<Record<string, EventTypeSummary[]>>({});
-  const [pagination, setPagination] = useState<Pagination | null>(null);
+  const queryClient = useQueryClient();
   const [page, setPage] = useState(1);
   const [statusFilter, setStatusFilter] = useState("");
   const [appFilter, setAppFilter] = useState("");
-  const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+
+  const endpointsQuery = useQuery({
+    queryKey: ["endpoints", { page, appFilter, statusFilter }],
+    queryFn: () => listEndpoints({
+      appId: appFilter || undefined,
+      status: statusFilter || undefined,
+      page,
+      pageSize: 20
+    })
+  });
+  const endpoints = useMemo(() => endpointsQuery.data?.data ?? [], [endpointsQuery.data]);
+  const pagination = endpointsQuery.data?.pagination ?? null;
+  const loading = endpointsQuery.isLoading;
+
+  const applicationsQuery = useQuery({
+    queryKey: ["applications-all"],
+    queryFn: () => listApplications(1, 200)
+  });
+  const applications = useMemo(() => applicationsQuery.data?.data ?? [], [applicationsQuery.data]);
+  const applicationsLoading = applicationsQuery.isLoading;
+
+  // Per-app event-type cache — populated lazily as the user opens the create
+  // modal or starts editing a row. We hold a local map so the create / edit
+  // forms have synchronous access to the list once it's fetched.
+  const [eventTypesByApp, setEventTypesByApp] = useState<Record<string, EventTypeSummary[]>>({});
+
+  const fetchError = endpointsQuery.error instanceof Error ? endpointsQuery.error.message : "";
+  const displayError = error || fetchError;
+
+  const invalidateEndpoints = () => queryClient.invalidateQueries({ queryKey: ["endpoints"] });
 
   // Create modal
   const [showCreate, setShowCreate] = useState(false);
@@ -83,7 +106,6 @@ export function EndpointsPage() {
   const [createFilterEventTypeIds, setCreateFilterEventTypeIds] = useState<string[]>([]);
   const [createTransformExpression, setCreateTransformExpression] = useState("");
   const [createTransformEnabled, setCreateTransformEnabled] = useState(false);
-  const [creating, setCreating] = useState(false);
 
   // Edit modal
   const [editingEndpointId, setEditingEndpointId] = useState<string | null>(null);
@@ -92,7 +114,6 @@ export function EndpointsPage() {
   const [editFilterEventTypeIds, setEditFilterEventTypeIds] = useState<string[]>([]);
   const [editTransformExpression, setEditTransformExpression] = useState("");
   const [editTransformEnabled, setEditTransformEnabled] = useState(false);
-  const [updating, setUpdating] = useState(false);
 
   // Confirm modal
   const [confirmState, setConfirmState] = useState<ConfirmState>(closedConfirm);
@@ -118,55 +139,29 @@ export function EndpointsPage() {
     return eventTypes;
   }, [eventTypesByApp]);
 
-  const fetchEndpoints = useCallback(async () => {
-    setLoading(true);
-    setError("");
-    try {
-      const result = await listEndpoints({ appId: appFilter || undefined, status: statusFilter || undefined, page, pageSize: 20 });
-      setEndpoints(result.data);
-      setPagination(result.pagination);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to load endpoints");
-    } finally {
-      setLoading(false);
-    }
-  }, [appFilter, page, statusFilter]);
-
+  // Default to the first application as the create-modal target once the
+  // applications list lands. Microtask defer matches the codebase's existing
+  // workaround for react-hooks/set-state-in-effect.
   useEffect(() => {
-    Promise.resolve()
-      .then(() => fetchEndpoints())
-      .catch(() => { /* surfaced via fetchEndpoints' setError */ });
-  }, [fetchEndpoints]);
+    if (applications.length === 0) return;
+    void Promise.resolve().then(() => {
+      setCreateAppId((c) => c || applications[0].id);
+    });
+  }, [applications]);
 
-  useEffect(() => {
-    const fetchApplications = async () => {
-      try {
-        const result = await listApplications(1, 200);
-        setApplications(result.data);
-        if (result.data.length > 0) setCreateAppId((c) => c || result.data[0].id);
-      } catch { /* no-op */ }
-      finally { setApplicationsLoading(false); }
-    };
-    fetchApplications();
-  }, []);
-
-  // Live-patch the row when the engine pushes a circuit transition. The hub
-  // event already carries the new visible status; we map it onto whichever
-  // row in the current page matches the endpointId. Rows on other pages
-  // pick up the change on the next manual refresh. The microtask defer
-  // matches the codebase's existing pattern for set-state-in-effect.
+  // Replace the F7 lastHealthChange direct setState patch with a query
+  // invalidation: the next refetch is the source of truth, dedup is automatic
+  // across multiple pages opening the same query, and stale-on-reconnect
+  // (DPR-1's reset to null) gets us a clean refresh. The "rows on other
+  // pages pick up on next refresh" caveat from before now applies to ANY
+  // open EndpointsPage instance — not just the one that received the event.
   const { lastHealthChange } = useDeliveryFeed();
   useEffect(() => {
     if (!lastHealthChange) return;
     void Promise.resolve().then(() => {
-      setEndpoints((prev) => {
-        const idx = prev.findIndex((e) => e.id === lastHealthChange.endpointId);
-        if (idx < 0) return prev;
-        const next = prev.slice();
-        next[idx] = { ...next[idx], status: lastHealthChange.status };
-        return next;
-      });
+      queryClient.invalidateQueries({ queryKey: ["endpoints"] });
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [lastHealthChange]);
 
   useEffect(() => {
@@ -189,31 +184,32 @@ export function EndpointsPage() {
     setCreateTransformEnabled(false);
   };
 
-  const handleCreate = async () => {
-    if (!createAppId || !createUrl.trim()) return;
-    setCreating(true);
-    setError("");
-    try {
-      const trimmedExpr = createTransformExpression.trim();
-      await createDashboardEndpoint({
-        appId: createAppId,
-        url: createUrl.trim(),
-        description: createDescription.trim() || undefined,
-        filterEventTypes: createFilterEventTypeIds.length > 0 ? createFilterEventTypeIds : [],
-        transformExpression: trimmedExpr || null,
-        transformEnabled: createTransformEnabled && trimmedExpr.length > 0
-      });
-      // TODO(DPR-3): createDashboardEndpoint now throws ApiErrorException with
-      // fieldErrors when the server returns 422 — wire url field error into the
-      // input once the form is upgraded in the next pass.
+  const createMutation = useMutation({
+    mutationFn: (vars: Parameters<typeof createDashboardEndpoint>[0]) => createDashboardEndpoint(vars),
+    onSuccess: () => {
       resetCreateForm();
       setShowCreate(false);
-      await fetchEndpoints();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to create endpoint");
-    } finally {
-      setCreating(false);
-    }
+      invalidateEndpoints();
+    },
+    onError: (e: unknown) => setError(e instanceof Error ? e.message : "Failed to create endpoint")
+  });
+  const creating = createMutation.isPending;
+
+  const handleCreate = () => {
+    if (!createAppId || !createUrl.trim()) return;
+    setError("");
+    const trimmedExpr = createTransformExpression.trim();
+    createMutation.mutate({
+      appId: createAppId,
+      url: createUrl.trim(),
+      description: createDescription.trim() || undefined,
+      filterEventTypes: createFilterEventTypeIds.length > 0 ? createFilterEventTypeIds : [],
+      transformExpression: trimmedExpr || null,
+      transformEnabled: createTransformEnabled && trimmedExpr.length > 0
+    });
+    // TODO(DPR-3): createMutation.error is an ApiErrorException with
+    // fieldErrors on 422 — wire url field error into the input once the
+    // form is upgraded in the next pass.
   };
 
   const startEdit = async (endpoint: EndpointRow) => {
@@ -240,31 +236,38 @@ export function EndpointsPage() {
     setEditTransformEnabled(false);
   };
 
-  const handleUpdate = async () => {
+  const updateMutation = useMutation({
+    mutationFn: (vars: { id: string; payload: Parameters<typeof updateDashboardEndpoint>[1] }) =>
+      updateDashboardEndpoint(vars.id, vars.payload),
+    onSuccess: () => { cancelEdit(); invalidateEndpoints(); },
+    onError: (e: unknown) => setError(e instanceof Error ? e.message : "Failed to update endpoint")
+  });
+  const updating = updateMutation.isPending;
+
+  const handleUpdate = () => {
     if (!editingEndpoint || !editUrl.trim()) return;
-    setUpdating(true);
     setError("");
-    try {
-      const trimmedExpr = editTransformExpression.trim();
-      await updateDashboardEndpoint(editingEndpoint.id, {
+    const trimmedExpr = editTransformExpression.trim();
+    updateMutation.mutate({
+      id: editingEndpoint.id,
+      payload: {
         url: editUrl.trim(),
         description: editDescription.trim() || undefined,
         filterEventTypes: editFilterEventTypeIds,
         transformExpression: trimmedExpr.length > 0 ? trimmedExpr : "",
         transformEnabled: editTransformEnabled && trimmedExpr.length > 0
-      });
-      cancelEdit();
-      await fetchEndpoints();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to update endpoint");
-    } finally {
-      setUpdating(false);
-    }
+      }
+    });
   };
+
+  const toggleStatusMutation = useMutation({
+    mutationFn: (vars: { id: string; enable: boolean }) => setDashboardEndpointStatus(vars.id, vars.enable),
+    onSuccess: () => invalidateEndpoints(),
+    onError: (e: unknown) => setError(e instanceof Error ? e.message : "Failed to toggle endpoint status")
+  });
 
   const requestToggleStatus = (endpoint: EndpointRow) => {
     const isDisabled = endpoint.status.toLowerCase() === "disabled";
-    const action = isDisabled ? "enable" : "disable";
     setConfirmState({
       open: true,
       title: `${isDisabled ? "Enable" : "Disable"} Endpoint`,
@@ -273,13 +276,9 @@ export function EndpointsPage() {
         : "This endpoint will stop receiving webhook deliveries until re-enabled.",
       confirmLabel: isDisabled ? "Enable" : "Disable",
       variant: isDisabled ? "default" : "danger",
-      onConfirm: async () => {
-        try {
-          await setDashboardEndpointStatus(endpoint.id, isDisabled);
-          await fetchEndpoints();
-        } catch (e) {
-          setError(e instanceof Error ? e.message : `Failed to ${action} endpoint`);
-        }
+      onConfirm: () => {
+        setError("");
+        toggleStatusMutation.mutate({ id: endpoint.id, enable: isDisabled });
       }
     });
   };
@@ -301,16 +300,18 @@ export function EndpointsPage() {
       description: `Delete this endpoint? All pending messages for this destination will be cancelled. This action cannot be undone.`,
       confirmLabel: "Delete",
       variant: "danger",
-      onConfirm: async () => {
-        try {
-          await deleteDashboardEndpoint(endpoint.id);
-          await fetchEndpoints();
-        } catch (e) {
-          setError(e instanceof Error ? e.message : "Failed to delete endpoint");
-        }
+      onConfirm: () => {
+        setError("");
+        deleteMutation.mutate(endpoint.id);
       }
     });
   };
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteDashboardEndpoint(id),
+    onSuccess: () => invalidateEndpoints(),
+    onError: (e: unknown) => setError(e instanceof Error ? e.message : "Failed to delete endpoint")
+  });
 
   const createEventTypes = createAppId ? eventTypesByApp[createAppId] ?? [] : [];
   const editEventTypes = editingEndpoint ? eventTypesByApp[editingEndpoint.appId] ?? [] : [];
@@ -334,10 +335,10 @@ export function EndpointsPage() {
       </div>
 
       {/* Error */}
-      {error && (
+      {displayError && (
         <div className="flex items-center gap-2 text-danger text-xs bg-danger-soft border border-danger/20 rounded-lg px-3 py-2 animate-fade-in-up">
           <AlertCircle className="w-3.5 h-3.5 shrink-0" />
-          {error}
+          {displayError}
           <button onClick={() => setError("")} className="ml-auto text-danger/60 hover:text-danger"><X className="w-3 h-3" /></button>
         </div>
       )}

--- a/src/dashboard/src/styles.css
+++ b/src/dashboard/src/styles.css
@@ -60,6 +60,15 @@
     color: var(--color-text-primary);
   }
 
+  /* Global affordance: every clickable button gets a pointer cursor.
+     Disabled / aria-disabled buttons keep the default arrow so users see
+     the affordance is gone. <a href> elements already get a pointer from
+     the user-agent stylesheet. */
+  button:not(:disabled):not([aria-disabled="true"]),
+  [role="button"]:not(:disabled):not([aria-disabled="true"]) {
+    cursor: pointer;
+  }
+
   /* Scrollbar — thin dark */
   ::-webkit-scrollbar {
     width: 6px;


### PR DESCRIPTION
## Summary

Final slice of the F12 useEffect refactor: `EndpointsPage` and `DashboardPage` migrate to TanStack Query, **R6's manual debounce rig (PR #66) is deleted entirely**, and a small global rule applies `cursor: pointer` to every clickable button.

## What changed

### `EndpointsPage.tsx`

- `listEndpoints` and `listApplications` become `useQuery` calls keyed on filter state.
- Per-app event types stay in the existing local map cache (lazy load on demand from the create/edit modals) — they don't benefit from `useQuery` keying since they're loaded once per app and held for the page lifetime.
- **F7 `lastHealthChange` direct `setEndpoints` patch becomes `queryClient.invalidateQueries(["endpoints"])`.** The next refetch is the source of truth, so a stale cached snapshot can't sit on top of a newer server state, and any other open `EndpointsPage` instance refreshes too. The DPR-1 `lastHealthChange = null` reset on reconnect already handles the post-disconnect case.
- Four mutations (`create`, `update`, `toggleStatus`, `delete`) replace the in-place `try/catch` blocks. `onSuccess` invalidates endpoints; `onError` routes to `setError`.
- The TODO(DPR-3) comment in the create handler now points at `createMutation.error` instead of the awaited `createDashboardEndpoint` call.

### `DashboardPage.tsx` — R6 manual rig deleted

- `getOverview`, `getTimeline` become two `useQuery` calls with `placeholderData` so the cards don't flash empty values on first paint.
- **All of these are gone:** `realtimeSyncPendingRef`, `realtimeSyncInFlightRef`, `hasEverConnectedRef`, `lastRealtimeRefreshAtRef`, the 5-second tick `setInterval`, the `REALTIME_MIN_INTERVAL_MS` constant. Replaced by **one** `useEffect` that calls `queryClient.invalidateQueries({ queryKey: ["overview"|"timeline"] })` when `events.length` or `connected` changes. The 30-second `staleTime` from `App.tsx` plus TanStack's request dedup means a flood of SignalR events still coalesces into at most one refetch per stale window — same UX, far less code.
- `getDevTrafficStatus` becomes a `useQuery` with a **function `refetchInterval`** that drives the adaptive 3 s / 30 s cadence based on `query.state.data?.running`. `retry: false` so an unauthenticated dev endpoint cleanly falls into `devToolsAvailable=false` instead of hammering the API.
- Three mutations (`seed`, `start`, `stop`) replace the in-place `try/catch` blocks. `seed` `onSuccess` invalidates dev-status + overview + timeline; `start` / `stop` use `queryClient.setQueryData` to apply the response status directly, avoiding a round-trip just to confirm what the response already said.

### `styles.css` — global cursor-pointer

Inline rule under `@layer base`:

```css
button:not(:disabled):not([aria-disabled="true"]),
[role="button"]:not(:disabled):not([aria-disabled="true"]) {
  cursor: pointer;
}
```

Disabled / aria-disabled buttons keep the default arrow so the lost affordance reads correctly. `<a href>` already gets pointer from the user-agent stylesheet.

## F12 series — final tally

| PR | Pages |
|---|---|
| #69 | DeliveryLogPage, EventTypesPage |
| #70 | ApplicationsPage, MessagesPage |
| **this** | **EndpointsPage, DashboardPage** + R6 rig deleted |

Across the series:
- **+1 dependency**: `@tanstack/react-query@5.100.9`.
- **−7 `useEffect` blocks**, **−1 `setInterval`**, **−4 manual fetch rigs**, **+12 `useQuery`**, **+11 `useMutation`**.
- The codemirror chunk shape is unchanged.

## Test plan

- [x] `bun run typecheck && bun run lint && bun run build` — clean
- [ ] CI green
- [ ] Smoke:
  - **Endpoints**: trigger a circuit transition (e.g. by failing 5 deliveries) — endpoint badge updates within ~30 s without manual refresh.
  - **Dashboard**: with dev-traffic running, network tab shows ~one overview/timeline pair per ~30 s rather than per ~5 s. Stop the flow → dev-status poll cadence drops to 30 s automatically.
  - **Hover any button** → cursor turns into a pointer.

## Follow-ups

- **DPR-3**: wire `ApiErrorException.fieldErrors` from PR #67 into form-level field routing (the TODO in `EndpointsPage.handleCreate`).
- **R2 + R4 + R5**: backend polish batch (matcher contract guard, sweep thread-safety, tracker double-fetch).