### PR TITLE
feat(core+infra): add Application.PortalSigningKey + AllowedPortalOriginsJson (B1 Step 2)

### DIFF
--- a/src/WebhookEngine.Core/Entities/Application.cs
+++ b/src/WebhookEngine.Core/Entities/Application.cs
@@ -23,6 +23,23 @@ public class Application
     /// </summary>
     public int? RateLimitPerSecond { get; set; }
 
+    /// <summary>
+    /// HMAC-SHA256 secret used to verify short-lived portal JWTs that the host
+    /// SaaS mints for its end-users. Null = the embeddable customer portal is
+    /// disabled for this application. Treat as a secret: never returned through
+    /// list/read APIs, never written to the audit log; only the dedicated
+    /// rotation endpoint exposes the raw value, and only at generation time.
+    /// </summary>
+    public string? PortalSigningKey { get; set; }
+
+    /// <summary>
+    /// JSON-serialized array of allowed CORS origins for portal endpoints
+    /// (e.g. <c>["https://app.acme.com"]</c>). Wildcards are intentionally not
+    /// supported — the host SaaS must enumerate exact origins. Null = portal
+    /// CORS is unconfigured (effectively no allowed origins).
+    /// </summary>
+    public string? AllowedPortalOriginsJson { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 

--- a/src/WebhookEngine.Infrastructure/Data/WebhookDbContext.cs
+++ b/src/WebhookEngine.Infrastructure/Data/WebhookDbContext.cs
@@ -46,6 +46,12 @@ public class WebhookDbContext : DbContext
                 .HasColumnName("retention_dead_letter_days");
             entity.Property(e => e.RateLimitPerSecond)
                 .HasColumnName("rate_limit_per_second");
+            entity.Property(e => e.PortalSigningKey)
+                .HasColumnName("portal_signing_key")
+                .HasMaxLength(64);
+            entity.Property(e => e.AllowedPortalOriginsJson)
+                .HasColumnName("allowed_portal_origins")
+                .HasColumnType("jsonb");
 
             entity.HasIndex(e => e.ApiKeyPrefix).IsUnique();
         });

--- a/src/WebhookEngine.Infrastructure/Migrations/20260510152238_AddPortalAccessFieldsToApplication.Designer.cs
+++ b/src/WebhookEngine.Infrastructure/Migrations/20260510152238_AddPortalAccessFieldsToApplication.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WebhookEngine.Infrastructure.Data;
@@ -11,9 +12,11 @@ using WebhookEngine.Infrastructure.Data;
 namespace WebhookEngine.Infrastructure.Migrations
 {
     [DbContext(typeof(WebhookDbContext))]
-    partial class WebhookDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260510152238_AddPortalAccessFieldsToApplication")]
+    partial class AddPortalAccessFieldsToApplication
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/WebhookEngine.Infrastructure/Migrations/20260510152238_AddPortalAccessFieldsToApplication.cs
+++ b/src/WebhookEngine.Infrastructure/Migrations/20260510152238_AddPortalAccessFieldsToApplication.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WebhookEngine.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPortalAccessFieldsToApplication : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "allowed_portal_origins",
+                table: "applications",
+                type: "jsonb",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "portal_signing_key",
+                table: "applications",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "allowed_portal_origins",
+                table: "applications");
+
+            migrationBuilder.DropColumn(
+                name: "portal_signing_key",
+                table: "applications");
+        }
+    }
+}

--- a/tests/WebhookEngine.Core.Tests/Entities/ApplicationEntityTests.cs
+++ b/tests/WebhookEngine.Core.Tests/Entities/ApplicationEntityTests.cs
@@ -40,4 +40,29 @@ public class ApplicationEntityTests
         // Default: [5,30,120,900,3600,21600,86400]
         app.RetryPolicyJson.Should().Contain("[5,30,120,900,3600,21600,86400]");
     }
