### PR TITLE
feat(api+infra): portal endpoints controller with 9 narrow routes (B1 Step 4)

### DIFF
--- a/src/WebhookEngine.API/Contracts/Portal/PortalDtos.cs
+++ b/src/WebhookEngine.API/Contracts/Portal/PortalDtos.cs
@@ -1,0 +1,215 @@
+using System.Text.Json;
+using WebhookEngine.API.Contracts;
+using WebhookEngine.Core.Entities;
+using WebhookEngine.Infrastructure.Repositories;
+using EndpointEntity = WebhookEngine.Core.Entities.Endpoint;
+
+namespace WebhookEngine.API.Contracts.Portal;
+
+/// <summary>
+/// Customer-facing endpoint summary returned by the portal list route. Drops the
+/// admin-only fields (transform-*, allowed-ips) outright; presents a boolean
+/// <see cref="HasSecretOverride"/> instead of leaking the secret value, and exposes
+/// custom-header NAMES only — values are deliberately omitted because the portal
+/// is shown to end-customers who should not see other tenants' shared secrets that
+/// host SaaS implementations sometimes plumb through custom headers.
+/// </summary>
+public sealed class PortalEndpointListItem
+{
+    public Guid Id { get; init; }
+    public string Url { get; init; } = string.Empty;
+    public string? Description { get; init; }
+    public string Status { get; init; } = string.Empty;
+    public bool HasSecretOverride { get; init; }
+    public List<string> CustomHeaderNames { get; init; } = [];
+    public JsonElement Metadata { get; init; }
+    public List<Guid> FilterEventTypes { get; init; } = [];
+    public DateTime CreatedAt { get; init; }
+    public DateTime UpdatedAt { get; init; }
+}
+
+/// <summary>
+/// Customer-facing endpoint detail. Same narrowing rules as the list shape — the
+/// transform expression, transform flags, and CIDR allowlist never reach the
+/// portal because they're host-operator concerns, not customer concerns.
+/// </summary>
+public sealed class PortalEndpointDetail
+{
+    public Guid Id { get; init; }
+    public string Url { get; init; } = string.Empty;
+    public string? Description { get; init; }
+    public string Status { get; init; } = string.Empty;
+    public bool HasSecretOverride { get; init; }
+    public List<string> CustomHeaderNames { get; init; } = [];
+    public JsonElement Metadata { get; init; }
+    public List<Guid> FilterEventTypes { get; init; } = [];
+    public DateTime CreatedAt { get; init; }
+    public DateTime UpdatedAt { get; init; }
+}
+
+/// <summary>
+/// Single attempt row served to the embedded portal. Mirrors
+/// <see cref="MessageAttemptResponseDto"/> minus request-headers / response-body
+/// (the portal is not a debugging tool — those fields stay on the dashboard).
+/// </summary>
+public sealed class PortalAttemptRow
+{
+    public Guid Id { get; init; }
+    public Guid MessageId { get; init; }
+    public int AttemptNumber { get; init; }
+    public string Status { get; init; } = string.Empty;
+    public int? StatusCode { get; init; }
+    public string? Error { get; init; }
+    public int LatencyMs { get; init; }
+    public DateTime CreatedAt { get; init; }
+}
+
+/// <summary>
+/// Portal create-endpoint payload. Transform fields and allowed-IPs are deliberately
+/// absent from this DTO — JSON model binding silently drops unknown properties so
+/// a host SaaS that mistakenly forwards an admin payload won't be rejected, the
+/// extra fields just don't reach the persistence layer.
+/// </summary>
+public class PortalCreateEndpointRequest
+{
+    public string Url { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public List<Guid>? FilterEventTypes { get; set; }
+    public Dictionary<string, string>? CustomHeaders { get; set; }
+    public Dictionary<string, string>? Metadata { get; set; }
+    // Customer-facing optional override. Empty/whitespace clears the override.
+    public string? SecretOverride { get; set; }
+}
+
+/// <summary>
+/// Portal update-endpoint payload. Same field-narrowing rationale as
+/// <see cref="PortalCreateEndpointRequest"/>.
+/// </summary>
+public class PortalUpdateEndpointRequest
+{
+    public string? Url { get; set; }
+    public string? Description { get; set; }
+    public List<Guid>? FilterEventTypes { get; set; }
+    public Dictionary<string, string>? CustomHeaders { get; set; }
+    public Dictionary<string, string>? Metadata { get; set; }
+    public string? SecretOverride { get; set; }
+}
+
+/// <summary>
+/// Portal "send test" request — same shape as the admin probe (the engine does
+/// the same signed delivery either way), kept as a separate type so portal
+/// validators can diverge later if customer-facing constraints change.
+/// </summary>
+public class PortalEndpointTestRequest
+{
+    public string? EventType { get; set; }
+    public JsonElement? Payload { get; set; }
+}
+
+/// <summary>
+/// Customer-facing event-type list item used to populate the endpoint
+/// FilterEventTypes dropdown. Archived rows are excluded at the controller.
+/// </summary>
+public sealed class PortalEventTypeListItem
+{
+    public Guid Id { get; init; }
+    public string Name { get; init; } = string.Empty;
+    public string? Description { get; init; }
+}
+
+public static class PortalDtoMapper
+{
+    public static PortalEndpointDetail ToPortalDetail(this EndpointEntity endpoint)
+    {
+        return new PortalEndpointDetail
+        {
+            Id = endpoint.Id,
+            Url = endpoint.Url,
+            Description = endpoint.Description,
+            Status = endpoint.Status.ToString().ToLowerInvariant(),
+            HasSecretOverride = !string.IsNullOrEmpty(endpoint.SecretOverride),
+            CustomHeaderNames = ParseHeaderNames(endpoint.CustomHeadersJson),
+            Metadata = JsonValueParser.ParseOrEmptyObject(endpoint.MetadataJson),
+            FilterEventTypes = endpoint.EventTypes.Select(et => et.Id).ToList(),
+            CreatedAt = endpoint.CreatedAt,
+            UpdatedAt = endpoint.UpdatedAt
+        };
+    }
+
+    public static PortalEndpointListItem ToPortalListItem(this EndpointEntity endpoint)
+    {
+        return new PortalEndpointListItem
+        {
+            Id = endpoint.Id,
+            Url = endpoint.Url,
+            Description = endpoint.Description,
+            Status = endpoint.Status.ToString().ToLowerInvariant(),
+            HasSecretOverride = !string.IsNullOrEmpty(endpoint.SecretOverride),
+            CustomHeaderNames = ParseHeaderNames(endpoint.CustomHeadersJson),
+            Metadata = JsonValueParser.ParseOrEmptyObject(endpoint.MetadataJson),
+            FilterEventTypes = endpoint.EventTypes.Select(et => et.Id).ToList(),
+            CreatedAt = endpoint.CreatedAt,
+            UpdatedAt = endpoint.UpdatedAt
+        };
+    }
+
+    public static PortalEndpointListItem ToPortalListItem(this EndpointListItem item)
+    {
+        return new PortalEndpointListItem
+        {
+            Id = item.Id,
+            Url = item.Url,
+            Description = item.Description,
+            Status = item.Status.ToString().ToLowerInvariant(),
+            HasSecretOverride = !string.IsNullOrEmpty(item.SecretOverride),
+            CustomHeaderNames = ParseHeaderNames(item.CustomHeadersJson),
+            Metadata = JsonValueParser.ParseOrEmptyObject(item.MetadataJson),
+            FilterEventTypes = item.EventTypeIds,
+            CreatedAt = item.CreatedAt,
+            UpdatedAt = item.UpdatedAt
+        };
+    }
+
+    public static PortalAttemptRow ToPortalRow(this MessageAttempt attempt)
+    {
+        return new PortalAttemptRow
+        {
+            Id = attempt.Id,
+            MessageId = attempt.MessageId,
+            AttemptNumber = attempt.AttemptNumber,
+            Status = attempt.Status.ToString().ToLowerInvariant(),
+            StatusCode = attempt.StatusCode,
+            Error = attempt.Error,
+            LatencyMs = attempt.LatencyMs,
+            CreatedAt = attempt.CreatedAt
+        };
+    }
+
+    public static PortalEventTypeListItem ToPortalListItem(this EventType eventType)
+    {
+        return new PortalEventTypeListItem
+        {
+            Id = eventType.Id,
+            Name = eventType.Name,
+            Description = eventType.Description
+        };
+    }
+
+    private static List<string> ParseHeaderNames(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return [];
+        }
+
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
+            return parsed is null ? [] : parsed.Keys.ToList();
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+    }
+}

