### PR TITLE
feat(api+core+infra): portal token auth middleware with HS256 JWT (B1 Step 3)

### DIFF
--- a/src/WebhookEngine.API/Middleware/ApiKeyAuthMiddleware.cs
+++ b/src/WebhookEngine.API/Middleware/ApiKeyAuthMiddleware.cs
@@ -22,13 +22,16 @@ public class ApiKeyAuthMiddleware
 
     public async Task InvokeAsync(HttpContext context)
     {
-        // Only apply to /api/v1/* routes (except auth endpoints)
+        // Only apply to /api/v1/* routes (except auth, dashboard, applications,
+        // health, metrics, and the embeddable customer portal — the portal
+        // has its own JWT-based middleware that runs after this one).
         var path = context.Request.Path.Value ?? "";
         if (!path.StartsWith("/api/v1/")
             || path.StartsWith("/api/v1/auth")
             || path.StartsWith("/api/v1/dashboard")
             || path.StartsWith("/api/v1/applications")
             || path.StartsWith("/api/v1/health")
+            || path.StartsWith("/api/v1/portal")
             || path.StartsWith("/metrics"))
         {
             await _next(context);

--- a/src/WebhookEngine.API/Middleware/PortalCorsMiddleware.cs
+++ b/src/WebhookEngine.API/Middleware/PortalCorsMiddleware.cs
@@ -1,0 +1,106 @@
+using WebhookEngine.Core.Utilities;
+using WebhookEngine.Infrastructure.Repositories;
+using WebhookEngine.Infrastructure.Services;
+
+namespace WebhookEngine.API.Middleware;
+
+/// <summary>
+/// Per-app CORS for the embeddable customer portal. Only touches paths under
+/// <c>/api/v1/portal/</c>. Allowed origins are stored on each
+/// <c>Application.AllowedPortalOriginsJson</c> — wildcards are intentionally
+/// not supported.
+///
+/// Ordering rule (load-bearing): for non-OPTIONS requests this middleware
+/// MUST run AFTER <see cref="PortalTokenAuthMiddleware"/>, because it reads
+/// <c>HttpContext.Items["PortalAppLookup"]</c> populated by the token
+/// validator. OPTIONS preflight has no token (browsers don't send one), so
+/// this middleware does its own bounded "any-app-allows-this-origin" lookup
+/// against <see cref="ApplicationRepository.AnyAllowsPortalOriginAsync"/>.
+/// </summary>
+public class PortalCorsMiddleware
+{
+    private const string PortalPathPrefix = "/api/v1/portal/";
+    private const string AllowedMethods = "GET,POST,PUT,DELETE,OPTIONS";
+    private const string AllowedHeaders = "Authorization,Content-Type";
+    private const string PreflightMaxAge = "600";
+
+    private readonly RequestDelegate _next;
+
+    public PortalCorsMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var path = context.Request.Path.Value ?? string.Empty;
+        if (!path.StartsWith(PortalPathPrefix, StringComparison.Ordinal))
+        {
+            await _next(context);
+            return;
+        }
+
+        var origin = context.Request.Headers.Origin.FirstOrDefault();
+        if (string.IsNullOrEmpty(origin))
+        {
+            await _next(context);
+            return;
+        }
+
+        if (HttpMethods.IsOptions(context.Request.Method))
+        {
+            await HandlePreflightAsync(context, origin);
+            return;
+        }
+
+        // Real request: token middleware should have populated the lookup
+        // in Items. If it didn't, the request is already on its way to a
+        // 401 from the token middleware — don't add CORS headers since the
+        // browser would surface a confusing CORS error rather than the
+        // intended 401.
+        if (context.Items[PortalTokenAuthMiddleware.AppLookupItemKey] is not PortalAppLookup lookup)
+        {
+            await _next(context);
+            return;
+        }
+
+        // RFC 6454 §4 makes scheme + host case-insensitive. Browsers send a
+        // lowercased Origin but a stored allowlist entry may have drifted.
+        if (lookup.AllowedOrigins.Any(o => string.Equals(o, origin, StringComparison.OrdinalIgnoreCase)))
+        {
+            ApplyCorsHeaders(context, origin);
+        }
+
+        await _next(context);
+    }
+
+    private static async Task HandlePreflightAsync(HttpContext context, string origin)
+    {
+        var appRepo = context.RequestServices.GetRequiredService<ApplicationRepository>();
+        var allowed = await appRepo.AnyAllowsPortalOriginAsync(origin, context.RequestAborted);
+
+        var logger = context.RequestServices
+            .GetRequiredService<ILoggerFactory>()
+            .CreateLogger("WebhookEngine.API.Middleware.PortalCorsMiddleware");
+
+        if (!allowed)
+        {
+            logger.LogInformation("Portal CORS preflight rejected for origin {Origin}.",
+                LogSanitizer.ForLog(origin));
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            return;
+        }
+
+        ApplyCorsHeaders(context, origin);
+        context.Response.Headers.Append("Access-Control-Allow-Methods", AllowedMethods);
+        context.Response.Headers.Append("Access-Control-Allow-Headers", AllowedHeaders);
+        context.Response.Headers.Append("Access-Control-Max-Age", PreflightMaxAge);
+        context.Response.StatusCode = StatusCodes.Status204NoContent;
+    }
+
+    private static void ApplyCorsHeaders(HttpContext context, string origin)
+    {
+        context.Response.Headers.Append("Access-Control-Allow-Origin", origin);
+        context.Response.Headers.Append("Vary", "Origin");
+    }
+}

--- a/src/WebhookEngine.API/Middleware/PortalTokenAuthMiddleware.cs
+++ b/src/WebhookEngine.API/Middleware/PortalTokenAuthMiddleware.cs
@@ -1,0 +1,231 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using WebhookEngine.Core.Enums;
+using WebhookEngine.Core.Options;
+using WebhookEngine.Core.Utilities;
+using WebhookEngine.Infrastructure.Services;
+
+namespace WebhookEngine.API.Middleware;
+
+/// <summary>
+/// Validates short-lived HS256 JWTs minted by host SaaS backends for the
+/// embeddable customer portal. The host signs with the per-app
+/// <c>PortalSigningKey</c>; this middleware only verifies — it never mints
+/// and never returns the signing key (that lives on the rotation endpoint).
+///
+/// Only paths under <c>/api/v1/portal/</c> are touched; CORS preflight
+/// (<c>OPTIONS</c>) is left to <see cref="PortalCorsMiddleware"/>.
+///
+/// On success: populates <c>HttpContext.Items["AppId"]</c>,
+/// <c>["PortalCapabilities"]</c>, and <c>["PortalAppLookup"]</c>.
+/// </summary>
+public class PortalTokenAuthMiddleware
+{
+    public const string AppIdItemKey = "AppId";
+    public const string CapabilitiesItemKey = "PortalCapabilities";
+    public const string AppLookupItemKey = "PortalAppLookup";
+
+    private const string PortalPathPrefix = "/api/v1/portal/";
+    private const string AppIdClaim = "appId";
+    private const string CapabilitiesClaim = "capabilities";
+
+    private static readonly JwtSecurityTokenHandler TokenHandler = new();
+
+    private readonly RequestDelegate _next;
+
+    public PortalTokenAuthMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var path = context.Request.Path.Value ?? string.Empty;
+        if (!path.StartsWith(PortalPathPrefix, StringComparison.Ordinal))
+        {
+            await _next(context);
+            return;
+        }
+
+        if (HttpMethods.IsOptions(context.Request.Method))
+        {
+            await _next(context);
+            return;
+        }
+
+        var logger = context.RequestServices
+            .GetRequiredService<ILoggerFactory>()
+            .CreateLogger("WebhookEngine.API.Middleware.PortalTokenAuthMiddleware");
+
+        var authHeader = context.Request.Headers.Authorization.FirstOrDefault();
+        if (string.IsNullOrEmpty(authHeader) || !authHeader.StartsWith("Bearer ", StringComparison.Ordinal))
+        {
+            await WriteUnauthorizedAsync(context, "PORTAL_AUTH_REQUIRED",
+                "Portal endpoints require a Bearer JWT minted by the host application.");
+            return;
+        }
+
+        var rawToken = authHeader["Bearer ".Length..].Trim();
+        if (string.IsNullOrEmpty(rawToken))
+        {
+            await WriteUnauthorizedAsync(context, "PORTAL_AUTH_REQUIRED",
+                "Portal endpoints require a Bearer JWT minted by the host application.");
+            return;
+        }
+
+        // Read the token without validation first to extract the appId claim
+        // — needed to find the per-app signing key. The signature check
+        // happens in step 6; until then this MUST NOT trust any other claim.
+        JwtSecurityToken unverified;
+        try
+        {
+            unverified = TokenHandler.ReadJwtToken(rawToken);
+        }
+        catch (Exception)
+        {
+            await WriteUnauthorizedAsync(context, "PORTAL_AUTH_INVALID_TOKEN",
+                "Portal token is malformed.");
+            return;
+        }
+
+        var appIdClaimValue = unverified.Claims.FirstOrDefault(c => c.Type == AppIdClaim)?.Value;
+        if (string.IsNullOrEmpty(appIdClaimValue) || !Guid.TryParse(appIdClaimValue, out var appId))
+        {
+            await WriteUnauthorizedAsync(context, "PORTAL_AUTH_INVALID_TOKEN",
+                "Portal token is missing a valid appId claim.");
+            return;
+        }
+
+        var lookupCache = context.RequestServices.GetRequiredService<PortalLookupCache>();
+        var lookup = await lookupCache.GetAsync(appId, context.RequestAborted);
+        if (lookup is null)
+        {
+            logger.LogWarning("Portal auth rejected for app {AppId}: portal not enabled.",
+                LogSanitizer.ForLog(appId.ToString()));
+            await WriteUnauthorizedAsync(context, "PORTAL_NOT_ENABLED",
+                "The portal is not enabled for this application.");
+            return;
+        }
+
+        var options = context.RequestServices.GetRequiredService<IOptions<PortalAuthOptions>>().Value;
+
+        var validationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = false,
+            ValidateAudience = false,
+            ValidateLifetime = true,
+            ValidateIssuerSigningKey = true,
+            RequireSignedTokens = true,
+            RequireExpirationTime = true,
+            ClockSkew = TimeSpan.FromSeconds(options.ClockSkewSeconds),
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(lookup.PortalSigningKey)),
+            // HS256-only allowlist — defends against algorithm confusion
+            // (e.g. unsigned "alg=none" tokens, or RS256 tokens whose public
+            // key is interpreted as an HMAC secret).
+            ValidAlgorithms = new[] { SecurityAlgorithms.HmacSha256 }
+        };
+
+        ClaimsPrincipal principal;
+        SecurityToken validatedToken;
+        try
+        {
+            principal = TokenHandler.ValidateToken(rawToken, validationParameters, out validatedToken);
+        }
+        catch (SecurityTokenExpiredException)
+        {
+            await WriteUnauthorizedAsync(context, "PORTAL_AUTH_TOKEN_EXPIRED",
+                "Portal token has expired.");
+            return;
+        }
+        catch (SecurityTokenSignatureKeyNotFoundException)
+        {
+            await WriteUnauthorizedAsync(context, "PORTAL_AUTH_INVALID_SIGNATURE",
+                "Portal token signature could not be verified.");
+            return;
+        }
+        catch (SecurityTokenInvalidSignatureException)
+        {
+            await WriteUnauthorizedAsync(context, "PORTAL_AUTH_INVALID_SIGNATURE",
+                "Portal token signature could not be verified.");
+            return;
+        }
+        catch (Exception)
+        {
+            // Catch-all (algorithm rejected, malformed claims, lifetime
+            // missing, etc.). NEVER echo the inner exception — the message
+            // can leak signing-key length, claim positions, or which
+            // validation step failed.
+            await WriteUnauthorizedAsync(context, "PORTAL_AUTH_INVALID_TOKEN",
+                "Portal token is invalid.");
+            return;
+        }
+
+        if (validatedToken is not JwtSecurityToken jwt)
+        {
+            await WriteUnauthorizedAsync(context, "PORTAL_AUTH_INVALID_TOKEN",
+                "Portal token is invalid.");
+            return;
+        }
+
+        // Lifetime cap: reject tokens whose declared `exp - nbf` window
+        // exceeds the configured ceiling, even if currently still valid.
+        // Keeps a leaked token's blast radius bounded regardless of what
+        // the host minted. `nbf` must be present so the cap is measurable;
+        // a missing `nbf` would otherwise compute a multi-thousand-year
+        // lifetime against `DateTime.MinValue` (which is the safe direction
+        // — but we want the rejection to be intentional, not accidental).
+        // We do NOT require `iat`: JwtSecurityTokenHandler does not emit it
+        // by default, and many host JWT libs follow the same convention.
+        if (jwt.ValidFrom == DateTime.MinValue)
+        {
+            await WriteUnauthorizedAsync(context, "PORTAL_AUTH_INVALID_TOKEN",
+                "Portal token is invalid.");
+            return;
+        }
+
+        var lifetime = jwt.ValidTo - jwt.ValidFrom;
+        if (lifetime > TimeSpan.FromMinutes(options.MaxLifetimeMinutes))
+        {
+            await WriteUnauthorizedAsync(context, "PORTAL_AUTH_LIFETIME_TOO_LONG",
+                $"Portal token lifetime exceeds the maximum of {options.MaxLifetimeMinutes} minutes.");
+            return;
+        }
+
+        var capabilities = ExtractCapabilities(principal);
+
+        context.Items[AppIdItemKey] = appId;
+        context.Items[CapabilitiesItemKey] = capabilities;
+        context.Items[AppLookupItemKey] = lookup;
+
+        await _next(context);
+    }
+
+    private static HashSet<PortalCapability> ExtractCapabilities(ClaimsPrincipal principal)
+    {
+        var result = new HashSet<PortalCapability>();
+        foreach (var claim in principal.FindAll(CapabilitiesClaim))
+        {
+            var parsed = PortalCapabilityExtensions.TryFromWire(claim.Value);
+            if (parsed.HasValue)
+            {
+                result.Add(parsed.Value);
+            }
+        }
+        return result;
+    }
+
+    private static async Task WriteUnauthorizedAsync(HttpContext context, string code, string message)
+    {
+        context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+        context.Response.ContentType = "application/json";
+        var requestId = context.Items["RequestId"]?.ToString() ?? "unknown";
+        await context.Response.WriteAsJsonAsync(new
+        {
+            error = new { code, message },
+            meta = new { requestId = $"req_{requestId}" }
+        });
+    }
+}

