### PR TITLE
fix(dashboard): UX polish — payload field error, mobile filter grid, modal dvh, signalr badge, url field error wiring (DPR-3)

### DIFF
--- a/src/dashboard/src/components/Modal.tsx
+++ b/src/dashboard/src/components/Modal.tsx
@@ -132,8 +132,10 @@ export function Modal({ open, onClose, title, description, children, width = "ma
           </button>
         </div>
 
-        {/* Body */}
-        <div className="px-5 py-4 max-h-[70vh] overflow-y-auto">
+        {/* Body — dvh handles mobile keyboard / address-bar resize without
+            cropping; overscroll-contain stops iOS from scrolling the page
+            underneath when the modal body itself reaches its end. */}
+        <div className="px-5 py-4 max-h-[85dvh] overflow-y-auto overscroll-contain">
           {children}
         </div>
       </div>

--- a/src/dashboard/src/pages/EndpointsPage.tsx
+++ b/src/dashboard/src/pages/EndpointsPage.tsx
@@ -7,6 +7,7 @@ import { Select } from "../components/Select";
 import { EventTypeSelect } from "../components/EventTypeSelect";
 import { useDeliveryFeed } from "../hooks/useDeliveryFeed";
 import {
+  ApiErrorException,
   createDashboardEndpoint,
   deleteDashboardEndpoint,
   listApplications,
@@ -28,7 +29,9 @@ import {
   ChevronLeft,
   ChevronRight,
   Save,
-  Send
+  Send,
+  Wifi,
+  WifiOff
 } from "lucide-react";
 import { formatLocaleDate } from "../utils/dateTime";
 import { inputClasses } from "../utils/styles";
@@ -155,7 +158,7 @@ export function EndpointsPage() {
   // (DPR-1's reset to null) gets us a clean refresh. The "rows on other
   // pages pick up on next refresh" caveat from before now applies to ANY
   // open EndpointsPage instance — not just the one that received the event.
-  const { lastHealthChange } = useDeliveryFeed();
+  const { lastHealthChange, connected } = useDeliveryFeed();
   useEffect(() => {
     if (!lastHealthChange) return;
     void Promise.resolve().then(() => {
@@ -207,10 +210,14 @@ export function EndpointsPage() {
       transformExpression: trimmedExpr || null,
       transformEnabled: createTransformEnabled && trimmedExpr.length > 0
     });
-    // TODO(DPR-3): createMutation.error is an ApiErrorException with
-    // fieldErrors on 422 — wire url field error into the input once the
-    // form is upgraded in the next pass.
   };
+
+  // Pull the url-specific message off ApiErrorException.fieldErrors when the
+  // server's 422 surfaces a per-field validation hint. Falls back to undefined
+  // when the error is something else (network / generic 4xx).
+  const createUrlFieldError = createMutation.error instanceof ApiErrorException
+    ? createMutation.error.fieldErrors?.Url ?? createMutation.error.fieldErrors?.url
+    : undefined;
 
   const startEdit = async (endpoint: EndpointRow) => {
     setEditingEndpointId(endpoint.id);
@@ -320,8 +327,21 @@ export function EndpointsPage() {
     <div className="space-y-4">
       {/* Header */}
       <div className="flex items-center justify-between animate-fade-in-up">
-        <div>
-          <h1 className="text-lg font-semibold">Endpoints</h1>
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <h1 className="text-lg font-semibold">Endpoints</h1>
+            {/* Live-feed pill: tells the user whether health badges are
+                actually live-updating from the SignalR feed, since the
+                visible row state otherwise looks identical when it's stale. */}
+            <span
+              className={`inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded ${connected ? "text-success bg-success-soft" : "text-text-muted bg-surface-2"}`}
+              title={connected ? "Live updates connected" : "Live updates offline — health badges may lag until reconnect"}
+              aria-label={connected ? "Live updates connected" : "Live updates offline"}
+            >
+              {connected ? <Wifi className="w-2.5 h-2.5" /> : <WifiOff className="w-2.5 h-2.5" />}
+              {connected ? "Live" : "Offline"}
+            </span>
+          </div>
           <p className="text-sm text-text-muted mt-0.5">Destination health and endpoint filters.</p>
         </div>
         <button
@@ -486,7 +506,16 @@ export function EndpointsPage() {
           </div>
           <label className="block">
             <span className="text-xs font-medium text-text-secondary mb-1.5 block">Endpoint URL</span>
-            <input placeholder="https://example.com/webhook" value={createUrl} onChange={(e) => setCreateUrl(e.target.value)} className={inputClasses} />
+            <input
+              placeholder="https://example.com/webhook"
+              value={createUrl}
+              onChange={(e) => setCreateUrl(e.target.value)}
+              aria-invalid={createUrlFieldError ? "true" : undefined}
+              className={`${inputClasses} ${createUrlFieldError ? "border-danger/60" : ""}`}
+            />
+            {createUrlFieldError && (
+              <span className="block text-[11px] text-danger mt-1">{createUrlFieldError}</span>
+            )}
           </label>
           <label className="block">
             <span className="text-xs font-medium text-text-secondary mb-1.5 block">Description (optional)</span>

--- a/src/dashboard/src/pages/MessagesPage.tsx
+++ b/src/dashboard/src/pages/MessagesPage.tsx
@@ -52,6 +52,9 @@ export function MessagesPage() {
   const [sendAppId, setSendAppId] = useState("");
   const [sendEventType, setSendEventType] = useState("");
   const [sendPayload, setSendPayload] = useState("{}");
+  // Ayrı state: payload-parse hatasını genel error banner'ı ile karıştırmak
+  // istemiyoruz — biri form-field-level, diğeri page-level / mutation-level.
+  const [payloadError, setPayloadError] = useState("");
   const [sendIdempotencyKey, setSendIdempotencyKey] = useState("");
   const [lastSendAt, setLastSendAt] = useState(0);
   const [sendResult, setSendResult] = useState("");
@@ -151,9 +154,17 @@ export function MessagesPage() {
     if (now - lastSendAt < 800) return;
 
     let parsedPayload: unknown;
-    try { parsedPayload = JSON.parse(sendPayload); } catch { setError("Payload must be valid JSON"); return; }
+    try {
+      parsedPayload = JSON.parse(sendPayload);
+    } catch {
+      // Field-level error stays anchored to the payload textarea instead of
+      // bouncing into the page-wide error banner where it loses context.
+      setPayloadError("Payload must be valid JSON");
+      return;
+    }
 
     setError("");
+    setPayloadError("");
     setSendResult("");
     sendMutation.mutate({
       appId: sendAppId,
@@ -206,7 +217,7 @@ export function MessagesPage() {
           <Filter className="w-3.5 h-3.5 text-text-muted" />
           <span className="text-xs font-medium text-text-secondary">Filters</span>
         </div>
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-6 gap-2">
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-2">
           <div>
             <span className="text-xs text-text-muted mb-1 block">Application</span>
             <Select
@@ -359,9 +370,13 @@ export function MessagesPage() {
               <textarea
                 rows={5}
                 value={sendPayload}
-                onChange={(e) => setSendPayload(e.target.value)}
-                className={`${inputClasses} font-mono text-xs resize-y`}
+                onChange={(e) => { setSendPayload(e.target.value); if (payloadError) setPayloadError(""); }}
+                aria-invalid={payloadError ? "true" : undefined}
+                className={`${inputClasses} font-mono text-xs resize-y ${payloadError ? "border-danger/60" : ""}`}
               />
+              {payloadError && (
+                <span className="block text-[11px] text-danger mt-1 font-mono">{payloadError}</span>
+              )}
             </label>
             {sendResult && <p className="text-xs text-success">{sendResult}</p>}
             <div className="flex items-center justify-end gap-2 pt-1">


### PR DESCRIPTION
## Summary

Five small UX items from the dashboard-expert audit, batched as the final polish pass after F12. **DPR-3 from the dashboard-improvement plan.**

## What changed

### Modal: 70vh → 85dvh + overscroll-contain (audit #15)

`Modal.tsx` body switches from `max-h-[70vh] overflow-y-auto` to `max-h-[85dvh] overflow-y-auto overscroll-contain`. The `dvh` unit handles iOS / Android mobile keyboard + address-bar resize without cropping the modal contents the way `vh` does, and `overscroll-contain` stops mobile Safari from scroll-chaining the page underneath when the modal body itself reaches its end.

### MessagesPage filter grid: missing md breakpoint (audit #13)

The filter row was `grid-cols-1 sm:grid-cols-2 lg:grid-cols-6`. Added `md:grid-cols-3` so the six inputs (application / endpoint / event type / status / after / before) breathe properly on tablet widths instead of collapsing to two cramped columns the entire range from `sm` up.

### EndpointsPage SignalR connection badge (audit #18)

A small pill in the header reflects the `useDeliveryFeed` `connected` flag:
- **Connected** → `Wifi` icon + `text-success bg-success-soft`, label "Live".
- **Disconnected** → `WifiOff` icon + `text-text-muted bg-surface-2`, label "Offline".

Health badges already update over the SignalR feed (F7), but when the hub disconnects there's no visible signal that the badges may be stale until the next reconnect — this pill closes that loop. `title` and `aria-label` carry the explanation for screen readers.

### MessagesPage payload textarea: dedicated field error (audit #24)

The previous `setError("Payload must be valid JSON")` dumped the parse failure into the page-wide error banner where it lost context — the same banner also shows mutation errors, so the user couldn't tell which input was wrong. New `payloadError` state lives alongside the textarea; `aria-invalid` toggles on the input; the error renders in red below the field; typing into the textarea clears it optimistically. Banner errors stay reserved for mutation / list errors.

### EndpointsPage create modal: URL field error from `ApiErrorException` (audit #25 wiring)

DPR-2 (PR #67) introduced `ApiErrorException.fieldErrors`. This PR demonstrates the use:

- `createMutation.error` is checked with `instanceof ApiErrorException`.
- `error.fieldErrors?.Url ?? error.fieldErrors?.url` (case fallback matches FluentValidation's default PascalCase) is rendered under the URL input.
- The input gets `aria-invalid="true"` when a field error is present.

The pattern carries to the other forms in a follow-up if the field-error coverage proves valuable in practice.

## Test plan

- [x] `bun run typecheck && bun run lint && bun run build` — clean
- [ ] CI green
- [ ] Smoke:
  - Open any modal on a phone with the keyboard up — modal body doesn't crop, page below doesn't scroll.
  - Resize MessagesPage to ~tablet width — filter grid lands in 3 columns instead of 2 cramped.
  - Stop the API server while the dashboard is open — Endpoints header pill flips to "Offline" within a few seconds; restart the API → "Live".
  - Type invalid JSON into the message-send modal payload — error appears under the textarea, not in the banner; type a valid `{}` → error disappears.
  - Create an endpoint with a non-https URL or an unresolvable hostname (F2) → error message appears under the URL input.

## Closes the dashboard-improvement turn

After this lands the dashboard-improvement plan is complete:
- DPR-1 (a11y + correctness): #68
- DPR-2 (consolidation + bundle + field-error API): #67
- DPR-3 (this PR)
- F12 (TanStack Query) #69 + #70 + #71

Backend follow-up batch is **R2 + R4 + R5** (matcher contract guard, sweep thread-safety, tracker double-fetch).