--- a/src/WebhookEngine.API/Controllers/PortalEndpointsController.cs
+++ b/src/WebhookEngine.API/Controllers/PortalEndpointsController.cs
@@ -1,0 +1,338 @@
+using Microsoft.AspNetCore.Mvc;
+using WebhookEngine.API.Contracts;
+using WebhookEngine.API.Contracts.Portal;
+using WebhookEngine.Core.Enums;
+using WebhookEngine.Core.Interfaces;
+using WebhookEngine.Core.Models;
+using WebhookEngine.Infrastructure.Repositories;
+using WebhookEngine.Infrastructure.Services;
+using EndpointEntity = WebhookEngine.Core.Entities.Endpoint;
+
+namespace WebhookEngine.API.Controllers;
+
+/// <summary>
+/// Narrow customer-facing mirror of <see cref="EndpointsController"/> for the
+/// embeddable portal. Auth is handled upstream by
+/// <see cref="Middleware.PortalTokenAuthMiddleware"/>: by the time any action
+/// executes the AppId is in <c>HttpContext.Items["AppId"]</c> and the granted
+/// capabilities are in <c>HttpContext.Items["PortalCapabilities"]</c>. We never
+/// touch the raw JWT here and never accept an appId from the request.
+///
+/// Cross-tenant lookups deliberately surface as 404 rather than 403 — returning
+/// 403 would leak the existence of resources owned by other applications.
+/// </summary>
+[ApiController]
+[Produces("application/json")]
+[ProducesResponseType<ApiErrorResponse>(StatusCodes.Status401Unauthorized)]
+[ProducesResponseType<ApiErrorResponse>(StatusCodes.Status403Forbidden)]
+[ProducesResponseType<ApiErrorResponse>(StatusCodes.Status404NotFound)]
+[ProducesResponseType<ApiErrorResponse>(StatusCodes.Status500InternalServerError)]
+[Route("api/v1/portal")]
+public class PortalEndpointsController : ControllerBase
+{
+    private readonly EndpointRepository _endpointRepo;
+    private readonly EventTypeRepository _eventTypeRepo;
+    private readonly ApplicationRepository _appRepo;
+    private readonly MessageRepository _messageRepo;
+    private readonly IEndpointTester _endpointTester;
+
+    public PortalEndpointsController(
+        EndpointRepository endpointRepo,
+        EventTypeRepository eventTypeRepo,
+        ApplicationRepository appRepo,
+        MessageRepository messageRepo,
+        IEndpointTester endpointTester)
+    {
+        _endpointRepo = endpointRepo;
+        _eventTypeRepo = eventTypeRepo;
+        _appRepo = appRepo;
+        _messageRepo = messageRepo;
+        _endpointTester = endpointTester;
+    }
+
+    // The auth middleware guarantees these keys exist before any action runs;
+    // the casts therefore fail loudly if anyone re-routes without going through
+    // the middleware (defense-in-depth, not silent fallback).
+    private Guid AppId => (Guid)HttpContext.Items["AppId"]!;
+    private HashSet<PortalCapability> Capabilities =>
+        (HashSet<PortalCapability>)HttpContext.Items["PortalCapabilities"]!;
+
+    private bool HasCapability(PortalCapability cap) => Capabilities.Contains(cap);
+
+    private IActionResult Forbidden() => StatusCode(
+        StatusCodes.Status403Forbidden,
+        ApiEnvelope.Error(HttpContext, "PORTAL_INSUFFICIENT_CAPABILITY",
+            "The portal token does not grant the required capability."));
+
+    private IActionResult PortalNotFound() => NotFound(
+        ApiEnvelope.Error(HttpContext, "PORTAL_NOT_FOUND", "Endpoint not found."));
+
+    // ── Endpoints ──────────────────────────────────────
+
+    [HttpGet("endpoints")]
+    public async Task<IActionResult> List(
+        [FromQuery] EndpointStatus? status,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 20,
+        CancellationToken ct = default)
+    {
+        if (!HasCapability(PortalCapability.EndpointsRead))
+            return Forbidden();
+
+        var endpoints = await _endpointRepo.ListByAppIdAsync(AppId, status, page, pageSize, ct);
+        var totalCount = await _endpointRepo.CountByAppIdAsync(AppId, status, ct);
+        var pagination = ApiEnvelope.Pagination(page, pageSize, totalCount);
+
+        return Ok(ApiEnvelope.Success(
+            HttpContext,
+            endpoints.Select(e => e.ToPortalListItem()),
+            pagination));
+    }
+
+    [HttpGet("endpoints/{endpointId:guid}")]
+    public async Task<IActionResult> Get(Guid endpointId, CancellationToken ct)
+    {
+        if (!HasCapability(PortalCapability.EndpointsRead))
+            return Forbidden();
+
+        var endpoint = await _endpointRepo.GetByIdAsync(AppId, endpointId, ct);
+        if (endpoint is null)
+            return PortalNotFound();
+
+        return Ok(ApiEnvelope.Success(HttpContext, endpoint.ToPortalDetail()));
+    }
+
+    [HttpPost("endpoints")]
+    public async Task<IActionResult> Create(
+        [FromBody] PortalCreateEndpointRequest request,
+        CancellationToken ct)
+    {
+        if (!HasCapability(PortalCapability.EndpointsWrite))
+            return Forbidden();
+
+        var endpoint = new EndpointEntity
+        {
+            AppId = AppId,
+            Url = request.Url,
+            Description = request.Description,
+            CustomHeadersJson = System.Text.Json.JsonSerializer.Serialize(request.CustomHeaders ?? new Dictionary<string, string>()),
+            MetadataJson = System.Text.Json.JsonSerializer.Serialize(request.Metadata ?? new Dictionary<string, string>()),
+            SecretOverride = string.IsNullOrWhiteSpace(request.SecretOverride) ? null : request.SecretOverride
+            // Transform fields and AllowedIpsJson are intentionally left at default.
+            // The portal DTO does not expose them; even if a caller smuggles the
+            // properties through, model binding drops the unknown keys before the
+            // request reaches this point.
+        };
+
+        if (request.FilterEventTypes is { Count: > 0 })
+        {
+            foreach (var eventTypeId in request.FilterEventTypes.Distinct())
+            {
+                var eventType = await _eventTypeRepo.GetByIdAsync(AppId, eventTypeId, ct);
+                if (eventType is null)
+                {
+                    return UnprocessableEntity(ApiEnvelope.Error(
+                        HttpContext,
+                        "PORTAL_VALIDATION_FAILED",
+                        $"Event type {eventTypeId} is invalid for this application."));
+                }
+
+                endpoint.EventTypes.Add(eventType);
+            }
+        }
+
+        await _endpointRepo.CreateAsync(endpoint, ct);
+        DeliveryLookupCache.InvalidateApplication(AppId);
+        var created = await _endpointRepo.GetByIdAsync(AppId, endpoint.Id, ct) ?? endpoint;
+
+        return Created(
+            $"/api/v1/portal/endpoints/{endpoint.Id}",
+            ApiEnvelope.Success(HttpContext, created.ToPortalDetail()));
+    }
+
+    [HttpPut("endpoints/{endpointId:guid}")]
+    public async Task<IActionResult> Update(
+        Guid endpointId,
+        [FromBody] PortalUpdateEndpointRequest request,
+        CancellationToken ct)
+    {
+        if (!HasCapability(PortalCapability.EndpointsWrite))
+            return Forbidden();
+
+        var endpoint = await _endpointRepo.GetByIdAsync(AppId, endpointId, ct);
+        if (endpoint is null)
+            return PortalNotFound();
+
+        if (request.Url is not null)
+            endpoint.Url = request.Url;
+
+        if (request.Description is not null)
+            endpoint.Description = request.Description;
+
+        if (request.CustomHeaders is not null)
+            endpoint.CustomHeadersJson = System.Text.Json.JsonSerializer.Serialize(request.CustomHeaders);
+
+        if (request.Metadata is not null)
+            endpoint.MetadataJson = System.Text.Json.JsonSerializer.Serialize(request.Metadata);
+
+        if (request.SecretOverride is not null)
+            endpoint.SecretOverride = string.IsNullOrWhiteSpace(request.SecretOverride) ? null : request.SecretOverride;
+
+        if (request.FilterEventTypes is not null)
+        {
+            endpoint.EventTypes.Clear();
+
+            foreach (var eventTypeId in request.FilterEventTypes.Distinct())
+            {
+                var eventType = await _eventTypeRepo.GetByIdAsync(AppId, eventTypeId, ct);
+                if (eventType is null)
+                {
+                    return UnprocessableEntity(ApiEnvelope.Error(
+                        HttpContext,
+                        "PORTAL_VALIDATION_FAILED",
+                        $"Event type {eventTypeId} is invalid for this application."));
+                }
+
+                endpoint.EventTypes.Add(eventType);
+            }
+        }
+
+        await _endpointRepo.UpdateAsync(endpoint, ct);
+        DeliveryLookupCache.InvalidateApplication(AppId);
+        var updated = await _endpointRepo.GetByIdAsync(AppId, endpoint.Id, ct) ?? endpoint;
+
+        return Ok(ApiEnvelope.Success(HttpContext, updated.ToPortalDetail()));
+    }
+
+    [HttpPost("endpoints/{endpointId:guid}/enable")]
+    public async Task<IActionResult> Enable(Guid endpointId, CancellationToken ct)
+    {
+        if (!HasCapability(PortalCapability.EndpointsWrite))
+            return Forbidden();
+
+        var endpoint = await _endpointRepo.GetByIdAsync(AppId, endpointId, ct);
+        if (endpoint is null)
+            return PortalNotFound();
+
+        endpoint.Status = EndpointStatus.Active;
+        await _endpointRepo.UpdateAsync(endpoint, ct);
+        DeliveryLookupCache.InvalidateApplication(AppId);
+
+        return Ok(ApiEnvelope.Success(HttpContext, endpoint.ToPortalDetail()));
+    }
+
+    [HttpPost("endpoints/{endpointId:guid}/disable")]
+    public async Task<IActionResult> Disable(Guid endpointId, CancellationToken ct)
+    {
+        if (!HasCapability(PortalCapability.EndpointsWrite))
+            return Forbidden();
+
+        var endpoint = await _endpointRepo.GetByIdAsync(AppId, endpointId, ct);
+        if (endpoint is null)
+            return PortalNotFound();
+
+        endpoint.Status = EndpointStatus.Disabled;
+        await _endpointRepo.UpdateAsync(endpoint, ct);
+        DeliveryLookupCache.InvalidateApplication(AppId);
+
+        return Ok(ApiEnvelope.Success(HttpContext, endpoint.ToPortalDetail()));
+    }
+
+    [HttpDelete("endpoints/{endpointId:guid}")]
+    public async Task<IActionResult> Delete(Guid endpointId, CancellationToken ct)
+    {
+        if (!HasCapability(PortalCapability.EndpointsWrite))
+            return Forbidden();
+
+        // App-scoped existence check first — without it, a delete of someone
+        // else's endpoint would succeed silently (no rows updated, NoContent
+        // returned) which is a quieter but equally bad cross-tenant leak.
+        var endpoint = await _endpointRepo.GetByIdAsync(AppId, endpointId, ct);
+        if (endpoint is null)
+            return PortalNotFound();
+
+        await _endpointRepo.DeleteAsync(AppId, endpointId, ct);
+        DeliveryLookupCache.InvalidateApplication(AppId);
+        return NoContent();
+    }
+
+    [HttpPost("endpoints/{endpointId:guid}/test")]
+    public async Task<IActionResult> SendTest(
+        Guid endpointId,
+        [FromBody] PortalEndpointTestRequest request,
+        CancellationToken ct)
+    {
+        if (!HasCapability(PortalCapability.EndpointsTest))
+            return Forbidden();
+
+        var endpoint = await _endpointRepo.GetByIdAsync(AppId, endpointId, ct);
+        if (endpoint is null)
+            return PortalNotFound();
+
+        var application = await _appRepo.GetByIdAsync(AppId, ct);
+        if (application is null)
+            return PortalNotFound();
+
+        var context = new EndpointTestContext
+        {
+            Endpoint = endpoint,
+            Application = application,
+            Request = new EndpointTestRequest
+            {
+                EventTypeName = request.EventType ?? string.Empty,
+                Payload = request.Payload
+            }
+        };
+
+        var result = await _endpointTester.ExecuteAsync(context, ct);
+        return Ok(ApiEnvelope.Success(HttpContext, result));
+    }
+
+    [HttpGet("endpoints/{endpointId:guid}/attempts")]
+    public async Task<IActionResult> Attempts(
+        Guid endpointId,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 20,
+        CancellationToken ct = default)
+    {
+        if (!HasCapability(PortalCapability.AttemptsRead))
+            return Forbidden();
+
+        // Existence check is app-scoped so cross-tenant probes return 404,
+        // and so a missing endpoint never reads as "valid id, zero attempts".
+        var endpoint = await _endpointRepo.GetByIdAsync(AppId, endpointId, ct);
+        if (endpoint is null)
+            return PortalNotFound();
+
+        var attempts = await _messageRepo.ListAttemptsByEndpointAsync(AppId, endpointId, page, pageSize, ct);
+        var totalCount = await _messageRepo.CountAttemptsByEndpointAsync(AppId, endpointId, ct);
+        var pagination = ApiEnvelope.Pagination(page, pageSize, totalCount);
+
+        return Ok(ApiEnvelope.Success(
+            HttpContext,
+            attempts.Select(a => a.ToPortalRow()),
+            pagination));
+    }
+
+    // ── Event types (read-only dropdown source) ────────
+
+    [HttpGet("event-types")]
+    public async Task<IActionResult> EventTypes(
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 100,
+        CancellationToken ct = default)
+    {
+        if (!HasCapability(PortalCapability.EndpointsRead))
+            return Forbidden();
+
+        // includeArchived: false — archived event types are admin-only history.
+        var eventTypes = await _eventTypeRepo.ListByAppIdAsync(AppId, includeArchived: false, page, pageSize, ct);
+        var totalCount = await _eventTypeRepo.CountByAppIdAsync(AppId, includeArchived: false, ct);
+        var pagination = ApiEnvelope.Pagination(page, pageSize, totalCount);
+
+        return Ok(ApiEnvelope.Success(
+            HttpContext,
+            eventTypes.Select(et => et.ToPortalListItem()),
+            pagination));
+    }
+}

