### PR TITLE
chore: set up Bun workspaces for the engine and future packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,8 @@ jobs:
         with:
           bun-version: ${{ env.BUN_VERSION }}
 
-      - name: Install dependencies
+      - name: Install dependencies (workspace root)
+        working-directory: .
         run: bun install --frozen-lockfile
 
       - name: Lint

--- a/.github/workflows/sync-bun-lock.yml
+++ b/.github/workflows/sync-bun-lock.yml
@@ -1,11 +1,12 @@
 name: Sync bun.lock for Dependabot
 
 # Dependabot only knows about npm — when it bumps a package in
-# src/dashboard/package.json it does NOT regenerate src/dashboard/bun.lock,
-# and CI's `bun install --frozen-lockfile` then fails with a lockfile drift.
-# This workflow auto-runs `bun install` on Dependabot PRs that touch the
-# dashboard's package.json and commits the refreshed lockfile back to the
-# PR branch so CI can go green without a manual sync commit.
+# src/dashboard/package.json it does NOT regenerate the workspace-root
+# bun.lock, and CI's `bun install --frozen-lockfile` then fails with a
+# lockfile drift. This workflow auto-runs `bun install` from the workspace
+# root on Dependabot PRs that touch the dashboard's package.json and
+# commits the refreshed lockfile back to the PR branch so CI can go green
+# without a manual sync commit.
 #
 # Trigger is `pull_request_target` so the workflow runs with write access
 # to the base repo (needed to push the lockfile back); we still gate on
@@ -40,12 +41,10 @@ jobs:
         with:
           bun-version: ${{ env.BUN_VERSION }}
 
-      - name: Regenerate lockfile
-        working-directory: src/dashboard
+      - name: Regenerate lockfile (workspace root)
         run: bun install --no-save
 
       - name: Commit and push if lockfile changed
-        working-directory: src/dashboard
         run: |
           if git diff --quiet bun.lock; then
             echo "::notice::bun.lock is already in sync with package.json"

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,10 @@
   "workspaces": {
     "": {
       "name": "webhookengine-dashboard",
+    },
+    "src/dashboard": {
+      "name": "webhookengine-dashboard",
+      "version": "0.1.6",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.2",
         "@codemirror/language": "^6.12.3",
@@ -583,6 +587,8 @@
     "vite": ["vite@8.0.11", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.14", "rolldown": "1.0.0-rc.18", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow=="],
 
     "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
+
+    "webhookengine-dashboard": ["webhookengine-dashboard@workspace:src/dashboard"],
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,12 +3,16 @@
 # ============================================================
 # Image digests pinned so Dependabot can track and bump them.
 FROM oven/bun:1-alpine@sha256:4de475389889577f346c636f956b42a5c31501b654664e9ae5726f94d7bb5349 AS dashboard-build
-WORKDIR /dashboard
+WORKDIR /workspace
 
-COPY src/dashboard/package.json src/dashboard/bun.lock ./
+# Workspace plumbing: install from the root so Bun resolves the workspace
+# graph correctly. Only the package manifests are copied for layer caching.
+COPY package.json bun.lock ./
+COPY src/dashboard/package.json src/dashboard/package.json
 RUN bun install --frozen-lockfile
 
-COPY src/dashboard/ .
+COPY src/dashboard src/dashboard
+WORKDIR /workspace/src/dashboard
 RUN bun run build
 
 # ============================================================
@@ -35,8 +39,8 @@ COPY src/ src/
 
 # Copy dashboard build output into wwwroot before publish.
 # Vite outDir is configured as ../WebhookEngine.API/wwwroot, which resolves
-# to /WebhookEngine.API/wwwroot inside the dashboard-build stage.
-COPY --from=dashboard-build /WebhookEngine.API/wwwroot/ src/WebhookEngine.API/wwwroot/
+# to /workspace/src/WebhookEngine.API/wwwroot inside the dashboard-build stage.
+COPY --from=dashboard-build /workspace/src/WebhookEngine.API/wwwroot/ src/WebhookEngine.API/wwwroot/
 
 RUN dotnet publish src/WebhookEngine.API/WebhookEngine.API.csproj \
     -c Release \

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "webhook-engine",
+  "private": true,
+  "workspaces": [
+    "src/dashboard",
+    "packages/*"
+  ]
+}


### PR DESCRIPTION
## Summary

**Step 1 of the B1 (embeddable customer portal) plan.** Promote the dashboard from a single-package layout to a Bun workspace so the upcoming `packages/endpoint-manager/` (and Phase 3's `<NotificationInbox />`) can land at `packages/*` without a second migration.

### What lands

- **New root `package.json`** with `workspaces: ["src/dashboard", "packages/*"]` and `"private": true`. No shared deps yet — each workspace member keeps its own scripts.
- **`src/dashboard/bun.lock` moved to the workspace root.** Bun produces a single lockfile for the whole graph; `bun install` from the root resolves both members. The new lockfile carries a `webhookengine-dashboard@workspace:src/dashboard` entry.
- **`docker/Dockerfile` dashboard build stage rewritten:**
  - Copy root `package.json` + `bun.lock` + `src/dashboard/package.json` for layer caching
  - Install from `/workspace`
  - Then `cd src/dashboard && bun run build`
  - The Vite `outDir` is unchanged (`../WebhookEngine.API/wwwroot`), so the publish stage's COPY source path becomes `/workspace/src/WebhookEngine.API/wwwroot`.
- **`.github/workflows/ci.yml` install step** runs from the workspace root via a one-line `working-directory: .` override; lint / typecheck / build still inherit the dashboard's `working-directory` default.
- **`.github/workflows/sync-bun-lock.yml` updated** for the lockfile's new home — `bun install --no-save` from the root, `git diff bun.lock` from the root.

### What does NOT change

- No new runtime or dev dependencies.
- No source code changes.
- No new published artifact.
- The dashboard's own `package.json` is untouched (still `"name": "webhookengine-dashboard"`, version `0.1.6`).
- No `packageManager` field on the new root — `oven-sh/setup-bun@v2` already pins `BUN_VERSION: "1.2.x"` in the workflow env, and a second source of truth would just drift.
- No Turborepo / Nx layered on top — single workspace with one lockfile is enough for two packages.

### Local validation

- [x] `bun install` from root regenerates the workspace lockfile cleanly
- [x] `bun run typecheck` / `lint` / `build` from `src/dashboard` all succeed
- [x] `dotnet build WebhookEngine.sln` clean (0 warnings, 0 errors)

### Test plan

- [ ] CI green (Backend + Frontend + Docker + CodeQL csharp + CodeQL js-ts)
- [ ] Docker build stage produces the same `wwwroot` output (verified via `docker build` job)

### Follows

- Step 2: `Application.PortalSigningKey` + `AllowedPortalOrigins` columns + EF migration (will require explicit user consent per project rule)
- Steps 3-11: see B1 plan