--- a/src/WebhookEngine.API/Program.cs
+++ b/src/WebhookEngine.API/Program.cs
@@ -48,6 +48,7 @@ builder.Services.Configure<DashboardAuthOptions>(builder.Configuration.GetSectio
 builder.Services.Configure<RetentionOptions>(builder.Configuration.GetSection(RetentionOptions.SectionName));
 builder.Services.Configure<RateLimitOptions>(builder.Configuration.GetSection(RateLimitOptions.SectionName));
 builder.Services.Configure<TransformationOptions>(builder.Configuration.GetSection(TransformationOptions.SectionName));
+builder.Services.Configure<PortalAuthOptions>(builder.Configuration.GetSection(PortalAuthOptions.SectionName));
 
 // Database
 builder.Services.AddDbContext<WebhookDbContext>(options =>
@@ -200,12 +201,15 @@ builder.Services.AddMvcCore(options => options.Filters.Add<FluentValidationFilte
 // SignalR
 builder.Services.AddSignalR();
 
-// In-memory cache used by ApiKeyAuthMiddleware (api-key→application) and
+// In-memory cache used by ApiKeyAuthMiddleware (api-key→application),
 // DeliveryLookupCache (event-type / subscribed-endpoints on the public
-// send path). SizeLimit caps unbounded growth in multi-tenant deployments;
-// every Set passes Size=1 so the limit translates to "10k entries".
+// send path), and PortalLookupCache (portal signing-key + allowed
+// origins per app). SizeLimit caps unbounded growth in multi-tenant
+// deployments; every Set passes Size=1 so the limit translates to
+// "10k entries".
 builder.Services.AddMemoryCache(o => o.SizeLimit = 10_000);
 builder.Services.AddScoped<DeliveryLookupCache>();
+builder.Services.AddScoped<PortalLookupCache>();
 
 // Readiness gate — flipped to true after migrations + admin seeding
 // complete. /health/ready reads this; orchestrators should probe that.
@@ -344,11 +348,23 @@ else
 }
 
 // Middleware pipeline (order matters)
+//   SecurityHeaders → MetricsAuth → RequestLogging → ExceptionHandling
+//   → ApiKeyAuth → PortalTokenAuth → PortalCors → RateLimiter
+//   → Authentication → Authorization
+//
+// PortalTokenAuth and PortalCors only act on /api/v1/portal/* requests;
+// they're inserted between ApiKeyAuth (which deliberately skips the
+// portal prefix) and the rate limiter so portal-token-derived AppIds
+// flow into the existing send-by-appid partition. PortalTokenAuth MUST
+// run before PortalCors for non-OPTIONS requests — the CORS layer reads
+// the validated app lookup from HttpContext.Items.
 app.UseMiddleware<SecurityHeadersMiddleware>();
 app.UseMiddleware<MetricsAuthMiddleware>();
 app.UseMiddleware<RequestLoggingMiddleware>();
 app.UseMiddleware<ExceptionHandlingMiddleware>();
 app.UseMiddleware<ApiKeyAuthMiddleware>();
+app.UseMiddleware<PortalTokenAuthMiddleware>();
+app.UseMiddleware<PortalCorsMiddleware>();
 app.UseRateLimiter();
 app.UseAuthentication();
 app.UseAuthorization();

--- a/src/WebhookEngine.API/WebhookEngine.API.csproj
+++ b/src/WebhookEngine.API/WebhookEngine.API.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Scalar.AspNetCore" Version="2.14.11" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/WebhookEngine.Core/Enums/PortalCapability.cs
+++ b/src/WebhookEngine.Core/Enums/PortalCapability.cs
@@ -1,0 +1,44 @@
+namespace WebhookEngine.Core.Enums;
+
+/// <summary>
+/// Capabilities a portal JWT may grant to the embedded customer portal session.
+/// Wire form is colon-delimited (e.g. <c>endpoints:read</c>) — see
+/// <see cref="PortalCapabilityExtensions"/> for round-trip helpers.
+/// </summary>
+public enum PortalCapability
+{
+    EndpointsRead,
+    EndpointsWrite,
+    EndpointsTest,
+    AttemptsRead
+}
+
+public static class PortalCapabilityExtensions
+{
+    /// <summary>
+    /// Convert the enum value to its colon-delimited wire form.
+    /// </summary>
+    public static string ToWire(this PortalCapability capability) => capability switch
+    {
+        PortalCapability.EndpointsRead => "endpoints:read",
+        PortalCapability.EndpointsWrite => "endpoints:write",
+        PortalCapability.EndpointsTest => "endpoints:test",
+        PortalCapability.AttemptsRead => "attempts:read",
+        _ => throw new ArgumentOutOfRangeException(nameof(capability), capability, null)
+    };
+
+    /// <summary>
+    /// Parse the colon-delimited wire form into an enum value. Unknown values
+    /// return <see langword="null"/> (forward-compat: tokens minted by a newer
+    /// host SaaS with capabilities this engine doesn't recognise yet are
+    /// silently dropped rather than failing the request).
+    /// </summary>
+    public static PortalCapability? TryFromWire(string? wire) => wire switch
+    {
+        "endpoints:read" => PortalCapability.EndpointsRead,
+        "endpoints:write" => PortalCapability.EndpointsWrite,
+        "endpoints:test" => PortalCapability.EndpointsTest,
+        "attempts:read" => PortalCapability.AttemptsRead,
+        _ => null
+    };
+}

--- a/src/WebhookEngine.Core/Options/PortalAuthOptions.cs
+++ b/src/WebhookEngine.Core/Options/PortalAuthOptions.cs
@@ -1,0 +1,33 @@
+namespace WebhookEngine.Core.Options;
+
+/// <summary>
+/// Tuning knobs for the embedded customer portal's JWT verification path.
+/// All values are deliberately conservative — the host SaaS mints fresh
+/// tokens per page render, so a short MaxLifetime and small ClockSkew are
+/// safe and reduce the blast radius of a leaked token.
+/// </summary>
+public class PortalAuthOptions
+{
+    public const string SectionName = "WebhookEngine:PortalAuth";
+
+    /// <summary>
+    /// Hard cap on <c>exp - nbf</c>. Tokens with a longer requested lifetime
+    /// are rejected even if currently still valid. <c>nbf</c> must be present;
+    /// <c>iat</c> is not consulted because not every JWT library emits it by
+    /// default. Defaults to 15 minutes.
+    /// </summary>
+    public int MaxLifetimeMinutes { get; set; } = 15;
+
+    /// <summary>
+    /// Allowance for clock drift between the host SaaS minter and this engine
+    /// when validating <c>nbf</c> / <c>exp</c>. Defaults to 30 seconds.
+    /// </summary>
+    public int ClockSkewSeconds { get; set; } = 30;
+
+    /// <summary>
+    /// TTL on the per-app signing-key + allowed-origins lookup cache. Trades
+    /// freshness on rotation against database round-trips per request.
+    /// Defaults to 60 seconds.
+    /// </summary>
+    public int LookupCacheTtlSeconds { get; set; } = 60;
+}

--- a/src/WebhookEngine.Infrastructure/Repositories/ApplicationRepository.cs
+++ b/src/WebhookEngine.Infrastructure/Repositories/ApplicationRepository.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using WebhookEngine.Core.Entities;
 using WebhookEngine.Infrastructure.Data;
@@ -57,5 +58,55 @@ public class ApplicationRepository
     public async Task DeleteAsync(Guid id, CancellationToken ct = default)
     {
         await _dbContext.Applications.Where(a => a.Id == id).ExecuteDeleteAsync(ct);
+    }
+
+    /// <summary>
+    /// Returns true when at least one portal-enabled application lists the
+    /// given origin in its <c>AllowedPortalOriginsJson</c>. Used by the
+    /// portal CORS layer for OPTIONS preflight, before a token is available.
+    ///
+    /// Filtering is performed in-process: the candidate set is the apps with
+    /// portal enabled (PortalSigningKey + AllowedPortalOriginsJson both set),
+    /// which is bounded and small. Doing the JSON containment in C# avoids
+    /// coupling to a provider-specific JSON translator (Npgsql vs InMemory)
+    /// and exact-string matching in the deserialized array is more strict
+    /// than a substring-style <c>JsonContains("\"origin\"")</c> probe.
+    /// </summary>
+    public async Task<bool> AnyAllowsPortalOriginAsync(string origin, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(origin))
+        {
+            return false;
+        }
+
+        var candidates = await _dbContext.Applications
+            .AsNoTracking()
+            .Where(a => a.PortalSigningKey != null && a.AllowedPortalOriginsJson != null)
+            .Select(a => a.AllowedPortalOriginsJson!)
+            .ToListAsync(ct);
+
+        foreach (var json in candidates)
+        {
+            string[]? origins;
+            try
+            {
+                origins = JsonSerializer.Deserialize<string[]>(json);
+            }
+            catch (JsonException)
+            {
+                continue;
+            }
+
+            // RFC 6454 §4 — scheme + host are case-insensitive. Match the
+            // ordinal-insensitive comparison used at request-time in
+            // PortalCorsMiddleware so preflight + real-request decisions agree.
+            if (origins is not null &&
+                origins.Any(o => string.Equals(o, origin, StringComparison.OrdinalIgnoreCase)))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/WebhookEngine.Infrastructure/Services/PortalLookupCache.cs
+++ b/src/WebhookEngine.Infrastructure/Services/PortalLookupCache.cs
@@ -1,0 +1,110 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using WebhookEngine.Core.Options;
+using WebhookEngine.Infrastructure.Repositories;
+
+namespace WebhookEngine.Infrastructure.Services;
+
+/// <summary>
+/// Per-app lookup of (PortalSigningKey, AllowedOrigins) used by the portal
+/// JWT auth + CORS middlewares on every request. Returns <see langword="null"/>
+/// when the application doesn't exist or the portal is not enabled
+/// (PortalSigningKey is null).
+///
+/// Mirrors the change-token + TTL invalidation pattern from
+/// <see cref="DeliveryLookupCache"/> so a future rotation endpoint can call
+/// <see cref="InvalidateApplication"/> for instant local invalidation
+/// without waiting for the TTL to expire.
+/// </summary>
+public sealed record PortalAppLookup(string PortalSigningKey, string[] AllowedOrigins);
+
+public class PortalLookupCache
+{
+    private static readonly ConcurrentDictionary<Guid, CancellationTokenSource> AppTokens = new();
+
+    private readonly IMemoryCache _cache;
+    private readonly ApplicationRepository _applicationRepository;
+    private readonly TimeSpan _ttl;
+
+    public PortalLookupCache(
+        IMemoryCache cache,
+        ApplicationRepository applicationRepository,
+        IOptions<PortalAuthOptions> options)
+    {
+        _cache = cache;
+        _applicationRepository = applicationRepository;
+        _ttl = TimeSpan.FromSeconds(options.Value.LookupCacheTtlSeconds);
+    }
+
+    public async Task<PortalAppLookup?> GetAsync(Guid appId, CancellationToken ct)
+    {
+        var key = $"portal:app:{appId}";
+        if (_cache.TryGetValue(key, out PortalAppLookup? cached))
+        {
+            return cached;
+        }
+
+        var app = await _applicationRepository.GetByIdAsync(appId, ct);
+        if (app is null || string.IsNullOrEmpty(app.PortalSigningKey))
+        {
+            return null;
+        }
+
+        var origins = ParseOrigins(app.AllowedPortalOriginsJson);
+        var lookup = new PortalAppLookup(app.PortalSigningKey, origins);
+        Set(appId, key, lookup);
+        return lookup;
+    }
+
+    /// <summary>
+    /// Drops every cached portal lookup for the given application synchronously
+    /// on this node. Other nodes still rely on <see cref="PortalAuthOptions.LookupCacheTtlSeconds"/>.
+    /// </summary>
+    public static void InvalidateApplication(Guid appId)
+    {
+        if (AppTokens.TryRemove(appId, out var source))
+        {
+            try
+            {
+                source.Cancel();
+            }
+            finally
+            {
+                source.Dispose();
+            }
+        }
+    }
+
+    private void Set(Guid appId, string key, PortalAppLookup value)
+    {
+        var token = AppTokens.GetOrAdd(appId, _ => new CancellationTokenSource());
+        var entryOptions = new MemoryCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = _ttl,
+            Size = 1
+        };
+        entryOptions.AddExpirationToken(new CancellationChangeToken(token.Token));
+        _cache.Set(key, value, entryOptions);
+    }
+
+    private static string[] ParseOrigins(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return [];
+        }
+
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<string[]>(json);
+            return parsed ?? [];
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+    }
+}

--- a/tests/WebhookEngine.API.Tests/Portal/PortalTokenAuthMiddlewareTests.cs
+++ b/tests/WebhookEngine.API.Tests/Portal/PortalTokenAuthMiddlewareTests.cs
@@ -1,0 +1,309 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.IdentityModel.Tokens;
+using WebhookEngine.API.Middleware;
+using WebhookEngine.Core.Entities;
+using WebhookEngine.Infrastructure.Data;
+
+namespace WebhookEngine.API.Tests.Portal;
+
+/// <summary>
+/// Verifies the five contractual rejection / acceptance paths for
+/// <c>PortalTokenAuthMiddleware</c>. Capability-scoping tests are
+/// out of scope until the portal route group lands in Step 4.
+///
+/// Uses a custom <see cref="WebApplicationFactory{TEntryPoint}"/> that
+/// stands up a self-contained pipeline around the middleware itself
+/// rather than the production <c>Program.cs</c>. This sidesteps the
+/// MVC application-part discovery quirk (test-project controllers
+/// aren't picked up by <c>AddControllers().AddApplicationPart</c> after
+/// <c>Program.cs</c> has already finalized its controller feature provider)
+/// and isolates the middleware contract from the rest of the API surface.
+/// </summary>
+public class PortalTokenAuthMiddlewareTests : IClassFixture<PortalTokenAuthMiddlewareTests.MiddlewareFactory>
+{
+    private const string ValidSigningKey = "portal-signing-key-must-be-at-least-32-bytes-for-hs256!!!";
+    private const string PingPath = "/api/v1/portal/_ping";
+
+    private readonly MiddlewareFactory _factory;
+
+    public PortalTokenAuthMiddlewareTests(MiddlewareFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task Portal_Request_With_Valid_Token_Reaches_The_Endpoint()
+    {
+        var app = await SeedAppAsync(ValidSigningKey);
+        var token = MintToken(app.Id, ValidSigningKey, lifetime: TimeSpan.FromMinutes(5));
+
+        var response = await SendPingAsync(token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("pong");
+    }
+
+    [Fact]
+    public async Task Portal_Request_With_Expired_Token_Returns_401_With_TOKEN_EXPIRED()
+    {
+        var app = await SeedAppAsync(ValidSigningKey);
+        var token = MintToken(
+            app.Id,
+            ValidSigningKey,
+            lifetime: TimeSpan.FromMinutes(5),
+            // Mint a token that already expired beyond the 30 s default skew.
+            notBefore: DateTime.UtcNow.AddMinutes(-10),
+            expires: DateTime.UtcNow.AddMinutes(-5));
+
+        var response = await SendPingAsync(token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        var code = await ReadErrorCodeAsync(response);
+        code.Should().Be("PORTAL_AUTH_TOKEN_EXPIRED");
+    }
+
+    [Fact]
+    public async Task Portal_Request_With_Wrong_Signing_Key_Returns_401_With_INVALID_SIGNATURE()
+    {
+        var app = await SeedAppAsync(ValidSigningKey);
+        const string wrongKey = "this-is-the-wrong-key-also-32-bytes-or-more!!!!!!!!!!!!!!";
+        var token = MintToken(app.Id, wrongKey, lifetime: TimeSpan.FromMinutes(5));
+
+        var response = await SendPingAsync(token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        var code = await ReadErrorCodeAsync(response);
+        code.Should().Be("PORTAL_AUTH_INVALID_SIGNATURE");
+    }
+
+    [Fact]
+    public async Task Portal_Request_With_Token_For_Disabled_App_Returns_401_With_NOT_ENABLED()
+    {
+        // Portal disabled = PortalSigningKey is null on the application.
+        var app = await SeedAppAsync(portalSigningKey: null);
+        var token = MintToken(app.Id, ValidSigningKey, lifetime: TimeSpan.FromMinutes(5));
+
+        var response = await SendPingAsync(token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        var code = await ReadErrorCodeAsync(response);
+        code.Should().Be("PORTAL_NOT_ENABLED");
+    }
+
+    [Fact]
+    public async Task Portal_Request_With_Token_Lifetime_Exceeding_Limit_Returns_401_With_LIFETIME_TOO_LONG()
+    {
+        var app = await SeedAppAsync(ValidSigningKey);
+        // Default MaxLifetimeMinutes = 15. Mint a 60-minute token; the
+        // signature verifies, lifetime is currently valid, but the cap
+        // rejects it.
+        var token = MintToken(app.Id, ValidSigningKey, lifetime: TimeSpan.FromMinutes(60));
+
+        var response = await SendPingAsync(token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        var code = await ReadErrorCodeAsync(response);
+        code.Should().Be("PORTAL_AUTH_LIFETIME_TOO_LONG");
+    }
+
+    [Fact]
+    public async Task Portal_Request_With_Alg_None_Token_Is_Rejected_As_Invalid_Signature()
+    {
+        // Algorithm-confusion guard: an unsigned `alg: none` token MUST be
+        // rejected by the HS256 allowlist, never silently trusted because
+        // the signature is empty. This is the highest-CVSS class of bug
+        // for HS256 verifiers (see CVE-2015-9235 family).
+        // Microsoft.IdentityModel.Tokens 8.x maps the algorithm rejection
+        // through SecurityTokenInvalidSignatureException, which the catch
+        // ladder surfaces as PORTAL_AUTH_INVALID_SIGNATURE — the precise
+        // error code is incidental; what matters is that the token is
+        // rejected with a 401 and never reaches the protected handler.
+        var app = await SeedAppAsync(ValidSigningKey);
+        var token = MintUnsignedToken(app.Id, lifetime: TimeSpan.FromMinutes(5));
+
+        var response = await SendPingAsync(token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        var code = await ReadErrorCodeAsync(response);
+        code.Should().Be("PORTAL_AUTH_INVALID_SIGNATURE");
+    }
+
+    [Fact]
+    public async Task Portal_Request_With_HS384_Token_Is_Rejected_As_Invalid_Signature()
+    {
+        // Algorithm-confusion guard: even a valid HMAC token signed with the
+        // correct key but a different SHA variant (HS384 / HS512) is rejected
+        // because ValidAlgorithms pins HS256 only. As with the alg=none case,
+        // Microsoft.IdentityModel.Tokens 8.x routes the rejection through
+        // SecurityTokenInvalidSignatureException → PORTAL_AUTH_INVALID_SIGNATURE.
+        var app = await SeedAppAsync(ValidSigningKey);
+        var token = MintToken(
+            app.Id,
+            ValidSigningKey,
+            lifetime: TimeSpan.FromMinutes(5),
+            algorithm: SecurityAlgorithms.HmacSha384);
+
+        var response = await SendPingAsync(token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        var code = await ReadErrorCodeAsync(response);
+        code.Should().Be("PORTAL_AUTH_INVALID_SIGNATURE");
+    }
+
+    private async Task<HttpResponseMessage> SendPingAsync(string token)
+    {
+        var client = _factory.CreateClient();
+        var request = new HttpRequestMessage(HttpMethod.Get, PingPath);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return await client.SendAsync(request);
+    }
+
+    private async Task<Application> SeedAppAsync(string? portalSigningKey)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+        var app = new Application
+        {
+            Id = Guid.NewGuid(),
+            Name = $"portal-test-{Guid.NewGuid():N}",
+            ApiKeyPrefix = $"whe_{Guid.NewGuid():N}".Substring(0, 12) + "_",
+            ApiKeyHash = "deadbeef",
+            SigningSecret = "secret",
+            PortalSigningKey = portalSigningKey
+        };
+        db.Applications.Add(app);
+        await db.SaveChangesAsync();
+        return app;
+    }
+
+    private static string MintToken(
+        Guid appId,
+        string signingKey,
+        TimeSpan lifetime,
+        DateTime? notBefore = null,
+        DateTime? expires = null,
+        IEnumerable<string>? capabilities = null,
+        string algorithm = SecurityAlgorithms.HmacSha256)
+    {
+        var nbf = notBefore ?? DateTime.UtcNow;
+        var exp = expires ?? nbf.Add(lifetime);
+
+        var claims = new List<Claim>
+        {
+            new("appId", appId.ToString())
+        };
+        if (capabilities is not null)
+        {
+            foreach (var capability in capabilities)
+            {
+                claims.Add(new Claim("capabilities", capability));
+            }
+        }
+
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(signingKey));
+        var creds = new SigningCredentials(key, algorithm);
+        var token = new JwtSecurityToken(
+            issuer: null,
+            audience: null,
+            claims: claims,
+            notBefore: nbf,
+            expires: exp,
+            signingCredentials: creds);
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    /// <summary>
+    /// Hand-rolled unsigned ("alg":"none") JWT — JwtSecurityTokenHandler refuses
+    /// to write one, so the test forges the three base64url segments directly.
+    /// </summary>
+    private static string MintUnsignedToken(Guid appId, TimeSpan lifetime)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var header = JsonSerializer.Serialize(new { alg = "none", typ = "JWT" });
+        var payload = JsonSerializer.Serialize(new
+        {
+            appId = appId.ToString(),
+            iat = now.ToUnixTimeSeconds(),
+            nbf = now.ToUnixTimeSeconds(),
+            exp = now.Add(lifetime).ToUnixTimeSeconds()
+        });
+        return $"{Base64Url(header)}.{Base64Url(payload)}.";
+    }
+
+    private static string Base64Url(string s)
+    {
+        var bytes = Encoding.UTF8.GetBytes(s);
+        return Convert.ToBase64String(bytes)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+
+    private static async Task<string?> ReadErrorCodeAsync(HttpResponseMessage response)
+    {
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.GetProperty("error").GetProperty("code").GetString();
+    }
+
+    /// <summary>
+    /// Re-uses the production <see cref="Program"/> entry assembly so DI is
+    /// wired identically, but replaces the application pipeline with a
+    /// minimal one that runs only <c>PortalTokenAuthMiddleware</c> followed
+    /// by a terminal "pong" delegate. Keeps the test focus on the
+    /// middleware's contract.
+    /// </summary>
+    public sealed class MiddlewareFactory : WebApplicationFactory<Program>
+    {
+        private readonly string _dbName = $"PortalTestDb_{Guid.NewGuid()}";
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Testing");
+
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<DbContextOptions<WebhookDbContext>>();
+                services.RemoveAll<DbContextOptions>();
+                services.RemoveAll<WebhookDbContext>();
+                services.RemoveAll(typeof(IDbContextOptionsConfiguration<WebhookDbContext>));
+                services.RemoveAll<Microsoft.Extensions.Hosting.IHostedService>();
+
+                services.AddDbContext<WebhookDbContext>(options =>
+                    options.UseInMemoryDatabase(_dbName));
+            });
+
+            builder.Configure(app =>
+            {
+                app.UseMiddleware<PortalTokenAuthMiddleware>();
+                app.Run(async context =>
+                {
+                    if (context.Request.Path == PingPath)
+                    {
+                        context.Response.StatusCode = StatusCodes.Status200OK;
+                        context.Response.ContentType = "application/json";
+                        await context.Response.WriteAsync("{\"message\":\"pong\"}");
+                        return;
+                    }
+
+                    context.Response.StatusCode = StatusCodes.Status404NotFound;
+                });
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary

**Step 3 of the B1 (embeddable customer portal) plan.** Adds the auth + CORS layer for the upcoming `/api/v1/portal/*` route group (lands in Step 4) without exposing any new public routes yet.

### What lands

- **`PortalCapability` enum** (`Core/Enums`) with colon-form helpers — `endpoints:read|write|test`, `attempts:read`.
- **`PortalAuthOptions`** (`Core/Options`) — `MaxLifetimeMinutes=15`, `ClockSkewSeconds=30`, `LookupCacheTtlSeconds=60`.
- **`PortalLookupCache`** (`Infrastructure/Services`) — `IMemoryCache`-backed per-app `PortalSigningKey + AllowedOrigins` lookup, mirrors `DeliveryLookupCache` (Size=1, scoped). `InvalidateApplication` exposed for the rotation hook that lands in Step 5.
- **`PortalTokenAuthMiddleware`** — HS256 JWT validation. Pre-parses the unsigned token to extract `appId` for cache lookup; rejects with `PORTAL_NOT_ENABLED` when the app has no `PortalSigningKey`. Algorithm-pinned via `ValidAlgorithms = [HmacSha256]` (defends against `alg=none` / RS256 / HS384 confusion). Catch-ladder routes specific failures to `PORTAL_AUTH_TOKEN_EXPIRED` / `PORTAL_AUTH_INVALID_SIGNATURE`; the catch-all returns generic `PORTAL_AUTH_INVALID_TOKEN` without echoing inner-exception detail (no signing-key leak). After successful validation, enforces a hard cap on `exp - nbf` via `PORTAL_AUTH_LIFETIME_TOO_LONG` (with explicit `nbf`-presence guard). Sets `HttpContext.Items["AppId"]` so the existing per-AppId rate limiter applies to portal traffic.
- **`PortalCorsMiddleware`** — per-app dynamic CORS. OPTIONS preflight uses `ApplicationRepository.AnyAllowsPortalOriginAsync` against the bounded set of portal-enabled apps; real requests echo the validated request `Origin` (never `*`). Origin matching is RFC 6454-compliant ordinal-case-insensitive on both code paths.
- **`ApplicationRepository.AnyAllowsPortalOriginAsync`** — client-side JSONB filter (intentional fallback away from `EF.Functions.JsonContains`; the InMemory test provider does not translate it, and a substring probe would falsely match origins embedded in longer URLs).
- **`ApiKeyAuthMiddleware` skip-list** now includes `/api/v1/portal` so the JWT middleware can claim those requests instead of being short-circuited by the public-API auth.
- **`System.IdentityModel.Tokens.Jwt 8.17.0`** added directly to `WebhookEngine.API.csproj` (NOT transitively available; verified via `obj/project.assets.json`). Worker / SDK / Core untouched.
- **Pipeline order** in `Program.cs` is now `ApiKeyAuth → PortalTokenAuth → PortalCors → RateLimiter`. Comment block updated.

### Reviewer-flagged concerns addressed before this PR opened

A read-only `reviewer` agent pass produced **APPROVE WITH CAVEATS** with three medium-severity items + one missing test. All four addressed in this same branch before the PR opened:

1. **Lifetime semantics drift** — option originally documented as "exp - iat" but the code measured `exp - nbf`. Renamed the option's contract to `exp - nbf` (XML doc updated) and added an explicit `nbf`-presence guard so a missing `nbf` becomes an intentional `PORTAL_AUTH_INVALID_TOKEN` rejection rather than the accidental "lifetime ≈ thousand years → too long" path. `iat` is intentionally NOT required because `JwtSecurityTokenHandler` does not emit it by default and many host JWT libs follow the same convention.
2. **CORS origin case-sensitivity** — both `PortalCorsMiddleware:67` and `ApplicationRepository.AnyAllowsPortalOriginAsync:100` switched from ordinal `Array.IndexOf` to `OrdinalIgnoreCase` `.Any(...)`. Stored allowlist entries like `https://Customer.example.com` now match a browser-normalized `https://customer.example.com`. Step 5 should canonicalize at write time as a follow-up.
3. **Algorithm-confusion negative tests** — added `Portal_Request_With_Alg_None_Token_Is_Rejected_As_Invalid_Signature` (hand-rolled three-segment JWT — `JwtSecurityTokenHandler` refuses to write `alg: none`) and `Portal_Request_With_HS384_Token_Is_Rejected_As_Invalid_Signature` (correct key, wrong SHA variant). Both correctly route through Microsoft.IdentityModel.Tokens 8.x's `SecurityTokenInvalidSignatureException` → `PORTAL_AUTH_INVALID_SIGNATURE`. The precise error code is incidental; what matters is the 401 + the protected handler is never reached. Test docstrings call this out.

### Test count

- `WebhookEngine.API.Tests`: **72 → 79** (+7: 5 contractual paths + 2 algorithm-confusion).
- Full solution: **215 → 224**, all passing.

### Build

```
Build succeeded.
    0 Warning(s)
    0 Error(s)
```

### Test plan

- [x] `dotnet build WebhookEngine.sln` clean
- [x] `dotnet test WebhookEngine.sln` — Core 34, API 79, Worker 46, Infrastructure 65 (real Postgres via Testcontainers — migration from Step 2 applies cleanly)
- [ ] CI green

### Out of scope (per the B1 plan)

- No `PortalEndpointsController` — Step 4.
- No dashboard portal-management UI — Step 5.
- No capability-gating attribute (`[RequirePortalCapability]`) — middleware exposes the parsed set in `HttpContext.Items["PortalCapabilities"]`; route-level enforcement decision deferred to Step 4.
- No CHANGELOG entry — bundled into engine v0.2.0 release in Step 6.

### Forward-looking note for Step 5

The rotation endpoint that lands in Step 5 must:
1. NOT add `portalSigningKey` to the audit `before`/`after` snapshot. Recommended audit shape: `new { allowedPortalOrigins, portalEnabled = application.PortalSigningKey is not null }`.
2. Call `PortalLookupCache.InvalidateApplication(appId)` after writing the new key so the cache flips within milliseconds rather than within `LookupCacheTtlSeconds`.
3. Canonicalize `AllowedPortalOrigins` entries at write time (lowercase scheme + host) so the OrdinalIgnoreCase comparison at request time becomes a degenerate optimization rather than a correctness gate.