--- a/src/WebhookEngine.API/Validators/PortalRequestValidators.cs
+++ b/src/WebhookEngine.API/Validators/PortalRequestValidators.cs
@@ -1,0 +1,100 @@
+using FluentValidation;
+using WebhookEngine.API.Contracts.Portal;
+using WebhookEngine.Infrastructure.Services;
+
+namespace WebhookEngine.API.Validators;
+
+public class PortalCreateEndpointRequestValidator : AbstractValidator<PortalCreateEndpointRequest>
+{
+    public PortalCreateEndpointRequestValidator(EndpointUrlPolicy urlPolicy)
+    {
+        RuleFor(x => x.Url)
+            .NotEmpty()
+            .Must(urlPolicy.IsValid)
+            .WithMessage(urlPolicy.ValidationMessage)
+            .DependentRules(() =>
+            {
+                RuleFor(x => x.Url).CustomAsync(async (url, ctx, ct) =>
+                {
+                    var error = await urlPolicy.CheckHostSafeAsync(url, ct);
+                    if (error is not null) ctx.AddFailure(error);
+                });
+            });
+
+        RuleFor(x => x.Description)
+            .MaximumLength(500)
+            .When(x => x.Description is not null);
+
+        RuleFor(x => x.CustomHeaders)
+            .Must(headers => CustomHeaderPolicy.Validate(headers) is null)
+            .WithMessage(x => CustomHeaderPolicy.Validate(x.CustomHeaders) ?? "Invalid custom headers.")
+            .When(x => x.CustomHeaders is not null);
+
+        RuleFor(x => x.SecretOverride)
+            .MinimumLength(32)
+            .MaximumLength(128)
+            .Must(s => s!.StartsWith("whsec_", StringComparison.Ordinal))
+            .WithMessage("SecretOverride must start with the 'whsec_' prefix and be at least 32 characters. Use the portal's rotate-secret action to generate one rather than typing a password.")
+            .When(x => x.SecretOverride is not null);
+    }
+}
+
+public class PortalUpdateEndpointRequestValidator : AbstractValidator<PortalUpdateEndpointRequest>
+{
+    public PortalUpdateEndpointRequestValidator(EndpointUrlPolicy urlPolicy)
+    {
+        RuleFor(x => x.Url)
+            .Must(urlPolicy.IsValid)
+            .When(x => x.Url is not null)
+            .WithMessage(urlPolicy.ValidationMessage)
+            .DependentRules(() =>
+            {
+                RuleFor(x => x.Url!).CustomAsync(async (url, ctx, ct) =>
+                {
+                    var error = await urlPolicy.CheckHostSafeAsync(url, ct);
+                    if (error is not null) ctx.AddFailure(error);
+                }).When(x => x.Url is not null);
+            });
+
+        RuleFor(x => x.Description)
+            .MaximumLength(500)
+            .When(x => x.Description is not null);
+
+        RuleFor(x => x.CustomHeaders)
+            .Must(headers => CustomHeaderPolicy.Validate(headers) is null)
+            .WithMessage(x => CustomHeaderPolicy.Validate(x.CustomHeaders) ?? "Invalid custom headers.")
+            .When(x => x.CustomHeaders is not null);
+
+        RuleFor(x => x.SecretOverride)
+            .MinimumLength(32)
+            .MaximumLength(128)
+            .Must(s => s!.StartsWith("whsec_", StringComparison.Ordinal))
+            .WithMessage("SecretOverride must start with the 'whsec_' prefix and be at least 32 characters. Use the portal's rotate-secret action to generate one rather than typing a password.")
+            .When(x => x.SecretOverride is not null);
+
+        RuleFor(x => x)
+            .Must(x => x.Url is not null
+                || x.Description is not null
+                || x.FilterEventTypes is not null
+                || x.CustomHeaders is not null
+                || x.Metadata is not null
+                || x.SecretOverride is not null)
+            .WithMessage("At least one field must be provided.");
+    }
+}
+
+public class PortalEndpointTestRequestValidator : AbstractValidator<PortalEndpointTestRequest>
+{
+    private const int MaxPayloadBytes = 256 * 1024;
+
+    public PortalEndpointTestRequestValidator()
+    {
+        RuleFor(x => x.EventType)
+            .MaximumLength(256)
+            .When(x => x.EventType is not null);
+
+        RuleFor(x => x.Payload)
+            .Must(payload => !payload.HasValue || payload.Value.GetRawText().Length <= MaxPayloadBytes)
+            .WithMessage($"Payload exceeds the {MaxPayloadBytes / 1024} KB probe cap.");
+    }
+}

