### PR TITLE
refactor(api+infra): extract AuditLogRepository to fix repository-pattern bypass

### DIFF
--- a/src/WebhookEngine.API/Controllers/AuditLogsController.cs
+++ b/src/WebhookEngine.API/Controllers/AuditLogsController.cs
@@ -2,9 +2,8 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using WebhookEngine.API.Contracts;
-using WebhookEngine.Infrastructure.Data;
+using WebhookEngine.Infrastructure.Repositories;
 
 namespace WebhookEngine.API.Controllers;
 
@@ -23,11 +22,11 @@ public class AuditLogsController : ControllerBase
 {
     private const int MaxPageSize = 100;
 
-    private readonly WebhookDbContext _dbContext;
+    private readonly AuditLogRepository _auditLogRepo;
 
-    public AuditLogsController(WebhookDbContext dbContext)
+    public AuditLogsController(AuditLogRepository auditLogRepo)
     {
-        _dbContext = dbContext;
+        _auditLogRepo = auditLogRepo;
     }
 
     [HttpGet]
@@ -45,51 +44,24 @@ public class AuditLogsController : ControllerBase
         page = Math.Max(1, page);
         pageSize = Math.Clamp(pageSize, 1, MaxPageSize);
 
-        var query = _dbContext.AuditLogs.AsNoTracking().AsQueryable();
-
-        if (appId.HasValue) query = query.Where(l => l.AppId == appId);
-        if (!string.IsNullOrWhiteSpace(action)) query = query.Where(l => l.Action == action);
-        if (!string.IsNullOrWhiteSpace(resourceType)) query = query.Where(l => l.ResourceType == resourceType);
-        if (resourceId.HasValue) query = query.Where(l => l.ResourceId == resourceId);
-        if (from.HasValue) query = query.Where(l => l.CreatedAt >= from);
-        if (to.HasValue) query = query.Where(l => l.CreatedAt <= to);
-
-        var total = await query.CountAsync(ct);
-        var rows = await query
-            .OrderByDescending(l => l.CreatedAt)
-            .Skip((page - 1) * pageSize)
-            .Take(pageSize)
-            .Select(l => new
-            {
-                id = l.Id,
-                appId = l.AppId,
-                userId = l.UserId,
-                action = l.Action,
-                resourceType = l.ResourceType,
-                resourceId = l.ResourceId,
-                before = l.BeforeJson,
-                after = l.AfterJson,
-                ipAddress = l.IpAddress,
-                userAgent = l.UserAgent,
-                createdAt = l.CreatedAt
-            })
-            .ToListAsync(ct);
+        var (rows, total) = await _auditLogRepo.ListAsync(
+            appId, action, resourceType, resourceId, from, to, page, pageSize, ct);
 
         // Re-shape before/after as JsonElement so the client can render them
         // as structured JSON instead of escaped strings.
         var hydrated = rows.Select(r => new
         {
-            r.id,
-            r.appId,
-            r.userId,
-            r.action,
-            r.resourceType,
-            r.resourceId,
-            before = ParseJson(r.before),
-            after = ParseJson(r.after),
-            r.ipAddress,
-            r.userAgent,
-            r.createdAt
+            id = r.Id,
+            appId = r.AppId,
+            userId = r.UserId,
+            action = r.Action,
+            resourceType = r.ResourceType,
+            resourceId = r.ResourceId,
+            before = ParseJson(r.BeforeJson),
+            after = ParseJson(r.AfterJson),
+            ipAddress = r.IpAddress,
+            userAgent = r.UserAgent,
+            createdAt = r.CreatedAt
         });
 
         return Ok(ApiEnvelope.Success(HttpContext, hydrated, ApiEnvelope.Pagination(page, pageSize, total)));

--- a/src/WebhookEngine.API/Program.cs
+++ b/src/WebhookEngine.API/Program.cs
@@ -120,6 +120,7 @@ builder.Services.AddScoped<MessageRepository>();
 builder.Services.AddScoped<EventTypeRepository>();
 builder.Services.AddScoped<DashboardUserRepository>();
 builder.Services.AddScoped<DashboardStatsRepository>();
+builder.Services.AddScoped<AuditLogRepository>();
 
 // Services
 builder.Services.AddScoped<IMessageQueue, PostgresMessageQueue>();

--- a/src/WebhookEngine.Infrastructure/Repositories/AuditLogRepository.cs
+++ b/src/WebhookEngine.Infrastructure/Repositories/AuditLogRepository.cs
@@ -1,0 +1,45 @@
+using Microsoft.EntityFrameworkCore;
+using WebhookEngine.Core.Entities;
+using WebhookEngine.Infrastructure.Data;
+
+namespace WebhookEngine.Infrastructure.Repositories;
+
+public class AuditLogRepository
+{
+    private readonly WebhookDbContext _dbContext;
+
+    public AuditLogRepository(WebhookDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<(List<AuditLog> Rows, int Total)> ListAsync(
+        Guid? appId,
+        string? action,
+        string? resourceType,
+        Guid? resourceId,
+        DateTime? from,
+        DateTime? to,
+        int page,
+        int pageSize,
+        CancellationToken ct = default)
+    {
+        var query = _dbContext.AuditLogs.AsNoTracking().AsQueryable();
+
+        if (appId.HasValue) query = query.Where(l => l.AppId == appId);
+        if (!string.IsNullOrWhiteSpace(action)) query = query.Where(l => l.Action == action);
+        if (!string.IsNullOrWhiteSpace(resourceType)) query = query.Where(l => l.ResourceType == resourceType);
+        if (resourceId.HasValue) query = query.Where(l => l.ResourceId == resourceId);
+        if (from.HasValue) query = query.Where(l => l.CreatedAt >= from);
+        if (to.HasValue) query = query.Where(l => l.CreatedAt <= to);
+
+        var total = await query.CountAsync(ct);
+        var rows = await query
+            .OrderByDescending(l => l.CreatedAt)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(ct);
+
+        return (rows, total);
+    }
+}


### PR DESCRIPTION
## Summary

Every other dashboard controller injects a concrete `*Repository` (per `.claude/rules/backend-api.md` and `.claude/rules/infrastructure.md`) and reads through it. `AuditLogsController.List` was the lone holdout — it built its `IQueryable` directly off `WebhookDbContext` and applied six conditional `Where` filters inline.

This PR moves the filter chain + paginated read into a new `AuditLogRepository.ListAsync(...)` that returns `(Rows, Total)`. The controller keeps the `JsonElement` before/after hydration since that is HTTP response-shaping, not persistence.

**No behavior change** — same `Where` filters, same `OrderByDescending(CreatedAt)`, same `Skip/Take`, same `AsNoTracking()`. The repository follows the existing convention used by `EventTypeRepository` etc. (concrete class, no interface, `WebhookDbContext`-only constructor, `CancellationToken ct = default` at the tail).

## Test plan

- [x] `dotnet build` clean (0 warnings, 0 errors)
- [ ] CI green — existing `AuditLoggingTests` integration suite covers the controller → repo path end-to-end without modification