+
+    [Fact]
+    public void New_Application_Defaults_Both_Portal_Fields_To_Null()
+    {
+        var app = new Application();
+
+        // Portal access is opt-in; a freshly-created application has no
+        // signing key and no allowed origins, which is the "portal disabled"
+        // state the API auth path will check for.
+        app.PortalSigningKey.Should().BeNull();
+        app.AllowedPortalOriginsJson.Should().BeNull();
+    }
+
+    [Fact]
+    public void Application_Can_Set_And_Read_PortalSigningKey_And_AllowedPortalOriginsJson()
+    {
+        var app = new Application
+        {
+            PortalSigningKey = "base64-encoded-32-byte-secret",
+            AllowedPortalOriginsJson = """["https://app.acme.com","https://staging.acme.com"]"""
+        };
+
+        app.PortalSigningKey.Should().Be("base64-encoded-32-byte-secret");
+        app.AllowedPortalOriginsJson.Should().Be("""["https://app.acme.com","https://staging.acme.com"]""");
+    }
 }


### PR DESCRIPTION
## Summary

**Step 2 of the B1 (embeddable customer portal) plan.** Two nullable, additive columns on the existing `applications` table — no behavior change yet, no API surface yet, just the persistence shape that Steps 3-5 will read from.

### What lands

- **`Application.PortalSigningKey`** (`string?`, max 64 chars) — per-app HMAC-SHA256 secret that signs short-lived portal JWTs. Host SaaS mints a 5-15 min token with this secret on its own backend; the WebhookEngine API only verifies, never returns or logs the key. Generated lazily by the operator from the dashboard (Step 5).
- **`Application.AllowedPortalOriginsJson`** (`string?`, jsonb) — JSON array of CORS origins allowed for the new `/api/v1/portal/*` routes. **Wildcards intentionally not supported** — each origin is enumerated explicitly so a leaked token can't be reused from arbitrary domains.

### Migration `AddPortalAccessFieldsToApplication`

Fully additive, fully reversible:

```sql
-- Up()
ALTER TABLE applications ADD COLUMN allowed_portal_origins jsonb NULL;
ALTER TABLE applications ADD COLUMN portal_signing_key varchar(64) NULL;

-- Down()
ALTER TABLE applications DROP COLUMN portal_signing_key;
ALTER TABLE applications DROP COLUMN allowed_portal_origins;
```

No defaults, no indexes, no constraints. Existing rows are unaffected; new rows default both to NULL.

### Audit-log secret-leak risk: pre-handled

`AuditLogger.LogAsync` JSON-serializes whatever the caller passes — so a raw `Application` entity would leak `PortalSigningKey` to plaintext snapshots. **This is not a problem here** because `ApplicationsController` already builds explicit anonymous-object `before`/`after` snapshots that never include the raw entity (`ApplicationsController.cs:142` carries the comment that pinned this convention to protect `SigningSecret` / `ApiKeyHash`). `PortalSigningKey` falls into the same protected-by-construction path.

**Forward-looking reminder for Step 4 / Step 5 implementer:** when the rotation endpoint lands, do NOT add `portalSigningKey` to the audit `before`/`after` snapshot. Use a shape like `new { allowedPortalOrigins, portalEnabled = application.PortalSigningKey is not null }`.

### Tests

Two new facts in `ApplicationEntityTests.cs`:
- `New_Application_Defaults_Both_Portal_Fields_To_Null`
- `Application_Can_Set_And_Read_PortalSigningKey_And_AllowedPortalOriginsJson`

No new repository tests — `ApplicationRepositoryTests.cs` doesn't exist (only `EndpointRepositoryTests.cs` and `MessageRepositoryTests.cs` live in `tests/WebhookEngine.Infrastructure.Tests/Repositories/`). The Testcontainers-backed `EndToEnd/` suite exercises the migration on real Postgres, so a missing column would fail CI loudly anyway.

### Test plan

- [x] `dotnet build WebhookEngine.sln` clean (0 warnings, 0 errors)
- [ ] CI green
- [ ] EndToEnd Testcontainers tests still pass (migration auto-applies on container start)

### Follows

- Step 3: `PortalTokenAuthMiddleware` + JWT validation
- Step 4: `PortalEndpointsController` (the new `/api/v1/portal/*` routes)
- Step 5: dashboard "Portal access" UI (key generate/rotate, allowed origins)