--- a/src/WebhookEngine.Infrastructure/Repositories/EndpointRepository.cs
+++ b/src/WebhookEngine.Infrastructure/Repositories/EndpointRepository.cs
@@ -122,6 +122,21 @@ public class EndpointRepository
 
     public async Task DeleteAsync(Guid appId, Guid id, CancellationToken ct = default)
     {
+        // ExecuteDeleteAsync isn't translated by the InMemory provider used in
+        // API integration tests; fall back to a tracked-entity remove there
+        // (mirrors EventTypeRepository.ArchiveAsync). Production runs Postgres
+        // and stays on the bulk-delete path.
+        if (string.Equals(_dbContext.Database.ProviderName, "Microsoft.EntityFrameworkCore.InMemory", StringComparison.Ordinal))
+        {
+            var endpoint = await _dbContext.Endpoints.FirstOrDefaultAsync(e => e.AppId == appId && e.Id == id, ct);
+            if (endpoint is null)
+                return;
+
+            _dbContext.Endpoints.Remove(endpoint);
+            await _dbContext.SaveChangesAsync(ct);
+            return;
+        }
+
         await _dbContext.Endpoints
             .Where(e => e.AppId == appId && e.Id == id)
             .ExecuteDeleteAsync(ct);

--- a/src/WebhookEngine.Infrastructure/Repositories/MessageRepository.cs
+++ b/src/WebhookEngine.Infrastructure/Repositories/MessageRepository.cs
@@ -156,6 +156,38 @@ public class MessageRepository
             .CountAsync(a => a.MessageId == messageId && a.Message.AppId == appId, ct);
     }
 
