### PR TITLE
chore(infra): backend polish — matcher contract, sweep thread-safety, tracker double-fetch (R2+R4+R5)

### DIFF
--- a/src/WebhookEngine.Infrastructure/Services/ApplicationRateLimiter.cs
+++ b/src/WebhookEngine.Infrastructure/Services/ApplicationRateLimiter.cs
@@ -17,16 +17,25 @@ public class ApplicationRateLimiter : IApplicationRateLimiter
     private static readonly TimeSpan SweepInterval = TimeSpan.FromMinutes(5);
 
     private readonly ConcurrentDictionary<Guid, WindowState> _windows = new();
-    private DateTime _lastSweepUtc = DateTime.UtcNow;
+    // Stored as Ticks so Volatile.Read / Interlocked.Exchange give us atomic
+    // 64-bit reads / writes on every platform. A torn DateTime read could
+    // otherwise spawn back-to-back sweeps on a 32-bit host, which is harmless
+    // but wasteful.
+    private long _lastSweepTicks = DateTime.UtcNow.Ticks;
 
     public bool TryAcquire(Guid appId, int limitPerSecond, out DateTime retryAtUtc)
     {
         var now = DateTime.UtcNow;
 
-        if (now - _lastSweepUtc > SweepInterval)
+        var lastSweepTicks = Volatile.Read(ref _lastSweepTicks);
+        if (now.Ticks - lastSweepTicks > SweepInterval.Ticks)
         {
-            SweepIdleEntries(now);
-            _lastSweepUtc = now;
+            // CAS so only one caller drives the sweep when a flood of
+            // concurrent acquires all crosses the interval boundary at once.
+            if (Interlocked.CompareExchange(ref _lastSweepTicks, now.Ticks, lastSweepTicks) == lastSweepTicks)
+            {
+                SweepIdleEntries(now);
+            }
         }
 
         if (limitPerSecond <= 0)
@@ -67,7 +76,19 @@ public class ApplicationRateLimiter : IApplicationRateLimiter
     {
         foreach (var (appId, state) in _windows)
         {
-            if (now - state.LastUsedUtc > IdleAfter)
+            // Read LastUsedUtc under the per-state lock so we can't race a
+            // concurrent TryAcquire that's mid-update. Without this the read
+            // could be torn on a 32-bit host (DateTime is not atomically read)
+            // and we'd evict an entry that's actually warm; the next acquire
+            // would just spawn a fresh state with Count=0, leaking one slot
+            // in that 1-second window — bounded but worth tightening.
+            DateTime lastUsed;
+            lock (state.Lock)
+            {
+                lastUsed = state.LastUsedUtc;
+            }
+
+            if (now - lastUsed > IdleAfter)
             {
                 _windows.TryRemove(appId, out _);
             }

--- a/src/WebhookEngine.Infrastructure/Services/EndpointHealthTracker.cs
+++ b/src/WebhookEngine.Infrastructure/Services/EndpointHealthTracker.cs
@@ -150,14 +150,15 @@ public class EndpointHealthTracker : IEndpointHealthTracker
         var beforeCircuit = health.CircuitState;
 
         // Fetch the tracked endpoint up front so the before/after read both
-        // see the same instance EF is mutating; AsNoTracking would miss the
-        // change UpdateEndpointStatusAsync makes below.
+        // see the same instance EF is mutating, then thread it into
+        // UpdateEndpointStatus so the helper doesn't issue a second round-trip
+        // for the same row.
         var endpoint = await _dbContext.Endpoints
             .FirstOrDefaultAsync(e => e.Id == endpointId, ct);
         var beforeStatus = endpoint?.Status ?? EndpointStatus.Active;
 
         mutate(health);
-        await UpdateEndpointStatusAsync(endpointId, health, DateTime.UtcNow, ct);
+        ApplyEndpointStatus(endpoint, health, DateTime.UtcNow);
 
         var afterStatus = endpoint?.Status ?? beforeStatus;
         var afterSnapshot = new HealthSnapshot(
@@ -238,18 +239,18 @@ public class EndpointHealthTracker : IEndpointHealthTracker
         return health;
     }
 
-    private async Task UpdateEndpointStatusAsync(Guid endpointId, EndpointHealth health, DateTime now, CancellationToken ct)
+    /// <summary>
+    /// Applies the target status onto an already-fetched, EF-tracked endpoint
+    /// row. The caller owns the fetch — eliminating the second round-trip that
+    /// the previous <c>UpdateEndpointStatusAsync</c> overload incurred.
+    /// </summary>
+    private static void ApplyEndpointStatus(WebhookEngine.Core.Entities.Endpoint? endpoint, EndpointHealth health, DateTime now)
     {
-        var endpoint = await _dbContext.Endpoints.FirstOrDefaultAsync(e => e.Id == endpointId, ct);
-        if (endpoint is null)
-            return;
-
-        if (endpoint.Status == EndpointStatus.Disabled)
-            return;
+        if (endpoint is null) return;
+        if (endpoint.Status == EndpointStatus.Disabled) return;
 
         var targetStatus = ResolveEndpointStatus(health);
-        if (endpoint.Status == targetStatus)
-            return;
+        if (endpoint.Status == targetStatus) return;
 
         endpoint.Status = targetStatus;
         endpoint.UpdatedAt = now;

--- a/src/WebhookEngine.Infrastructure/Services/IpAllowlistMatcher.cs
+++ b/src/WebhookEngine.Infrastructure/Services/IpAllowlistMatcher.cs
@@ -71,11 +71,17 @@ public static class IpAllowlistMatcher
     /// <summary>
     /// True when every address in <paramref name="resolvedAddresses"/> is
     /// contained by at least one entry in <paramref name="allowed"/>. An
-    /// empty allowlist returns true (the gate is opt-in). An empty resolution
-    /// returns false (we will not deliver to nothing).
+    /// empty allowlist returns true (the gate is opt-in) regardless of the
+    /// resolved set — the empty-allowlist check fires first so the
+    /// "allowlist not configured" path can't accidentally fail because no
+    /// addresses came back from the resolver. An empty resolution against a
+    /// configured allowlist returns false (we will not deliver to nothing).
     /// </summary>
     public static bool AllAddressesAllowed(IReadOnlyList<IPNetwork> allowed, IReadOnlyList<IPAddress> resolvedAddresses)
     {
+        // Order is intentional: empty allowlist short-circuits FIRST so a
+        // future caller passing an empty resolved set with no allowlist
+        // configured cannot accidentally land on the deny branch below.
         if (allowed.Count == 0)
         {
             return true;

--- a/tests/WebhookEngine.Infrastructure.Tests/Services/IpAllowlistMatcherTests.cs
+++ b/tests/WebhookEngine.Infrastructure.Tests/Services/IpAllowlistMatcherTests.cs
@@ -67,6 +67,17 @@ public class IpAllowlistMatcherTests
     }
 
     [Fact]
+    public void AllAddressesAllowed_Returns_True_When_Both_Allowlist_And_Resolution_Are_Empty()
+    {
+        // Empty allowlist short-circuits BEFORE the empty-resolution branch,
+        // so the "allowlist not configured" semantics survive even when the
+        // caller passes an empty resolved set. Today no production path lands
+        // here (DeliveryWorker skips the matcher entirely when the allowlist
+        // is empty), but the contract guard keeps a future caller honest.
+        IpAllowlistMatcher.AllAddressesAllowed([], []).Should().BeTrue();
+    }
+
+    [Fact]
     public void AllAddressesAllowed_Returns_False_When_Resolution_Is_Empty_With_NonEmpty_List()
     {
         var allowed = IpAllowlistMatcher.Parse("""["203.0.113.0/24"]""");


### PR DESCRIPTION
## Summary

Three small follow-ups from the F1-F9 reviewer punch list, batched into one PR. **None is a correctness blocker** — the production paths today don't reach any of the failure modes — but each closes a contract hole before it becomes a bug in a future caller. **Final backend polish from the post-v0.1.5 plan.**

## What changed

### R2 — `IpAllowlistMatcher.AllAddressesAllowed` contract guard

The empty-allowlist short-circuit already fires before the empty-resolution deny branch, but the ordering wasn't load-bearing-documented. Comment makes the order intentional and a new unit test asserts **"empty allowlist + empty resolution = true"** so a future refactor can't silently flip the guard. No behavior change today.

### R4 — `ApplicationRateLimiter` sweep thread-safety

- `_lastSweepUtc` was a plain `DateTime` read/written without synchronization on the hot acquire path. On a 32-bit host that's a torn 64-bit read which could spawn back-to-back sweeps when a flood of concurrent acquires all crossed the `SweepInterval` boundary at once.
- Now stored as ticks (`long`), read with `Volatile.Read`, swapped with `Interlocked.CompareExchange` so only one acquire actually drives the sweep.
- `SweepIdleEntries` also reads `state.LastUsedUtc` **inside** the per-state lock now — the old read was outside, opening the same torn-read window for the eviction decision.

Realistic blast radius before the fix was bounded (one wasted sweep + one re-spawned `WindowState` per app per second), but worth tightening so a future contention scenario doesn't surprise us.

### R5 — `EndpointHealthTracker` double-fetch

`ApplyAndCaptureChangeAsync` was fetching the tracked endpoint, then the private `UpdateEndpointStatusAsync` helper fetched it again on the same `DbContext`. EF returned the same tracked instance both times, so it was correct; just one extra round-trip. The helper is now `ApplyEndpointStatus` — synchronous, takes the already-fetched endpoint as a parameter, and mutates it in place. Caller owns the fetch.

## Test plan

- [x] `dotnet build WebhookEngine.sln --configuration Release` — 0 warnings, 0 errors
- [x] `dotnet test WebhookEngine.sln --configuration Release` — 215 / 215 pass (was 214; one new matcher contract test)
- [ ] CI green

## Closes the post-v0.1.5 punch list

After this lands, the backend reviewer punch list is fully closed:
- 🟠 R1 (F8 transient DNS retry): #64
- 🟠 R3 (App delete cascade): #65
- 🟠 R6 (Dashboard polling): #66
- 🟠 R2 + R4 + R5: this PR

Dashboard improvement turn (DPR-1 / DPR-2 / DPR-3) and F12 (TanStack Query) are also complete. The next planned work is Phase 2 metric-driven decisions (TS SDK / launch posts / Phase 3 readiness gate).