+    /// <summary>
+    /// Lists attempts for a single endpoint, app-scoped via the parent <see cref="Message"/>.
+    /// MessageAttempt has no AppId column of its own — the join through Message is what
+    /// keeps cross-tenant rows out of the result. Ordered most-recent first so the portal's
+    /// "Recent attempts" list works without client-side sorting.
+    /// </summary>
+    public async Task<List<MessageAttempt>> ListAttemptsByEndpointAsync(
+        Guid appId,
+        Guid endpointId,
+        int page,
+        int pageSize,
+        CancellationToken ct = default)
+    {
+        return await _dbContext.MessageAttempts
+            .AsNoTracking()
+            .Where(a => a.EndpointId == endpointId && a.Message.AppId == appId)
+            .OrderByDescending(a => a.CreatedAt)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(ct);
+    }
+
+    public async Task<int> CountAttemptsByEndpointAsync(
+        Guid appId,
+        Guid endpointId,
+        CancellationToken ct = default)
+    {
+        return await _dbContext.MessageAttempts
+            .AsNoTracking()
+            .CountAsync(a => a.EndpointId == endpointId && a.Message.AppId == appId, ct);
+    }
+
     public async Task CreateAttemptAsync(MessageAttempt attempt, CancellationToken ct = default)
     {
         _dbContext.MessageAttempts.Add(attempt);

--- a/tests/WebhookEngine.API.Tests/Portal/PortalEndpointsControllerTests.cs
+++ b/tests/WebhookEngine.API.Tests/Portal/PortalEndpointsControllerTests.cs
@@ -1,0 +1,513 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using NSubstitute;
+using WebhookEngine.API.Tests.Integration;
+using WebhookEngine.Core.Entities;
+using WebhookEngine.Core.Enums;
+using WebhookEngine.Core.Interfaces;
+using WebhookEngine.Core.Models;
+using WebhookEngine.Infrastructure.Data;
+using ApplicationEntity = WebhookEngine.Core.Entities.Application;
+using EndpointEntity = WebhookEngine.Core.Entities.Endpoint;
+
+namespace WebhookEngine.API.Tests.Portal;
+
+/// <summary>
+/// End-to-end exercise of <c>PortalEndpointsController</c> through the production
+/// pipeline: portal JWT middleware → MVC → controller → repository. Uses the
+/// shared <see cref="TestWebApplicationFactory"/> so the request travels through
+/// the real middleware ordering rather than an isolated test harness.
+/// </summary>
+public class PortalEndpointsControllerTests : IClassFixture<PortalEndpointsControllerTests.PortalTestFactory>
+{
+    private const string PortalRoot = "/api/v1/portal";
+
+    private readonly PortalTestFactory _factory;
+
+    public PortalEndpointsControllerTests(PortalTestFactory factory)
+    {
+        _factory = factory;
+    }
+
+    // ── Read paths ─────────────────────────────────────
+
+    [Fact]
+    public async Task Portal_List_Endpoints_Returns_App_Scoped_Rows_With_Secrets_Stripped()
+    {
+        await ResetDatabaseAsync();
+        var (appId, endpointId) = await SeedAppAndEndpointAsync(secretOverride: "whsec_top_secret");
+        var token = MintFullToken(appId);
+        using var client = CreateClient(token);
+
+        var response = await client.GetAsync($"{PortalRoot}/endpoints");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var data = (await ParseJsonAsync(response)).GetProperty("data");
+        data.GetArrayLength().Should().Be(1);
+        var row = data[0];
+        row.GetProperty("id").GetGuid().Should().Be(endpointId);
+        // The portal list shape never carries the override value or full custom-header values.
+        row.TryGetProperty("secretOverride", out _).Should().BeFalse();
+        row.GetProperty("hasSecretOverride").GetBoolean().Should().BeTrue();
+        row.GetProperty("customHeaderNames").GetArrayLength().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Portal_Get_Endpoint_Strips_Transform_And_AllowedIps_Fields()
+    {
+        await ResetDatabaseAsync();
+        var (appId, endpointId) = await SeedAppAndEndpointAsync(
+            transformExpression: "@",
+            transformEnabled: true,
+            allowedIpsJson: "[\"203.0.113.0/24\"]");
+        var token = MintFullToken(appId);
+        using var client = CreateClient(token);
+
+        var response = await client.GetAsync($"{PortalRoot}/endpoints/{endpointId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var data = (await ParseJsonAsync(response)).GetProperty("data");
+        data.TryGetProperty("transformExpression", out _).Should().BeFalse();
+        data.TryGetProperty("transformEnabled", out _).Should().BeFalse();
+        data.TryGetProperty("transformValidatedAt", out _).Should().BeFalse();
+        data.TryGetProperty("allowedIpsJson", out _).Should().BeFalse();
+        data.TryGetProperty("allowedIps", out _).Should().BeFalse();
+    }
+
+    // ── Write paths ────────────────────────────────────
+
+    [Fact]
+    public async Task Portal_Create_Endpoint_Persists_Without_Transform_Or_AllowedIps()
+    {
+        await ResetDatabaseAsync();
+        var (appId, _) = await SeedAppAsync();
+        var token = MintFullToken(appId);
+        using var client = CreateClient(token);
+
+        // Transform / allowed-ips are smuggled into the body; model binding must drop them.
+        var response = await client.PostAsJsonAsync($"{PortalRoot}/endpoints", new
+        {
+            url = "https://example.com/portal-create",
+            description = "from portal",
+            transformExpression = "@",
+            transformEnabled = true,
+            allowedIpsJson = "[\"203.0.113.0/24\"]"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var createdId = (await ParseJsonAsync(response))
+            .GetProperty("data").GetProperty("id").GetGuid();
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+        var persisted = await db.Endpoints.AsNoTracking().FirstAsync(e => e.Id == createdId);
+
+        persisted.AppId.Should().Be(appId);
+        persisted.TransformExpression.Should().BeNull();
+        persisted.TransformEnabled.Should().BeFalse();
+        persisted.AllowedIpsJson.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Portal_Update_Endpoint_Returns_200_And_Updates_Fields()
+    {
+        await ResetDatabaseAsync();
+        var (appId, endpointId) = await SeedAppAndEndpointAsync();
+        var token = MintFullToken(appId);
+        using var client = CreateClient(token);
+
+        var response = await client.PutAsJsonAsync($"{PortalRoot}/endpoints/{endpointId}", new
+        {
+            description = "updated by portal"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+        var persisted = await db.Endpoints.AsNoTracking().FirstAsync(e => e.Id == endpointId);
+        persisted.Description.Should().Be("updated by portal");
+    }
+
+    [Fact]
+    public async Task Portal_Enable_And_Disable_Endpoint_Toggle_Status()
+    {
+        await ResetDatabaseAsync();
+        var (appId, endpointId) = await SeedAppAndEndpointAsync();
+        var token = MintFullToken(appId);
+        using var client = CreateClient(token);
+
+        var disable = await client.PostAsync($"{PortalRoot}/endpoints/{endpointId}/disable", content: null);
+        disable.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await GetEndpointStatusAsync(endpointId)).Should().Be(EndpointStatus.Disabled);
+
+        var enable = await client.PostAsync($"{PortalRoot}/endpoints/{endpointId}/enable", content: null);
+        enable.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await GetEndpointStatusAsync(endpointId)).Should().Be(EndpointStatus.Active);
+    }
+
+    [Fact]
+    public async Task Portal_Delete_Endpoint_Returns_204()
+    {
+        await ResetDatabaseAsync();
+        var (appId, endpointId) = await SeedAppAndEndpointAsync();
+        var token = MintFullToken(appId);
+        using var client = CreateClient(token);
+
+        var response = await client.DeleteAsync($"{PortalRoot}/endpoints/{endpointId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+        var exists = await db.Endpoints.AsNoTracking().AnyAsync(e => e.Id == endpointId);
+        exists.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Portal_Test_Endpoint_Posts_Through_IEndpointTester()
+    {
+        await ResetDatabaseAsync();
+        var (appId, endpointId) = await SeedAppAndEndpointAsync();
+        var token = MintFullToken(appId);
+        using var client = CreateClient(token);
+
+        // Reset prior calls — the substitute is shared across tests in the fixture.
+        _factory.EndpointTester.ClearReceivedCalls();
+
+        var response = await client.PostAsJsonAsync($"{PortalRoot}/endpoints/{endpointId}/test", new
+        {
+            eventType = "order.created",
+            payload = new { id = "evt_1" }
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        await _factory.EndpointTester.Received(1).ExecuteAsync(
+            Arg.Is<EndpointTestContext>(c =>
+                c.Endpoint.Id == endpointId
+                && c.Endpoint.AppId == appId
+                && c.Application.Id == appId
+                && c.Request.EventTypeName == "order.created"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Portal_Get_Attempts_Returns_Most_Recent_First_With_Pagination()
+    {
+        await ResetDatabaseAsync();
+        var (appId, endpointId) = await SeedAppAndEndpointAsync();
+        await SeedAttemptsAsync(appId, endpointId, count: 3);
+        var token = MintFullToken(appId);
+        using var client = CreateClient(token);
+
+        var response = await client.GetAsync($"{PortalRoot}/endpoints/{endpointId}/attempts?page=1&pageSize=10");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await ParseJsonAsync(response);
+        var rows = json.GetProperty("data");
+        rows.GetArrayLength().Should().Be(3);
+
+        // Most-recent first → AttemptNumber sequence is reversed.
+        rows[0].GetProperty("attemptNumber").GetInt32().Should().Be(3);
+        rows[1].GetProperty("attemptNumber").GetInt32().Should().Be(2);
+        rows[2].GetProperty("attemptNumber").GetInt32().Should().Be(1);
+
+        var pagination = json.GetProperty("meta").GetProperty("pagination");
+        pagination.GetProperty("totalCount").GetInt32().Should().Be(3);
+    }
+
+    // ── Capability gating ──────────────────────────────
+
+    [Fact]
+    public async Task Portal_Read_Only_Token_Cannot_Create_An_Endpoint()
+    {
+        await ResetDatabaseAsync();
+        var (appId, _) = await SeedAppAsync();
+        var token = MintToken(appId, "endpoints:read");
+        using var client = CreateClient(token);
+
+        var response = await client.PostAsJsonAsync($"{PortalRoot}/endpoints", new
+        {
+            url = "https://example.com/forbidden"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        (await ReadErrorCodeAsync(response)).Should().Be("PORTAL_INSUFFICIENT_CAPABILITY");
+    }
+
+    [Fact]
+    public async Task Portal_Token_Without_AttemptsRead_Cannot_Read_Attempts()
+    {
+        await ResetDatabaseAsync();
+        var (appId, endpointId) = await SeedAppAndEndpointAsync();
+        var token = MintToken(appId, "endpoints:read");
+        using var client = CreateClient(token);
+
+        var response = await client.GetAsync($"{PortalRoot}/endpoints/{endpointId}/attempts");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        (await ReadErrorCodeAsync(response)).Should().Be("PORTAL_INSUFFICIENT_CAPABILITY");
+    }
+
+    // ── Cross-tenant guard ─────────────────────────────
+
+    [Fact]
+    public async Task Portal_Cannot_See_Other_Apps_Endpoint()
+    {
+        await ResetDatabaseAsync();
+        var (appA, _) = await SeedAppAsync(name: "tenant-A");
+        var (appB, otherEndpointId) = await SeedAppAndEndpointAsync(name: "tenant-B");
+
+        // Token scoped to tenant A asks for tenant B's endpoint id.
+        var tokenA = MintFullToken(appA);
+        using var client = CreateClient(tokenA);
+
+        var response = await client.GetAsync($"{PortalRoot}/endpoints/{otherEndpointId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        (await ReadErrorCodeAsync(response)).Should().Be("PORTAL_NOT_FOUND");
+    }
+
+    [Fact]
+    public async Task Portal_Token_Without_EndpointsTest_Cannot_Send_Test()
+    {
+        // Highest-risk capability boundary: the test route makes outbound HTTP.
+        // A token that holds endpoints:read+write but NOT endpoints:test must
+        // be rejected so a leaked read/write token cannot be used to fan out
+        // arbitrary HTTP requests through the engine.
+        await ResetDatabaseAsync();
+        var (appId, endpointId) = await SeedAppAndEndpointAsync();
+        var token = MintToken(appId, "endpoints:read", "endpoints:write");
+        using var client = CreateClient(token);
+
+        var body = new { eventType = "test.event", payload = new { } };
+        var response = await client.PostAsJsonAsync($"{PortalRoot}/endpoints/{endpointId}/test", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        (await ReadErrorCodeAsync(response)).Should().Be("PORTAL_INSUFFICIENT_CAPABILITY");
+    }
+
+    [Fact]
+    public async Task Portal_Cannot_Update_Other_Apps_Endpoint()
+    {
+        // Cross-tenant write smoke: even with full write capability, a token
+        // scoped to tenant A must not silently mutate or 204 a tenant B
+        // endpoint. The 2-arg app-scoped GetByIdAsync inside Update is the
+        // only thing standing between this and a quiet cross-tenant write.
+        await ResetDatabaseAsync();
+        var (appA, _) = await SeedAppAsync(name: "tenant-A");
+        var (appB, otherEndpointId) = await SeedAppAndEndpointAsync(name: "tenant-B");
+
+        var tokenA = MintFullToken(appA);
+        using var client = CreateClient(tokenA);
+
+        var body = new { url = "https://example.com/new" };
+        var response = await client.PutAsJsonAsync($"{PortalRoot}/endpoints/{otherEndpointId}", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        (await ReadErrorCodeAsync(response)).Should().Be("PORTAL_NOT_FOUND");
+    }
+
+    [Fact]
+    public async Task Portal_Create_With_Weak_Secret_Override_Returns_422()
+    {
+        // SecretOverride entropy floor: a customer typing "password123" as
+        // their HMAC secret silently undermines every signed delivery's
+        // authenticity guarantee. The validator requires the whsec_ prefix
+        // and a 32-char minimum so a hand-typed weak secret is rejected
+        // before it touches the database.
+        await ResetDatabaseAsync();
+        var (appId, _) = await SeedAppAsync();
+        var token = MintFullToken(appId);
+        using var client = CreateClient(token);
+
+        var body = new
+        {
+            url = "https://example.com/hook",
+            secretOverride = "password123" // missing prefix + too short
+        };
+        var response = await client.PostAsJsonAsync($"{PortalRoot}/endpoints", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    // ── Plumbing ──────────────────────────────────────
+
+    private HttpClient CreateClient(string bearerToken)
+    {
+        var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            HandleCookies = false
+        });
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
+        return client;
+    }
+
+    private static string MintFullToken(Guid appId) => MintToken(
+        appId,
+        "endpoints:read",
+        "endpoints:write",
+        "endpoints:test",
+        "attempts:read");
+
+    private static string MintToken(Guid appId, params string[] capabilities)
+        => PortalJwtFactory.Mint(appId, capabilities);
+
+    private async Task ResetDatabaseAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+        await db.Database.EnsureDeletedAsync();
+        await db.Database.EnsureCreatedAsync();
+    }
+
+    private async Task<(Guid AppId, Guid EndpointId)> SeedAppAndEndpointAsync(
+        string? name = null,
+        string? secretOverride = null,
+        string? transformExpression = null,
+        bool transformEnabled = false,
+        string? allowedIpsJson = null)
+    {
+        var (appId, _) = await SeedAppAsync(name);
+        var endpointId = Guid.NewGuid();
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+        db.Endpoints.Add(new EndpointEntity
+        {
+            Id = endpointId,
+            AppId = appId,
+            Url = "https://example.invalid/seeded",
+            Status = EndpointStatus.Active,
+            SecretOverride = secretOverride,
+            TransformExpression = transformExpression,
+            TransformEnabled = transformEnabled,
+            AllowedIpsJson = allowedIpsJson
+        });
+        await db.SaveChangesAsync();
+        return (appId, endpointId);
+    }
+
+    private async Task<(Guid AppId, ApplicationEntity App)> SeedAppAsync(string? name = null)
+    {
+        var appId = Guid.NewGuid();
+        var app = new ApplicationEntity
+        {
+            Id = appId,
+            Name = name ?? $"app-{appId:N}",
+            ApiKeyPrefix = $"whe_{appId:N}".Substring(0, 12) + "_",
+            ApiKeyHash = "deadbeef",
+            SigningSecret = "whsec_test",
+            PortalSigningKey = PortalJwtFactory.ValidSigningKey,
+            IsActive = true
+        };
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+        db.Applications.Add(app);
+        await db.SaveChangesAsync();
+        return (appId, app);
+    }
+
+    private async Task SeedAttemptsAsync(Guid appId, Guid endpointId, int count)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+        var eventType = new EventType { Id = Guid.NewGuid(), AppId = appId, Name = "evt" };
+        var message = new Message
+        {
+            Id = Guid.NewGuid(),
+            AppId = appId,
+            EndpointId = endpointId,
+            EventTypeId = eventType.Id,
+            Payload = "{}",
+            Status = MessageStatus.Delivered,
+            CreatedAt = DateTime.UtcNow.AddMinutes(-30)
+        };
+        db.EventTypes.Add(eventType);
+        db.Messages.Add(message);
+        var baseTime = DateTime.UtcNow.AddMinutes(-10);
+        for (int i = 1; i <= count; i++)
+        {
+            db.MessageAttempts.Add(new MessageAttempt
+            {
+                Id = Guid.NewGuid(),
+                MessageId = message.Id,
+                EndpointId = endpointId,
+                AttemptNumber = i,
+                Status = AttemptStatus.Success,
+                StatusCode = 200,
+                LatencyMs = 42,
+                // Strict ordering so the "most-recent first" assertion is unambiguous.
+                CreatedAt = baseTime.AddSeconds(i)
+            });
+        }
+        await db.SaveChangesAsync();
+    }
+
+    private async Task<EndpointStatus> GetEndpointStatusAsync(Guid endpointId)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+        var endpoint = await db.Endpoints.AsNoTracking().FirstAsync(e => e.Id == endpointId);
+        return endpoint.Status;
+    }
+
+    private static async Task<JsonElement> ParseJsonAsync(HttpResponseMessage response)
+    {
+        var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        return doc.RootElement.Clone();
+    }
+
+    private static async Task<string?> ReadErrorCodeAsync(HttpResponseMessage response)
+    {
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.GetProperty("error").GetProperty("code").GetString();
+    }
+
+    /// <summary>
+    /// Production <see cref="TestWebApplicationFactory"/> with the live
+    /// <see cref="IEndpointTester"/> swapped for an NSubstitute fake. Lets the
+    /// "send test" route exercise the full controller path without a real HTTP
+    /// dial, and lets the test assert call arguments.
+    /// </summary>
+    public sealed class PortalTestFactory : TestWebApplicationFactory
+    {
+        public IEndpointTester EndpointTester { get; } = Substitute.For<IEndpointTester>();
+
+        public PortalTestFactory()
+        {
+            EndpointTester
+                .ExecuteAsync(Arg.Any<EndpointTestContext>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult(new EndpointTestResult
+                {
+                    Success = true,
+                    StatusCode = 200,
+                    LatencyMs = 7,
+                    ResponseBody = "{}"
+                }));
+        }
+
+        protected override void ConfigureWebHost(Microsoft.AspNetCore.Hosting.IWebHostBuilder builder)
+        {
+            base.ConfigureWebHost(builder);
+
+            builder.ConfigureServices(services =>
+            {
+                // Replace the live tester so the portal /test route doesn't dial out.
+                services.RemoveAll<IEndpointTester>();
+                services.AddSingleton(EndpointTester);
+            });
+        }
+    }
+}

--- a/tests/WebhookEngine.API.Tests/Portal/PortalJwtFactory.cs
+++ b/tests/WebhookEngine.API.Tests/Portal/PortalJwtFactory.cs
@@ -1,0 +1,53 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.IdentityModel.Tokens;
+
+namespace WebhookEngine.API.Tests.Portal;
+
+/// <summary>
+/// Shared JWT mint helpers for portal-route tests. Mirrors the production
+/// <c>PortalTokenAuthMiddleware</c> claim shape (<c>appId</c> + repeated
+/// <c>capabilities</c> claims) so test tokens flow through the production
+/// validator unchanged. Kept separate from the middleware-tests file so the
+/// new controller tests don't need to take a friend dependency on the older
+/// test class.
+/// </summary>
+internal static class PortalJwtFactory
+{
+    public const string ValidSigningKey = "portal-signing-key-must-be-at-least-32-bytes-for-hs256!!!";
+
+    public static string Mint(
+        Guid appId,
+        IEnumerable<string> capabilities,
+        string signingKey = ValidSigningKey,
+        TimeSpan? lifetime = null,
+        DateTime? notBefore = null,
+        DateTime? expires = null,
+        string algorithm = SecurityAlgorithms.HmacSha256)
+    {
+        var window = lifetime ?? TimeSpan.FromMinutes(5);
+        var nbf = notBefore ?? DateTime.UtcNow;
+        var exp = expires ?? nbf.Add(window);
+
+        var claims = new List<Claim>
+        {
+            new("appId", appId.ToString())
+        };
+        foreach (var capability in capabilities)
+        {
+            claims.Add(new Claim("capabilities", capability));
+        }
+
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(signingKey));
+        var creds = new SigningCredentials(key, algorithm);
+        var token = new JwtSecurityToken(
+            issuer: null,
+            audience: null,
+            claims: claims,
+            notBefore: nbf,
+            expires: exp,
+            signingCredentials: creds);
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}

--- a/tests/WebhookEngine.API.Tests/WebhookEngine.API.Tests.csproj
+++ b/tests/WebhookEngine.API.Tests/WebhookEngine.API.Tests.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">


### PR DESCRIPTION
## Summary

**Step 4 of the B1 (embeddable customer portal) plan.** Adds the customer-facing `/api/v1/portal/*` route surface that the upcoming `<EndpointManager />` React component (Step 8) will consume. Auth + CORS were laid down in Step 3 (PR #83); this PR is the actual route group.

## Routes

| # | Verb + path | Capability |
|---|---|---|
| 1 | `GET /endpoints` | `endpoints:read` |
| 2 | `GET /endpoints/{id}` | `endpoints:read` |
| 3 | `POST /endpoints` | `endpoints:write` |
| 4 | `PUT /endpoints/{id}` | `endpoints:write` |
| 5 | `POST /endpoints/{id}/enable` | `endpoints:write` |
| 6 | `POST /endpoints/{id}/disable` | `endpoints:write` |
| 7 | `DELETE /endpoints/{id}` | `endpoints:write` |
| 8 | `POST /endpoints/{id}/test` | `endpoints:test` (re-uses `IEndpointTester`) |
| 9 | `GET /endpoints/{id}/attempts` | `attempts:read` (new repo methods) |
| 10 | `GET /event-types` | `endpoints:read` (read-only dropdown source) |

## Security contract

- **Capability gating:** inline `if (!HasCapability(...)) return Forbidden();` at the top of every action; missing → `403 PORTAL_INSUFFICIENT_CAPABILITY`.
- **App-scope isolation:** every action reads `AppId` from `HttpContext.Items["AppId"]` (set by `PortalTokenAuthMiddleware`), never from query/body/route. All lookups go through the 2-arg `EndpointRepository.GetByIdAsync(appId, endpointId, ct)` overload.
- **Cross-tenant probe:** returns `404 PORTAL_NOT_FOUND` (not 403) — returning `Forbidden` would leak the existence of cross-tenant resources.
- **Field narrowing (silent strip):** `PortalCreateEndpointRequest` and `PortalUpdateEndpointRequest` do NOT carry `TransformExpression` / `TransformEnabled` / `AllowedIpsJson` properties. Model binding silently drops the fields if a caller sends them — no 422, no leak. List response strips `secretOverride` and `customHeaders` values; detail response strips `transform*` and `allowedIpsJson`. `SecretOverride` is replaced with a `hasSecretOverride: bool` flag.

## Reviewer-flagged concerns addressed before this PR opened

A read-only `reviewer` agent pass produced **APPROVE WITH CAVEATS**. Two fixes landed in this same branch:

### Concern B (HIGH) — `SecretOverride` entropy floor

The original validator only enforced `MaximumLength(64)` — a customer could set their HMAC secret to `password123` and silently undermine every signed delivery's authenticity guarantee. `PortalRequestValidators` now requires the `whsec_` prefix and a 32-128 char range. New test `Portal_Create_With_Weak_Secret_Override_Returns_422` proves the gate.

### Capability gating coverage gap

Two new tests:
- `Portal_Token_Without_EndpointsTest_Cannot_Send_Test` — highest-risk capability boundary because `/test` makes outbound HTTP. A leaked `endpoints:read+write` token without `endpoints:test` would have been a real exposure.
- `Portal_Cannot_Update_Other_Apps_Endpoint` — cross-tenant write smoke. The 2-arg `GetByIdAsync` inside Update is the only thing standing between a write token and a quiet cross-tenant mutation.

## Outstanding follow-ups intentionally NOT in this PR

Captured for the Step 5/6 backlog so the surface can land without bundle creep:

- **Concern A (medium)** — capability check today runs AFTER FluentValidation, so a malformed body returns `422` before the capability check fires. Low-but-real side-channel oracle (e.g., an `endpoints:read`-only token can probe arbitrary URLs through the SSRF guard via malformed POSTs and read the validator error). Fix: convert capability gating to an `IAsyncAuthorizationFilter` (`[RequirePortalCapability(...)]` attribute) so the check runs before model binding.
- **(low)** Per-app rate-limit partition specifically for portal write routes. Token `MaxLifetimeMinutes` (15) bounds blast radius today; per-app write partition is a public-launch nice-to-have.
- **(low)** Audit-log entries for portal mutations (Create/Update/Delete/Enable/Disable). The admin `EndpointsController` writes to the AuditLog from PR #79; the portal does not yet. Customer-facing audit trails arguably matter MORE than admin ones.
- **(low)** Dedicated `POST /endpoints/{id}/rotate-secret` route that mints a server-generated secret and returns it once — primary UI path so customers don't hand-type secrets even with the entropy floor in place.

## Index check (reviewer-confirmed)

The new `MessageRepository.ListAttemptsByEndpointAsync` query rides on existing `idx_attempts_endpoint_status` `(endpoint_id, status, created_at DESC)` — leading-column match on `EndpointId` + trailing `CreatedAt DESC` keeps the planner on an index seek with no separate sort step. The join filter `Message.AppId = @app` is satisfied via the `messages` PK. **No new migration needed.**

## Test count

- `WebhookEngine.API.Tests`: **79 → 93** (+14: +11 contractual + +3 reviewer follow-up).
- Full solution: **224 → 238**, all passing.

## Build

```
Build succeeded.
    0 Warning(s)
    0 Error(s)
```

## Test plan

- [x] `dotnet build WebhookEngine.sln` clean
- [x] `dotnet test WebhookEngine.sln` — Core 34, API 93, Worker 46, Infrastructure 65 (real Postgres via Testcontainers — admin DeleteAsync InMemory branch is provider-gated, no production change)
- [ ] CI green