### PR TITLE
feat(api+dashboard+infra): dashboard portal-access management UI (B1 Step 5)

### DIFF
--- a/src/WebhookEngine.API/Controllers/DashboardPortalController.cs
+++ b/src/WebhookEngine.API/Controllers/DashboardPortalController.cs
@@ -1,0 +1,311 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using WebhookEngine.API.Audit;
+using WebhookEngine.Core.Interfaces;
+using WebhookEngine.API.Contracts;
+using WebhookEngine.Core.Utilities;
+using WebhookEngine.Infrastructure.Repositories;
+using WebhookEngine.Infrastructure.Services;
+
+namespace WebhookEngine.API.Controllers;
+
+/// <summary>
+/// Dashboard surface for managing the embeddable customer portal: enable /
+/// rotate / disable the per-app HMAC signing key and maintain the allow-listed
+/// CORS origins. The signing key is returned in plain text exactly once on
+/// enable / rotate and is never echoed by the read endpoint or the audit log.
+/// All mutations invalidate the in-process <see cref="PortalLookupCache"/> so
+/// the portal middleware sees the new state within milliseconds rather than
+/// after the configured TTL.
+/// </summary>
+[ApiController]
+[Produces("application/json")]
+[ProducesResponseType<ApiErrorResponse>(StatusCodes.Status401Unauthorized)]
+[ProducesResponseType<ApiErrorResponse>(StatusCodes.Status500InternalServerError)]
+[Route("api/v1/dashboard/applications/{appId:guid}/portal")]
+[Authorize(AuthenticationSchemes = CookieAuthenticationDefaults.AuthenticationScheme)]
+public class DashboardPortalController : ControllerBase
+{
+    private const string SigningKeyPrefix = "whsec_";
+    private const string SetupInstructions =
+        "Store this signing key in your host SaaS backend's environment as PORTAL_SIGNING_KEY. " +
+        "Use it to mint short-lived HS256 JWTs (claim: appId + capabilities) for the embeddable portal. " +
+        "The key is shown ONCE — re-run rotate to mint a new one if you lose it.";
+
+    private readonly ApplicationRepository _applicationRepository;
+    private readonly IAuditLogger _auditLogger;
+    private readonly ILogger<DashboardPortalController> _logger;
+
+    public DashboardPortalController(
+        ApplicationRepository applicationRepository,
+        IAuditLogger auditLogger,
+        ILogger<DashboardPortalController> logger)
+    {
+        _applicationRepository = applicationRepository;
+        _auditLogger = auditLogger;
+        _logger = logger;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Get(Guid appId, CancellationToken ct)
+    {
+        var application = await _applicationRepository.GetByIdAsync(appId, ct);
+        if (application is null)
+        {
+            return NotFound(ApiEnvelope.Error(HttpContext, "NOT_FOUND", "Application not found."));
+        }
+
+        return Ok(ApiEnvelope.Success(HttpContext, BuildReadResponse(application)));
+    }
+
+    [HttpPost("enable")]
+    public async Task<IActionResult> Enable(Guid appId, CancellationToken ct)
+    {
+        var application = await _applicationRepository.GetByIdAsync(appId, ct);
+        if (application is null)
+        {
+            return NotFound(ApiEnvelope.Error(HttpContext, "NOT_FOUND", "Application not found."));
+        }
+
+        var beforeSnapshot = BuildAuditSnapshot(application);
+
+        var newSigningKey = GenerateSigningKey();
+        application.PortalSigningKey = newSigningKey;
+        application.PortalRotatedAt = DateTime.UtcNow;
+
+        await _applicationRepository.UpdateAsync(application, ct);
+        PortalLookupCache.InvalidateApplication(appId);
+
+        var afterSnapshot = BuildAuditSnapshot(application);
+        await _auditLogger.LogActionAsync(
+            HttpContext,
+            action: "application.portal.enabled",
+            resourceType: "application",
+            resourceId: appId,
+            appId: appId,
+            before: beforeSnapshot,
+            after: afterSnapshot,
+            ct: ct);
+
+        // Intentionally narrow log line: appId only, never the key.
+        _logger.LogInformation("Portal enabled for application {AppId}.", LogSanitizer.ForLog(appId.ToString()));
+
+        return Ok(ApiEnvelope.Success(HttpContext, new
+        {
+            signingKey = newSigningKey,
+            rotatedAt = application.PortalRotatedAt,
+            instructions = SetupInstructions
+        }));
+    }
+
+    [HttpPost("rotate")]
+    public async Task<IActionResult> Rotate(Guid appId, CancellationToken ct)
+    {
+        var application = await _applicationRepository.GetByIdAsync(appId, ct);
+        if (application is null)
+        {
+            return NotFound(ApiEnvelope.Error(HttpContext, "NOT_FOUND", "Application not found."));
+        }
+
+        if (string.IsNullOrEmpty(application.PortalSigningKey))
+        {
+            return Conflict(ApiEnvelope.Error(HttpContext, "PORTAL_NOT_ENABLED",
+                "Portal is not enabled for this application. Call /portal/enable first."));
+        }
+
+        var beforeSnapshot = BuildAuditSnapshot(application);
+
+        var newSigningKey = GenerateSigningKey();
+        application.PortalSigningKey = newSigningKey;
+        application.PortalRotatedAt = DateTime.UtcNow;
+
+        await _applicationRepository.UpdateAsync(application, ct);
+        PortalLookupCache.InvalidateApplication(appId);
+
+        var afterSnapshot = BuildAuditSnapshot(application);
+        await _auditLogger.LogActionAsync(
+            HttpContext,
+            action: "application.portal.rotated",
+            resourceType: "application",
+            resourceId: appId,
+            appId: appId,
+            before: beforeSnapshot,
+            after: afterSnapshot,
+            ct: ct);
+
+        _logger.LogInformation("Portal signing key rotated for application {AppId}.", LogSanitizer.ForLog(appId.ToString()));
+
+        return Ok(ApiEnvelope.Success(HttpContext, new
+        {
+            signingKey = newSigningKey,
+            rotatedAt = application.PortalRotatedAt,
+            instructions = SetupInstructions
+        }));
+    }
+
+    [HttpPost("disable")]
+    public async Task<IActionResult> Disable(Guid appId, CancellationToken ct)
+    {
+        var application = await _applicationRepository.GetByIdAsync(appId, ct);
+        if (application is null)
+        {
+            return NotFound(ApiEnvelope.Error(HttpContext, "NOT_FOUND", "Application not found."));
+        }
+
+        var beforeSnapshot = BuildAuditSnapshot(application);
+
+        application.PortalSigningKey = null;
+        application.AllowedPortalOriginsJson = null;
+        application.PortalRotatedAt = null;
+
+        await _applicationRepository.UpdateAsync(application, ct);
+        PortalLookupCache.InvalidateApplication(appId);
+
+        var afterSnapshot = BuildAuditSnapshot(application);
+        await _auditLogger.LogActionAsync(
+            HttpContext,
+            action: "application.portal.disabled",
+            resourceType: "application",
+            resourceId: appId,
+            appId: appId,
+            before: beforeSnapshot,
+            after: afterSnapshot,
+            ct: ct);
+
+        _logger.LogInformation("Portal disabled for application {AppId}.", LogSanitizer.ForLog(appId.ToString()));
+
+        return NoContent();
+    }
+
+    [HttpPut("origins")]
+    public async Task<IActionResult> UpdateOrigins(Guid appId, [FromBody] DashboardPortalOriginsRequest request, CancellationToken ct)
+    {
+        var application = await _applicationRepository.GetByIdAsync(appId, ct);
+        if (application is null)
+        {
+            return NotFound(ApiEnvelope.Error(HttpContext, "NOT_FOUND", "Application not found."));
+        }
+
+        if (string.IsNullOrEmpty(application.PortalSigningKey))
+        {
+            return Conflict(ApiEnvelope.Error(HttpContext, "PORTAL_NOT_ENABLED",
+                "Portal is not enabled for this application. Call /portal/enable before configuring origins."));
+        }
+
+        var beforeSnapshot = BuildAuditSnapshot(application);
+
+        // Canonicalize: lowercase scheme + host before persistence so portal CORS
+        // matching at request time is predictable. RFC 6454 §4 — scheme + host
+        // are case-insensitive; we normalize on write to avoid every reader
+        // having to compare case-insensitively.
+        var canonical = (request.Origins ?? new List<string>())
+            .Select(CanonicalizeOrigin)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        application.AllowedPortalOriginsJson = canonical.Count == 0
+            ? "[]"
+            : JsonSerializer.Serialize(canonical);
+
+        await _applicationRepository.UpdateAsync(application, ct);
+        PortalLookupCache.InvalidateApplication(appId);
+
+        var afterSnapshot = BuildAuditSnapshot(application);
+        await _auditLogger.LogActionAsync(
+            HttpContext,
+            action: "application.portal.origins.updated",
+            resourceType: "application",
+            resourceId: appId,
+            appId: appId,
+            before: beforeSnapshot,
+            after: afterSnapshot,
+            ct: ct);
+
+        return Ok(ApiEnvelope.Success(HttpContext, new
+        {
+            allowedOrigins = canonical
+        }));
+    }
+
+    private static string GenerateSigningKey()
+    {
+        // 32 bytes of cryptographic randomness → 44 base64 chars + "whsec_"
+        // prefix = 50 chars, well within the varchar(64) PortalSigningKey
+        // column. The PortalTokenAuthMiddleware reads this literal string as
+        // the HMAC key — do not hash it before persistence.
+        var random = RandomNumberGenerator.GetBytes(32);
+        return SigningKeyPrefix + Convert.ToBase64String(random);
+    }
+
+    private static string CanonicalizeOrigin(string origin)
+    {
+        // Validator already rejects malformed input, so a parse failure here
+        // would be a programming bug. Defensive fallback returns the raw value
+        // lowercased so a future bug never silently writes mixed-case data.
+        if (!Uri.TryCreate(origin, UriKind.Absolute, out var uri))
+        {
+            return origin.ToLowerInvariant();
+        }
+
+        var scheme = uri.Scheme.ToLowerInvariant();
+        var host = uri.Host.ToLowerInvariant();
+        var port = uri.IsDefaultPort ? string.Empty : $":{uri.Port}";
+        return $"{scheme}://{host}{port}";
+    }
+
+    private static object BuildReadResponse(Core.Entities.Application application)
+    {
+        return new
+        {
+            portalEnabled = !string.IsNullOrEmpty(application.PortalSigningKey),
+            allowedOrigins = ParseOrigins(application.AllowedPortalOriginsJson),
+            rotatedAt = application.PortalRotatedAt,
+            // Always null on read — the signing key is shown once at enable / rotate
+            // and never returned by GET. Callers must not attempt to use this field.
+            signingKey = (string?)null
+        };
+    }
+
+    private static object BuildAuditSnapshot(Core.Entities.Application application)
+    {
+        // CRITICAL: PortalSigningKey MUST NOT appear here. Audit rows persist
+        // the boolean fact + origin list + rotated-at timestamp only — every
+        // controller action writes the same shape so tampering is grep-able.
+        return new
+        {
+            portalEnabled = !string.IsNullOrEmpty(application.PortalSigningKey),
+            allowedOrigins = ParseOrigins(application.AllowedPortalOriginsJson),
+            rotatedAt = application.PortalRotatedAt
+        };
+    }
+
+    private static string[] ParseOrigins(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return [];
+        }
+
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<string[]>(json);
+            return parsed ?? [];
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+    }
+}
+
+/// <summary>
+/// Request body for <c>PUT /api/v1/dashboard/applications/{appId}/portal/origins</c>.
+/// Empty list is valid — clears the allowlist.
+/// </summary>
+public class DashboardPortalOriginsRequest
+{
+    public List<string> Origins { get; set; } = new();
+}

--- a/src/WebhookEngine.API/Validators/PortalRequestValidators.cs
+++ b/src/WebhookEngine.API/Validators/PortalRequestValidators.cs
@@ -98,3 +98,87 @@ public class PortalEndpointTestRequestValidator : AbstractValidator<PortalEndpoi
             .WithMessage($"Payload exceeds the {MaxPayloadBytes / 1024} KB probe cap.");
     }
 }
+
+
+/// <summary>
+/// Validator for the dashboard "set portal allowed origins" payload. Each origin
+/// must be an absolute URL with no path/query/fragment, https-only outside of
+/// development. Wildcards are rejected — the host SaaS must enumerate exact
+/// origins. Empty array is valid (clears the allowlist).
+///
+/// Sanity caps: max 50 origins per app and max 256 chars per origin. The 50-cap
+/// keeps the in-process membership check (PortalLookupCache + PortalCorsMiddleware)
+/// O(small); 256 chars covers the longest reasonable scheme+host+port combo while
+/// rejecting payload abuse.
+/// </summary>
+public class DashboardPortalOriginsRequestValidator : AbstractValidator<WebhookEngine.API.Controllers.DashboardPortalOriginsRequest>
+{
+    public const int MaxOrigins = 50;
+    public const int MaxOriginLength = 256;
+
+    public DashboardPortalOriginsRequestValidator(Microsoft.Extensions.Hosting.IHostEnvironment hostEnvironment)
+    {
+        var allowHttp = hostEnvironment.IsDevelopment();
+
+        RuleFor(x => x.Origins)
+            .NotNull().WithMessage("Origins must be an array (use [] to clear).")
+            .Must(origins => origins!.Count <= MaxOrigins)
+            .WithMessage($"At most {MaxOrigins} origins are allowed per application.");
+
+        RuleForEach(x => x.Origins)
+            .NotEmpty().WithMessage("Origin must not be empty.")
+            .MaximumLength(MaxOriginLength)
+            .WithMessage($"Origin exceeds the {MaxOriginLength}-character limit.")
+            .Must(origin => !origin!.Contains('*'))
+            .WithMessage("Wildcards are not allowed; enumerate exact origins.")
+            .Must(origin => IsValidOrigin(origin, allowHttp))
+            .WithMessage("Origin must be an absolute https URL with scheme and host only (no path, query, or fragment).");
+    }
+
+    private static bool IsValidOrigin(string? origin, bool allowHttp)
+    {
+        if (string.IsNullOrWhiteSpace(origin))
+        {
+            return false;
+        }
+
+        if (!Uri.TryCreate(origin, UriKind.Absolute, out var uri))
+        {
+            return false;
+        }
+
+        var schemeOk = uri.Scheme == Uri.UriSchemeHttps || (allowHttp && uri.Scheme == Uri.UriSchemeHttp);
+        if (!schemeOk)
+        {
+            return false;
+        }
+
+        // RFC 6454 origins are scheme + host (+ optional non-default port).
+        // Reject anything that smuggles a path, query, or fragment.
+        if (uri.AbsolutePath != "/" && uri.AbsolutePath.Length > 0)
+        {
+            return false;
+        }
+        if (!string.IsNullOrEmpty(uri.Query) || !string.IsNullOrEmpty(uri.Fragment))
+        {
+            return false;
+        }
+        if (!string.IsNullOrEmpty(uri.UserInfo))
+        {
+            return false;
+        }
+
+        // The original input shouldn't carry a trailing slash beyond the host
+        // (Uri parses "https://x" and "https://x/" identically into AbsolutePath="/",
+        // so we check the raw string for the path segment after host:port).
+        var schemePart = $"{uri.Scheme}://";
+        var afterScheme = origin.AsSpan(schemePart.Length);
+        // Forbid any '/' or '?' or '#' in the part after the scheme.
+        if (afterScheme.IndexOfAny('/', '?', '#') >= 0)
+        {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/WebhookEngine.Core/Entities/Application.cs
+++ b/src/WebhookEngine.Core/Entities/Application.cs
@@ -40,6 +40,13 @@ public class Application
     /// </summary>
     public string? AllowedPortalOriginsJson { get; set; }
 
+    /// <summary>
+    /// Timestamp of the last portal-signing-key mint (enable or rotate). Null
+    /// when the portal is disabled. Surfaced through the read endpoint so the
+    /// dashboard can show "rotated 3 minutes ago" without reading the secret.
+    /// </summary>
+    public DateTime? PortalRotatedAt { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 

--- a/src/WebhookEngine.Infrastructure/Data/WebhookDbContext.cs
+++ b/src/WebhookEngine.Infrastructure/Data/WebhookDbContext.cs
@@ -52,6 +52,8 @@ public class WebhookDbContext : DbContext
             entity.Property(e => e.AllowedPortalOriginsJson)
                 .HasColumnName("allowed_portal_origins")
                 .HasColumnType("jsonb");
+            entity.Property(e => e.PortalRotatedAt)
+                .HasColumnName("portal_rotated_at");
 
             entity.HasIndex(e => e.ApiKeyPrefix).IsUnique();
         });

--- a/src/WebhookEngine.Infrastructure/Migrations/20260510193800_AddPortalRotatedAtToApplication.Designer.cs
+++ b/src/WebhookEngine.Infrastructure/Migrations/20260510193800_AddPortalRotatedAtToApplication.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WebhookEngine.Infrastructure.Data;
@@ -11,9 +12,11 @@ using WebhookEngine.Infrastructure.Data;
 namespace WebhookEngine.Infrastructure.Migrations
 {
     [DbContext(typeof(WebhookDbContext))]
-    partial class WebhookDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260510193800_AddPortalRotatedAtToApplication")]
+    partial class AddPortalRotatedAtToApplication
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/WebhookEngine.Infrastructure/Migrations/20260510193800_AddPortalRotatedAtToApplication.cs
+++ b/src/WebhookEngine.Infrastructure/Migrations/20260510193800_AddPortalRotatedAtToApplication.cs
@@ -1,0 +1,29 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WebhookEngine.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPortalRotatedAtToApplication : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "portal_rotated_at",
+                table: "applications",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "portal_rotated_at",
+                table: "applications");
+        }
+    }
+}

--- a/src/dashboard/src/api/dashboardApi.ts
+++ b/src/dashboard/src/api/dashboardApi.ts
@@ -263,6 +263,64 @@ export async function rotateSigningSecret(id: string): Promise<{ signingSecret: 
   return { signingSecret: payload.data.signingSecret };
 }
 
+// ── Portal access ─────────────────────────────────────
+
+export interface PortalAccessState {
+  portalEnabled: boolean;
+  allowedOrigins: string[];
+  rotatedAt: string | null;
+  // Always null on read — key is only returned from enable / rotate responses.
+  signingKey: null;
+}
+
+export interface PortalSigningKeyReveal {
+  signingKey: string;
+  rotatedAt: string;
+  instructions: string;
+}
+
+export async function getPortalAccess(appId: string): Promise<PortalAccessState> {
+  const payload = await fetchJson<ApiEnvelope<PortalAccessState>>(
+    `/api/v1/dashboard/applications/${appId}/portal`
+  );
+  return payload.data;
+}
+
+export async function enablePortal(appId: string): Promise<PortalSigningKeyReveal> {
+  const payload = await mutate<ApiEnvelope<PortalSigningKeyReveal>>(
+    `/api/v1/dashboard/applications/${appId}/portal/enable`,
+    "POST"
+  );
+  return payload.data;
+}
+
+export async function rotatePortalKey(appId: string): Promise<PortalSigningKeyReveal> {
+  const payload = await mutate<ApiEnvelope<PortalSigningKeyReveal>>(
+    `/api/v1/dashboard/applications/${appId}/portal/rotate`,
+    "POST"
+  );
+  return payload.data;
+}
+
+export async function disablePortal(appId: string): Promise<void> {
+  await mutate<void>(
+    `/api/v1/dashboard/applications/${appId}/portal/disable`,
+    "POST"
+  );
+}
+
+export async function updatePortalOrigins(
+  appId: string,
+  origins: string[]
+): Promise<{ allowedOrigins: string[] }> {
+  const payload = await mutate<ApiEnvelope<{ allowedOrigins: string[] }>>(
+    `/api/v1/dashboard/applications/${appId}/portal/origins`,
+    "PUT",
+    { origins }
+  );
+  return payload.data;
+}
+
 // ── Endpoints ───────────────────────────────────
 
 export interface EndpointListParams {

--- a/src/dashboard/src/components/PortalAccessModal.tsx
+++ b/src/dashboard/src/components/PortalAccessModal.tsx
@@ -1,0 +1,634 @@
+import { useState, useRef, useCallback } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  Globe,
+  Copy,
+  Check,
+  AlertCircle,
+  X,
+  Plus,
+  CheckCircle2
+} from "lucide-react";
+import { Modal } from "./Modal";
+import { ConfirmModal } from "./ConfirmModal";
+import {
+  getPortalAccess,
+  enablePortal,
+  rotatePortalKey,
+  disablePortal,
+  updatePortalOrigins,
+  ApiErrorException
+} from "../api/dashboardApi";
+import type { PortalSigningKeyReveal } from "../api/dashboardApi";
+import { formatLocaleDateTime } from "../utils/dateTime";
+
+// ── Copy button (same pattern as ApplicationsPage) ───────────────────────────
+
+function CopyButton({ text, className }: { text: string; className?: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      className={className ?? "p-1 rounded hover:bg-surface-3 text-text-muted hover:text-text-primary transition-colors"}
+      title="Copy"
+    >
+      {copied ? <Check className="w-3.5 h-3.5 text-success" /> : <Copy className="w-3.5 h-3.5" />}
+    </button>
+  );
+}
+
+// ── Embed snippet code blocks ─────────────────────────────────────────────────
+
+const MINT_SNIPPET = `// In your backend (Express, Next API route, etc.)
+import { SignJWT } from "jose";
+
+export async function mintPortalToken(appId: string) {
+  const secret = new TextEncoder().encode(process.env.PORTAL_SIGNING_KEY);
+  return await new SignJWT({
+    appId,
+    capabilities: ["endpoints:read", "endpoints:write", "endpoints:test", "attempts:read"]
+  })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setNotBefore("0s")
+    .setExpirationTime("10m")
+    .sign(secret);
+}`;
+
+const RENDER_SNIPPET = `// In your settings page
+import { EndpointManager } from "@webhookengine/endpoint-manager";
+
+<EndpointManager
+  baseUrl="https://hooks.your-domain.com"
+  appId="<the same appId>"
+  token={await mintPortalToken("<the same appId>")}
+/>`;
+
+function CodeBlock({ code, label }: { code: string; label: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(code);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium text-text-secondary">{label}</span>
+        <button
+          onClick={handleCopy}
+          className="inline-flex items-center gap-1 text-xs text-text-muted hover:text-text-primary transition-colors"
+          title="Copy snippet"
+        >
+          {copied ? (
+            <><Check className="w-3 h-3 text-success" /><span className="text-success">Copied</span></>
+          ) : (
+            <><Copy className="w-3 h-3" />Copy</>
+          )}
+        </button>
+      </div>
+      <pre className="bg-surface-0 border border-border rounded-lg px-3 py-2.5 text-xs font-mono text-text-secondary overflow-x-auto leading-relaxed whitespace-pre">
+        <code>{code}</code>
+      </pre>
+    </div>
+  );
+}
+
+// ── Origin chip list ──────────────────────────────────────────────────────────
+
+function validateOrigin(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("http://") && !trimmed.startsWith("https://")) {
+    return "Origin must start with http:// or https://";
+  }
+  try {
+    const url = new URL(trimmed);
+    if (url.pathname !== "/" && url.pathname !== "") {
+      return "Origin must not include a path";
+    }
+    if (url.search || url.hash) {
+      return "Origin must not include query string or fragment";
+    }
+  } catch {
+    return "Invalid URL";
+  }
+  if (trimmed.includes("*")) {
+    return "Wildcards are not allowed";
+  }
+  return null;
+}
+
+interface OriginChipListProps {
+  origins: string[];
+  onChange: (origins: string[]) => void;
+  disabled: boolean;
+}
+
+function OriginChipList({ origins, onChange, disabled }: OriginChipListProps) {
+  const [inputValue, setInputValue] = useState("");
+  const [inputError, setInputError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const addOrigin = useCallback(() => {
+    const trimmed = inputValue.trim();
+    if (!trimmed) return;
+
+    const err = validateOrigin(trimmed);
+    if (err) {
+      setInputError(err);
+      return;
+    }
+
+    // Normalize: lowercase scheme + host, strip trailing slash
+    let normalized = trimmed.toLowerCase();
+    try {
+      const url = new URL(normalized);
+      normalized = `${url.protocol}//${url.host}`;
+    } catch {
+      // keep as-is — backend will canonicalize / reject
+    }
+
+    if (origins.includes(normalized)) {
+      setInputError("Origin already in the list");
+      return;
+    }
+
+    onChange([...origins, normalized]);
+    setInputValue("");
+    setInputError(null);
+    inputRef.current?.focus();
+  }, [inputValue, origins, onChange]);
+
+  const removeOrigin = (origin: string) => {
+    onChange(origins.filter((o) => o !== origin));
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      addOrigin();
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap gap-1.5">
+        {origins.map((origin) => (
+          <span
+            key={origin}
+            className="inline-flex items-center gap-1 text-xs font-mono bg-surface-2 border border-border rounded-md px-2 py-0.5 text-text-secondary"
+          >
+            {origin}
+            {!disabled && (
+              <button
+                type="button"
+                onClick={() => removeOrigin(origin)}
+                className="text-text-muted hover:text-danger transition-colors ml-0.5"
+                aria-label={`Remove ${origin}`}
+              >
+                <X className="w-3 h-3" />
+              </button>
+            )}
+          </span>
+        ))}
+        {origins.length === 0 && (
+          <span className="text-xs text-text-muted italic">No origins configured</span>
+        )}
+      </div>
+
+      {!disabled && (
+        <div className="flex items-start gap-2">
+          <div className="flex-1">
+            <input
+              ref={inputRef}
+              type="url"
+              value={inputValue}
+              onChange={(e) => { setInputValue(e.target.value); setInputError(null); }}
+              onKeyDown={handleKeyDown}
+              placeholder="https://app.example.com"
+              className="w-full px-3 py-1.5 text-xs font-mono bg-surface-2 border border-border rounded-lg text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-1 focus:ring-accent/50 focus:border-accent/50 transition-colors"
+            />
+            {inputError && (
+              <p className="text-xs text-danger mt-1 flex items-center gap-1">
+                <AlertCircle className="w-3 h-3 shrink-0" />
+                {inputError}
+              </p>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={addOrigin}
+            disabled={!inputValue.trim()}
+            className="p-1.5 rounded-lg border border-border bg-surface-2 text-text-muted hover:text-text-primary hover:bg-surface-3 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            aria-label="Add origin"
+          >
+            <Plus className="w-3.5 h-3.5" />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Show-once signing key reveal ─────────────────────────────────────────────
+
+interface SigningKeyRevealProps {
+  reveal: PortalSigningKeyReveal;
+  onAcknowledge: () => void;
+}
+
+function SigningKeyReveal({ reveal, onAcknowledge }: SigningKeyRevealProps) {
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border border-warning/30 bg-warning-soft p-4 space-y-3">
+        <div className="flex items-start gap-2">
+          <AlertCircle className="w-4 h-4 text-warning shrink-0 mt-0.5" />
+          <p className="text-sm font-semibold text-warning">Save this signing key — you will not see it again</p>
+        </div>
+        <div className="flex items-center gap-2 bg-surface-0 border border-border rounded-lg px-3 py-2">
+          <code className="text-xs font-mono text-text-primary flex-1 break-all select-all">
+            {reveal.signingKey}
+          </code>
+          <CopyButton text={reveal.signingKey} />
+        </div>
+        <p className="text-xs text-text-secondary leading-relaxed">
+          Store this in your host SaaS backend's environment as{" "}
+          <code className="font-mono bg-surface-0 px-1 py-0.5 rounded text-text-primary">PORTAL_SIGNING_KEY</code>.
+          Once you click "I've saved it" below, the key will not be retrievable from this dashboard again
+          — you'd have to rotate to get a new one.
+        </p>
+      </div>
+
+      <button
+        onClick={onAcknowledge}
+        className="w-full inline-flex items-center justify-center gap-1.5 text-sm font-medium px-4 py-2 rounded-lg bg-accent text-zinc-950 hover:bg-accent/90 transition-colors"
+      >
+        <CheckCircle2 className="w-4 h-4" />
+        I've saved it
+      </button>
+    </div>
+  );
+}
+
+// ── Inner modal body — mounted fresh on each open via key prop ────────────────
+// Keeping all ephemeral state here means we get free reset on every open
+// without needing useEffect-driven setState calls (which trigger the
+// react-hooks/set-state-in-effect lint rule).
+
+interface PortalModalBodyProps {
+  appId: string;
+  appName: string;
+  onClose: () => void;
+}
+
+function PortalModalBody({ appId, appName, onClose }: PortalModalBodyProps) {
+  const queryClient = useQueryClient();
+
+  // Key reveal is ephemeral — never cached; starts null, set by enable/rotate
+  const [keyReveal, setKeyReveal] = useState<PortalSigningKeyReveal | null>(null);
+
+  // Local origin list — initialized from first successful query fetch.
+  // `null` means "not yet initialized from server"; we render skeleton until set.
+  const [localOrigins, setLocalOrigins] = useState<string[] | null>(null);
+  const [originsError, setOriginsError] = useState<string | null>(null);
+
+  // Confirm modal state
+  const [confirmAction, setConfirmAction] = useState<"rotate" | "disable" | null>(null);
+
+  // Mutation error displayed inline in the status section
+  const [mutationError, setMutationError] = useState<string | null>(null);
+
+  const portalQuery = useQuery({
+    queryKey: ["portal-access", appId],
+    queryFn: () => getPortalAccess(appId),
+    // Don't re-fetch while the key-reveal banner is showing; the data is
+    // already stale until the operator acknowledges and we re-enable the query.
+    enabled: !keyReveal,
+    staleTime: 30_000,
+    // Initialize local origins from server on first successful fetch.
+    // Using `select` here would lose the ability to detect dirty state, so
+    // we rely on the onSuccess equivalent: structuring the component so that
+    // localOrigins starts null and we fill it from portal data in render.
+  });
+
+  const portal = portalQuery.data;
+
+  // Derive effective local origins: use edited copy if present, otherwise
+  // fall back to server data. This avoids useEffect-driven setState.
+  const effectiveOrigins: string[] = localOrigins ?? portal?.allowedOrigins ?? [];
+
+  const invalidatePortal = () =>
+    queryClient.invalidateQueries({ queryKey: ["portal-access", appId] });
+
+  const enableMutation = useMutation({
+    mutationFn: () => enablePortal(appId),
+    onSuccess: (result) => {
+      setKeyReveal(result);
+      setMutationError(null);
+      // Reset local origins so next render picks up server data after acknowledge
+      setLocalOrigins(null);
+      invalidatePortal();
+    },
+    onError: (e: unknown) =>
+      setMutationError(e instanceof Error ? e.message : "Failed to enable portal access")
+  });
+
+  const rotateMutation = useMutation({
+    mutationFn: () => rotatePortalKey(appId),
+    onSuccess: (result) => {
+      setKeyReveal(result);
+      setMutationError(null);
+      setLocalOrigins(null);
+      invalidatePortal();
+    },
+    onError: (e: unknown) =>
+      setMutationError(e instanceof Error ? e.message : "Failed to rotate portal key")
+  });
+
+  const disableMutation = useMutation({
+    mutationFn: () => disablePortal(appId),
+    onSuccess: () => {
+      setMutationError(null);
+      setLocalOrigins(null);
+      invalidatePortal();
+    },
+    onError: (e: unknown) =>
+      setMutationError(e instanceof Error ? e.message : "Failed to disable portal access")
+  });
+
+  const originsMutation = useMutation({
+    mutationFn: (origins: string[]) => updatePortalOrigins(appId, origins),
+    onSuccess: (result) => {
+      // Replace local copy with canonicalized server response; marks clean.
+      setLocalOrigins(result.allowedOrigins);
+      setOriginsError(null);
+      invalidatePortal();
+    },
+    onError: (e: unknown) => {
+      if (e instanceof ApiErrorException && e.fieldErrors) {
+        const firstFieldError = Object.values(e.fieldErrors)[0];
+        setOriginsError(firstFieldError ?? e.message);
+      } else {
+        setOriginsError(e instanceof Error ? e.message : "Failed to save origins");
+      }
+    }
+  });
+
+  const isBusy =
+    enableMutation.isPending ||
+    rotateMutation.isPending ||
+    disableMutation.isPending ||
+    originsMutation.isPending;
+
+  // Origins are dirty when the local copy has been set by the user AND differs
+  // from the last known server state.
+  const savedOrigins = portal?.allowedOrigins ?? [];
+  const originsChanged =
+    localOrigins !== null &&
+    JSON.stringify([...localOrigins].sort()) !== JSON.stringify([...savedOrigins].sort());
+
+  const handleConfirmRotate = () => {
+    setMutationError(null);
+    rotateMutation.mutate();
+  };
+
+  const handleConfirmDisable = () => {
+    setMutationError(null);
+    disableMutation.mutate();
+  };
+
+  const handleSaveOrigins = () => {
+    setOriginsError(null);
+    originsMutation.mutate(effectiveOrigins);
+  };
+
+  return (
+    <>
+      <Modal
+        open
+        onClose={onClose}
+        title={`Portal access — ${appName}`}
+        width="max-w-2xl"
+      >
+        {/* Key reveal view — replaces all other content until acknowledged */}
+        {keyReveal ? (
+          <SigningKeyReveal
+            reveal={keyReveal}
+            onAcknowledge={() => setKeyReveal(null)}
+          />
+        ) : (
+          <div className="space-y-4">
+            {/* Loading / fetch error */}
+            {portalQuery.isLoading && (
+              <div className="flex items-center justify-center py-8">
+                <span className="text-sm text-text-muted">Loading portal settings...</span>
+              </div>
+            )}
+
+            {portalQuery.error && !portalQuery.isLoading && (
+              <div className="flex items-center gap-2 text-danger text-xs bg-danger-soft border border-danger/20 rounded-lg px-3 py-2">
+                <AlertCircle className="w-3.5 h-3.5 shrink-0" />
+                {portalQuery.error instanceof Error
+                  ? portalQuery.error.message
+                  : "Failed to load portal settings"}
+              </div>
+            )}
+
+            {/* Mutation error */}
+            {mutationError && (
+              <div className="flex items-center gap-2 text-danger text-xs bg-danger-soft border border-danger/20 rounded-lg px-3 py-2">
+                <AlertCircle className="w-3.5 h-3.5 shrink-0" />
+                {mutationError}
+                <button
+                  onClick={() => setMutationError(null)}
+                  className="ml-auto text-danger/60 hover:text-danger"
+                >
+                  <X className="w-3 h-3" />
+                </button>
+              </div>
+            )}
+
+            {portal && (
+              <>
+                {/* ── Status section ─────────────────────────────────── */}
+                <div className="rounded-lg border border-border bg-surface-1 p-4 space-y-3">
+                  <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wide">Status</h3>
+
+                  {portal.portalEnabled ? (
+                    <>
+                      <div className="flex items-center gap-2">
+                        <Globe className="w-4 h-4 text-success" />
+                        <span className="inline-flex items-center gap-1 text-xs font-medium px-1.5 py-0.5 rounded bg-success-soft text-success">
+                          Enabled
+                        </span>
+                        {portal.rotatedAt && (
+                          <span className="text-xs text-text-muted">
+                            Last rotated {formatLocaleDateTime(portal.rotatedAt)}
+                          </span>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <button
+                          onClick={() => setConfirmAction("rotate")}
+                          disabled={isBusy}
+                          className="text-xs font-medium px-3 py-1.5 rounded-lg border border-border bg-surface-2 text-text-secondary hover:text-text-primary hover:bg-surface-3 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                        >
+                          Rotate signing key
+                        </button>
+                        <button
+                          onClick={() => setConfirmAction("disable")}
+                          disabled={isBusy}
+                          className="text-xs font-medium px-3 py-1.5 rounded-lg bg-danger-soft text-danger hover:bg-danger/20 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                        >
+                          Disable portal
+                        </button>
+                      </div>
+                    </>
+                  ) : (
+                    <>
+                      <div className="flex items-center gap-2">
+                        <Globe className="w-4 h-4 text-text-muted" />
+                        <span className="text-xs text-text-muted">
+                          Portal access is disabled. Enable it to let your customers manage
+                          their own endpoints via the embedded component.
+                        </span>
+                      </div>
+                      <button
+                        onClick={() => enableMutation.mutate()}
+                        disabled={isBusy}
+                        className="text-xs font-medium px-3 py-1.5 rounded-lg bg-accent text-zinc-950 hover:bg-accent/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                      >
+                        {enableMutation.isPending ? "Enabling..." : "Enable portal access"}
+                      </button>
+                    </>
+                  )}
+                </div>
+
+                {/* ── Allowed origins + Embed snippet (only when enabled) ─── */}
+                {portal.portalEnabled && (
+                  <>
+                    {/* Allowed origins */}
+                    <div className="rounded-lg border border-border bg-surface-1 p-4 space-y-3">
+                      <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wide">
+                        Allowed origins
+                      </h3>
+                      <p className="text-xs text-text-secondary">
+                        CORS origins that may embed the portal component. Add the exact
+                        scheme + hostname of your SaaS frontend (no paths, no wildcards).
+                      </p>
+
+                      <OriginChipList
+                        origins={effectiveOrigins}
+                        onChange={setLocalOrigins}
+                        disabled={isBusy}
+                      />
+
+                      {originsError && (
+                        <p className="text-xs text-danger flex items-center gap-1">
+                          <AlertCircle className="w-3 h-3 shrink-0" />
+                          {originsError}
+                        </p>
+                      )}
+
+                      <div className="flex justify-end">
+                        <button
+                          onClick={handleSaveOrigins}
+                          disabled={!originsChanged || isBusy}
+                          className="text-xs font-medium px-3 py-1.5 rounded-lg bg-accent text-zinc-950 hover:bg-accent/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                        >
+                          {originsMutation.isPending ? "Saving..." : "Save changes"}
+                        </button>
+                      </div>
+                    </div>
+
+                    {/* Embed snippet */}
+                    <div className="rounded-lg border border-border bg-surface-1 p-4 space-y-3">
+                      <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wide">
+                        Embed snippet
+                      </h3>
+
+                      <CodeBlock
+                        label="Backend — mint a portal token (Node / TypeScript)"
+                        code={MINT_SNIPPET}
+                      />
+
+                      <CodeBlock
+                        label="Frontend — render the React component"
+                        code={RENDER_SNIPPET}
+                      />
+
+                      <p className="text-xs text-text-muted border-t border-border-subtle pt-2">
+                        Package{" "}
+                        <code className="font-mono bg-surface-0 px-1 py-0.5 rounded text-text-primary">
+                          @webhookengine/endpoint-manager
+                        </code>{" "}
+                        will be published in B1 Step 7 (not yet available on npm).
+                      </p>
+                    </div>
+                  </>
+                )}
+              </>
+            )}
+          </div>
+        )}
+      </Modal>
+
+      {/* Rotate confirm */}
+      <ConfirmModal
+        open={confirmAction === "rotate"}
+        onClose={() => setConfirmAction(null)}
+        onConfirm={handleConfirmRotate}
+        title="Rotate signing key"
+        description="Existing portal sessions using the current key will stop working immediately. Continue?"
+        confirmLabel="Rotate key"
+        variant="default"
+        loading={rotateMutation.isPending}
+      />
+
+      {/* Disable confirm */}
+      <ConfirmModal
+        open={confirmAction === "disable"}
+        onClose={() => setConfirmAction(null)}
+        onConfirm={handleConfirmDisable}
+        title="Disable portal access"
+        description="Customers embedding <EndpointManager /> will lose access. The signing key and allowed-origin list will both be cleared. Continue?"
+        confirmLabel="Disable portal"
+        variant="danger"
+        loading={disableMutation.isPending}
+      />
+    </>
+  );
+}
+
+// ── Public export ─────────────────────────────────────────────────────────────
+// The outer shell is just an open/closed gate. When open=true we mount
+// PortalModalBody with a stable key (appId) so that switching between
+// different apps via the table never bleeds state from one app to another.
+
+export interface PortalAccessModalProps {
+  open: boolean;
+  onClose: () => void;
+  appId: string;
+  appName: string;
+}
+
+export function PortalAccessModal({ open, onClose, appId, appName }: PortalAccessModalProps) {
+  if (!open) return null;
+  return (
+    <PortalModalBody
+      key={appId}
+      appId={appId}
+      appName={appName}
+      onClose={onClose}
+    />
+  );
+}

--- a/src/dashboard/src/pages/ApplicationsPage.tsx
+++ b/src/dashboard/src/pages/ApplicationsPage.tsx
@@ -10,6 +10,7 @@ import {
 } from "../api/dashboardApi";
 import { Modal } from "../components/Modal";
 import { ConfirmModal } from "../components/ConfirmModal";
+import { PortalAccessModal } from "../components/PortalAccessModal";
 import type { EndpointRow } from "../types";
 import { formatLocaleDate } from "../utils/dateTime";
 import {
@@ -22,7 +23,8 @@ import {
   AlertCircle,
   X,
   ChevronLeft,
-  ChevronRight
+  ChevronRight,
+  Globe
 } from "lucide-react";
 
 function CopyButton({ text }: { text: string }) {
@@ -175,6 +177,9 @@ export function ApplicationsPage() {
 
   // Confirm modal
   const [confirm, setConfirm] = useState<ConfirmState>(closedConfirm);
+
+  // Portal access modal
+  const [portalTarget, setPortalTarget] = useState<{ id: string; name: string } | null>(null);
 
   const createMutation = useMutation({
     mutationFn: (name: string) => createApplication(name),
@@ -394,6 +399,13 @@ export function ApplicationsPage() {
                         <td className="px-4 py-2.5 text-xs text-text-muted">{formatLocaleDate(app.createdAt)}</td>
                         <td className="px-4 py-2.5">
                           <div className="flex items-center justify-end gap-1">
+                            <button
+                              onClick={() => setPortalTarget({ id: app.id, name: app.name })}
+                              className="p-1.5 rounded-md text-text-muted hover:text-accent hover:bg-accent-soft transition-colors"
+                              title="Portal access"
+                            >
+                              <Globe className="w-3.5 h-3.5" />
+                            </button>
                             <button onClick={() => requestRotateKey(app.id)} className="p-1.5 rounded-md text-text-muted hover:text-accent hover:bg-accent-soft transition-colors" title="Rotate API Key">
                               <KeyRound className="w-3.5 h-3.5" />
                             </button>
@@ -474,6 +486,16 @@ export function ApplicationsPage() {
         confirmLabel={confirm.confirmLabel}
         variant={confirm.variant}
       />
+
+      {/* Portal Access Modal */}
+      {portalTarget && (
+        <PortalAccessModal
+          open={portalTarget !== null}
+          onClose={() => setPortalTarget(null)}
+          appId={portalTarget.id}
+          appName={portalTarget.name}
+        />
+      )}
     </div>
   );
 }

--- a/tests/WebhookEngine.API.Tests/Portal/DashboardPortalControllerTests.cs
+++ b/tests/WebhookEngine.API.Tests/Portal/DashboardPortalControllerTests.cs
@@ -1,0 +1,430 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using WebhookEngine.API.Auth;
+using WebhookEngine.API.Tests.Integration;
+using WebhookEngine.Core.Entities;
+using WebhookEngine.Infrastructure.Data;
+using WebhookEngine.Infrastructure.Services;
+using ApplicationEntity = WebhookEngine.Core.Entities.Application;
+
+namespace WebhookEngine.API.Tests.Portal;
+
+/// <summary>
+/// Dashboard portal-access management controller. Cookie auth + audit-log
+/// secret-leak guarantees + cache-invalidation guarantees + origin-validation
+/// rules all live here. These tests own the load-bearing security contracts
+/// (signing key never echoed on read, never written to audit, cache flushes
+/// immediately on disable).
+/// </summary>
+public class DashboardPortalControllerTests : IClassFixture<TestWebApplicationFactory>
+{
+    private const string DashboardEmail = "admin@portal-tests.local";
+    private const string DashboardPassword = "P@ssw0rd-portal-1";
+
+    private readonly TestWebApplicationFactory _factory;
+
+    public DashboardPortalControllerTests(TestWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task Enable_Generates_SigningKey_And_Returns_It_Once()
+    {
+        await ResetDatabaseAsync();
+        var (appId, _) = await SeedAppAsync(portalEnabled: false);
+        using var client = await CreateAuthenticatedClientAsync();
+
+        var enable = await client.PostAsync(PortalRoute(appId, "enable"), content: null);
+
+        enable.StatusCode.Should().Be(HttpStatusCode.OK);
+        var enableJson = await ParseJsonAsync(enable);
+        var signingKey = enableJson.GetProperty("data").GetProperty("signingKey").GetString();
+        signingKey.Should().NotBeNullOrEmpty();
+        signingKey!.Should().StartWith("whsec_");
+        signingKey.Length.Should().Be(50, "32 random bytes base64-encode to 44 chars + 6-char prefix");
+
+        // Subsequent reads MUST NOT echo the signing key.
+        var read = await client.GetAsync(PortalRoute(appId));
+        read.StatusCode.Should().Be(HttpStatusCode.OK);
+        var readJson = await ParseJsonAsync(read);
+        var data = readJson.GetProperty("data");
+        data.GetProperty("portalEnabled").GetBoolean().Should().BeTrue();
+        data.GetProperty("signingKey").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Fact]
+    public async Task Enable_Twice_Rotates_The_Existing_Key()
+    {
+        await ResetDatabaseAsync();
+        var (appId, _) = await SeedAppAsync(portalEnabled: false);
+        using var client = await CreateAuthenticatedClientAsync();
+
+        var first = await client.PostAsync(PortalRoute(appId, "enable"), content: null);
+        var second = await client.PostAsync(PortalRoute(appId, "enable"), content: null);
+
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+        second.StatusCode.Should().Be(HttpStatusCode.OK);
+        var firstKey = (await ParseJsonAsync(first)).GetProperty("data").GetProperty("signingKey").GetString();
+        var secondKey = (await ParseJsonAsync(second)).GetProperty("data").GetProperty("signingKey").GetString();
+
+        firstKey.Should().NotBe(secondKey, "the second enable rotates rather than no-ops");
+    }
+
+    [Fact]
+    public async Task Rotate_Returns_409_When_Portal_Not_Enabled()
+    {
+        await ResetDatabaseAsync();
+        var (appId, _) = await SeedAppAsync(portalEnabled: false);
+        using var client = await CreateAuthenticatedClientAsync();
+
+        var rotate = await client.PostAsync(PortalRoute(appId, "rotate"), content: null);
+
+        rotate.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        (await ReadErrorCodeAsync(rotate)).Should().Be("PORTAL_NOT_ENABLED");
+    }
+
+    [Fact]
+    public async Task Rotate_Returns_New_Signing_Key_And_Updates_RotatedAt()
+    {
+        await ResetDatabaseAsync();
+        var (appId, _) = await SeedAppAsync(portalEnabled: false);
+        using var client = await CreateAuthenticatedClientAsync();
+
+        var enable = await client.PostAsync(PortalRoute(appId, "enable"), content: null);
+        enable.StatusCode.Should().Be(HttpStatusCode.OK);
+        var enabledKey = (await ParseJsonAsync(enable)).GetProperty("data").GetProperty("signingKey").GetString();
+        DateTime? firstRotatedAt = await ReadRotatedAtAsync(appId);
+        firstRotatedAt.Should().NotBeNull();
+
+        // Move forward enough that the second timestamp is strictly newer even on
+        // coarse-resolution wall clocks.
+        await Task.Delay(20);
+
+        var rotate = await client.PostAsync(PortalRoute(appId, "rotate"), content: null);
+        rotate.StatusCode.Should().Be(HttpStatusCode.OK);
+        var rotatedKey = (await ParseJsonAsync(rotate)).GetProperty("data").GetProperty("signingKey").GetString();
+
+        rotatedKey.Should().NotBe(enabledKey);
+        var secondRotatedAt = await ReadRotatedAtAsync(appId);
+        secondRotatedAt.Should().NotBeNull();
+        secondRotatedAt!.Value.Should().BeAfter(firstRotatedAt!.Value);
+    }
+
+    [Fact]
+    public async Task Disable_Clears_SigningKey_And_Origins()
+    {
+        await ResetDatabaseAsync();
+        var (appId, _) = await SeedAppAsync(
+            portalEnabled: true,
+            allowedOriginsJson: "[\"https://app.acme.com\"]");
+        using var client = await CreateAuthenticatedClientAsync();
+
+        var disable = await client.PostAsync(PortalRoute(appId, "disable"), content: null);
+        disable.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        await ExecuteDbAsync(async db =>
+        {
+            var app = await db.Applications.AsNoTracking().FirstAsync(a => a.Id == appId);
+            app.PortalSigningKey.Should().BeNull();
+            app.AllowedPortalOriginsJson.Should().BeNull();
+            app.PortalRotatedAt.Should().BeNull();
+        });
+    }
+
+    [Fact]
+    public async Task Update_Origins_Persists_Lowercased_Values()
+    {
+        await ResetDatabaseAsync();
+        var (appId, _) = await SeedAppAsync(portalEnabled: true);
+        using var client = await CreateAuthenticatedClientAsync();
+
+        var put = await client.PutAsJsonAsync(PortalRoute(appId, "origins"), new
+        {
+            origins = new[] { "HTTPS://APP.ACME.COM", "https://staging.acme.com" }
+        });
+        put.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await ExecuteDbAsync(async db =>
+        {
+            var app = await db.Applications.AsNoTracking().FirstAsync(a => a.Id == appId);
+            app.AllowedPortalOriginsJson.Should().NotBeNullOrEmpty();
+            var stored = JsonSerializer.Deserialize<string[]>(app.AllowedPortalOriginsJson!);
+            stored.Should().BeEquivalentTo(new[] { "https://app.acme.com", "https://staging.acme.com" });
+        });
+    }
+
+    [Fact]
+    public async Task Update_Origins_Returns_422_On_Wildcard()
+    {
+        await ResetDatabaseAsync();
+        var (appId, _) = await SeedAppAsync(portalEnabled: true);
+        using var client = await CreateAuthenticatedClientAsync();
+
+        var put = await client.PutAsJsonAsync(PortalRoute(appId, "origins"), new
+        {
+            origins = new[] { "https://*.acme.com" }
+        });
+
+        put.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact]
+    public async Task Update_Origins_Returns_409_When_Portal_Not_Enabled()
+    {
+        await ResetDatabaseAsync();
+        var (appId, _) = await SeedAppAsync(portalEnabled: false);
+        using var client = await CreateAuthenticatedClientAsync();
+
+        var put = await client.PutAsJsonAsync(PortalRoute(appId, "origins"), new
+        {
+            origins = new[] { "https://app.acme.com" }
+        });
+
+        put.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        (await ReadErrorCodeAsync(put)).Should().Be("PORTAL_NOT_ENABLED");
+    }
+
+    [Fact]
+    public async Task Audit_Log_Never_Contains_SigningKey()
+    {
+        await ResetDatabaseAsync();
+        var (appId, _) = await SeedAppAsync(portalEnabled: false);
+        using var client = await CreateAuthenticatedClientAsync();
+
+        var enable = await client.PostAsync(PortalRoute(appId, "enable"), content: null);
+        enable.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await ExecuteDbAsync(async db =>
+        {
+            var rows = await db.AuditLogs
+                .AsNoTracking()
+                .Where(l => l.ResourceId == appId && l.Action == "application.portal.enabled")
+                .ToListAsync();
+
+            rows.Should().HaveCount(1);
+            var row = rows[0];
+            (row.BeforeJson ?? string.Empty).Should().NotContain("whsec_",
+                "the audit snapshot must never include the portal signing key");
+            (row.AfterJson ?? string.Empty).Should().NotContain("whsec_",
+                "the audit snapshot must never include the portal signing key");
+        });
+    }
+
+    [Fact]
+    public async Task Get_Portal_Returns_Enabled_State_Without_Key()
+    {
+        await ResetDatabaseAsync();
+        var (appId, _) = await SeedAppAsync(portalEnabled: false);
+        using var client = await CreateAuthenticatedClientAsync();
+
+        var enable = await client.PostAsync(PortalRoute(appId, "enable"), content: null);
+        enable.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var read = await client.GetAsync(PortalRoute(appId));
+        read.StatusCode.Should().Be(HttpStatusCode.OK);
+        var data = (await ParseJsonAsync(read)).GetProperty("data");
+
+        data.GetProperty("portalEnabled").GetBoolean().Should().BeTrue();
+        data.GetProperty("signingKey").ValueKind.Should().Be(JsonValueKind.Null);
+        data.GetProperty("rotatedAt").ValueKind.Should().NotBe(JsonValueKind.Null);
+    }
+
+    [Fact]
+    public async Task Get_Portal_Returns_Disabled_State_For_Fresh_App()
+    {
+        await ResetDatabaseAsync();
+        var (appId, _) = await SeedAppAsync(portalEnabled: false);
+        using var client = await CreateAuthenticatedClientAsync();
+
+        var read = await client.GetAsync(PortalRoute(appId));
+        read.StatusCode.Should().Be(HttpStatusCode.OK);
+        var data = (await ParseJsonAsync(read)).GetProperty("data");
+
+        data.GetProperty("portalEnabled").GetBoolean().Should().BeFalse();
+        data.GetProperty("signingKey").ValueKind.Should().Be(JsonValueKind.Null);
+        data.GetProperty("rotatedAt").ValueKind.Should().Be(JsonValueKind.Null);
+        data.GetProperty("allowedOrigins").GetArrayLength().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Cache_Invalidation_Reflects_Disabled_State_Immediately()
+    {
+        await ResetDatabaseAsync();
+        var (appId, _) = await SeedAppAsync(portalEnabled: false);
+        using var client = await CreateAuthenticatedClientAsync();
+
+        // Enable portal — this is the path the production code uses to populate
+        // the cache miss → DB hit on the first portal request.
+        var enable = await client.PostAsync(PortalRoute(appId, "enable"), content: null);
+        enable.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Warm the cache by directly resolving the lookup. After this, the cache
+        // holds the enabled state for `LookupCacheTtlSeconds` (60s default).
+        await WarmCacheAsync(appId);
+
+        // Disable through the controller — this MUST call PortalLookupCache.InvalidateApplication.
+        var disable = await client.PostAsync(PortalRoute(appId, "disable"), content: null);
+        disable.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        // Re-resolve — the cache must already see the disabled state, NOT the
+        // stale enabled lookup that's still within the TTL window.
+        var lookup = await ResolveCacheAsync(appId);
+        lookup.Should().BeNull("the controller must invalidate the cache on disable, not wait for TTL");
+    }
+
+    [Fact]
+    public async Task Enable_Returns_404_When_Application_Missing()
+    {
+        // Frozen contract: a non-existent appId yields the project's standard
+        // dashboard `NOT_FOUND` envelope (matches DashboardEndpointController).
+        await ResetDatabaseAsync();
+        using var client = await CreateAuthenticatedClientAsync();
+        var unknownAppId = Guid.NewGuid();
+
+        var response = await client.PostAsync(PortalRoute(unknownAppId, "enable"), content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var code = await ReadErrorCodeAsync(response);
+        code.Should().Be("NOT_FOUND");
+    }
+
+    [Fact]
+    public async Task Disable_On_Already_Disabled_Application_Is_Idempotent()
+    {
+        // Frozen contract: disable on an already-disabled app is a no-op success
+        // (204), not a 409. Rationale: the operator's intent ("portal off") is
+        // already satisfied; surfacing 409 would force them to script around a
+        // benign condition. Cache invalidation still fires (defensive) but the
+        // row write is a no-op on already-null columns.
+        await ResetDatabaseAsync();
+        var (appId, _) = await SeedAppAsync(portalEnabled: false);
+        using var client = await CreateAuthenticatedClientAsync();
+
+        var response = await client.PostAsync(PortalRoute(appId, "disable"), content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    // ── Plumbing ──────────────────────────────────────
+
+    private static string PortalRoute(Guid appId, string? action = null)
+    {
+        return action is null
+            ? $"/api/v1/dashboard/applications/{appId}/portal"
+            : $"/api/v1/dashboard/applications/{appId}/portal/{action}";
+    }
+
+    private async Task<HttpClient> CreateAuthenticatedClientAsync()
+    {
+        var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            HandleCookies = true
+        });
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+            if (!await db.DashboardUsers.AnyAsync(u => u.Email == DashboardEmail))
+            {
+                db.DashboardUsers.Add(new DashboardUser
+                {
+                    Email = DashboardEmail,
+                    PasswordHash = PasswordHasher.HashPassword(DashboardPassword),
+                    Role = "admin"
+                });
+                await db.SaveChangesAsync();
+            }
+        }
+
+        var login = await client.PostAsJsonAsync("/api/v1/auth/login", new
+        {
+            email = DashboardEmail,
+            password = DashboardPassword
+        });
+        login.StatusCode.Should().Be(HttpStatusCode.OK);
+        return client;
+    }
+
+    private async Task ResetDatabaseAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+        await db.Database.EnsureDeletedAsync();
+        await db.Database.EnsureCreatedAsync();
+    }
+
+    private async Task<(Guid AppId, ApplicationEntity App)> SeedAppAsync(
+        bool portalEnabled = false,
+        string? allowedOriginsJson = null)
+    {
+        var appId = Guid.NewGuid();
+        var app = new ApplicationEntity
+        {
+            Id = appId,
+            Name = $"app-{appId:N}",
+            ApiKeyPrefix = $"whe_{appId:N}".Substring(0, 12) + "_",
+            ApiKeyHash = "deadbeef",
+            SigningSecret = "whsec_test",
+            PortalSigningKey = portalEnabled ? "whsec_" + Convert.ToBase64String(new byte[32]) : null,
+            AllowedPortalOriginsJson = allowedOriginsJson,
+            PortalRotatedAt = portalEnabled ? DateTime.UtcNow : null,
+            IsActive = true
+        };
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+        db.Applications.Add(app);
+        await db.SaveChangesAsync();
+        return (appId, app);
+    }
+
+    private async Task<DateTime?> ReadRotatedAtAsync(Guid appId)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+        var app = await db.Applications.AsNoTracking().FirstAsync(a => a.Id == appId);
+        return app.PortalRotatedAt;
+    }
+
+    private async Task ExecuteDbAsync(Func<WebhookDbContext, Task> action)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+        await action(db);
+    }
+
+    private async Task WarmCacheAsync(Guid appId)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var cache = scope.ServiceProvider.GetRequiredService<PortalLookupCache>();
+        await cache.GetAsync(appId, CancellationToken.None);
+    }
+
+    private async Task<PortalAppLookup?> ResolveCacheAsync(Guid appId)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var cache = scope.ServiceProvider.GetRequiredService<PortalLookupCache>();
+        return await cache.GetAsync(appId, CancellationToken.None);
+    }
+
+    private static async Task<JsonElement> ParseJsonAsync(HttpResponseMessage response)
+    {
+        var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        return doc.RootElement.Clone();
+    }
+
+    private static async Task<string?> ReadErrorCodeAsync(HttpResponseMessage response)
+    {
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.GetProperty("error").GetProperty("code").GetString();
+    }
+}


### PR DESCRIPTION
## Summary

**Step 5 of the B1 (embeddable customer portal) plan.** Operator-facing surface to enable / rotate / disable portal access per application + manage allowed CORS origins, plus the React UI that drives it. Backend + frontend bundled in one PR — they stand together.

## Backend — `DashboardPortalController`

5 cookie-authed routes under `/api/v1/dashboard/applications/{appId}/portal`:

| Verb + path | Body | 2xx | Errors |
|---|---|---|---|
| `GET /` | — | `{ portalEnabled, allowedOrigins, rotatedAt, signingKey: null }` | `404 NOT_FOUND` |
| `POST /enable` | — | `{ signingKey: "whsec_...", rotatedAt, instructions }` (returned **once**) | `404 NOT_FOUND` |
| `POST /rotate` | — | same shape as enable | `409 PORTAL_NOT_ENABLED`, `404 NOT_FOUND` |
| `POST /disable` | — | `204` | `404 NOT_FOUND` |
| `PUT /origins` | `{ origins: [] }` | `{ allowedOrigins }` (canonicalized) | `422 VALIDATION_ERROR`, `409 PORTAL_NOT_ENABLED`, `404 NOT_FOUND` |

`enable` is idempotent (calling it on an already-enabled app rotates). `disable` is idempotent (no-op success on already-disabled). `PUT /origins` canonicalizes scheme + host to lowercase, strips default ports, rejects wildcards / paths / non-https / >50 entries / >256 chars per entry; empty array clears.

New `Application.PortalRotatedAt` nullable column (migration `AddPortalRotatedAtToApplication`, additive, no default, no index, prod-safe).

### Three load-bearing security guarantees (reviewer-confirmed)

- **Signing-key isolation** — `signingKey` reaches the wire on exactly two paths (enable, rotate); `Get` and audit projections explicitly force null / omit the field; no `JsonSerializer.Serialize(application)` anywhere in the controller.
- **Audit redaction** — every mutating action funnels through a private `BuildAuditSnapshot` helper that reduces `PortalSigningKey` to a `portalEnabled` boolean. Test `Audit_Log_Never_Contains_SigningKey` queries the `audit_logs` table after a real enable and asserts neither snapshot contains `whsec_`.
- **Cache-invalidation ordering** — `UpdateAsync → PortalLookupCache.InvalidateApplication → AuditLogger.LogActionAsync` across all 4 mutating sites. Test `Cache_Invalidation_Reflects_Disabled_State_Immediately` proves the cache flips within milliseconds, not within the 60s TTL.

## Frontend — `<PortalAccessModal />`

New modal opened from `ApplicationsPage`'s row actions (Lucide `Globe` icon). Three sections in a single dialog:

- **Status** — enabled/disabled pill, last-rotated timestamp, `[Rotate signing key]` / `[Disable portal]` buttons (with `ConfirmModal`) when enabled, single `[Enable portal access]` button when disabled.
- **Allowed origins** — chip-list editor with inline add/remove. `[Save changes]` submits to `PUT /origins`; server-side errors surface inline.
- **Embed snippet** — copy-paste-ready Node.js token-mint helper + React render snippet, with a one-line note that `@webhookengine/endpoint-manager` lands in B1 Step 7.

Show-once secret reveal mirrors the existing `apiKey` reveal pattern in `ApplicationsPage` — same `bg-surface-0 + font-mono break-all + CopyButton` shell, palette switched from `accent` to `warning` to signal the higher criticality. TanStack Query key `["portal-access", appId]` invalidated by all four mutations.

## Reviewer findings addressed before this PR opened

A read-only reviewer pass produced **APPROVE WITH CAVEATS**. Two items, both fixed in this same branch:

1. **Error code convention drift** — `DashboardPortalController` originally returned `APPLICATION_NOT_FOUND`; the rest of the dashboard returns `NOT_FOUND`. Renamed all 5 occurrences so the frontend's `parseError` contract stays uniform across dashboard controllers.
2. **Coverage gaps freezing the contract** — added `Enable_Returns_404_When_Application_Missing` (proves the `NOT_FOUND` envelope) and `Disable_On_Already_Disabled_Application_Is_Idempotent` (freezes the chosen 204 semantic — operator's intent "portal off" is already satisfied; surfacing 409 would force callers to script around a benign condition).

## Outstanding follow-ups intentionally NOT in this PR

- **(low)** UX guard for unsaved origins changes when operator clicks Disable mid-edit (frontend agent flagged).
- **(low)** "I've saved it" button on the secret-reveal banner has no confirmation step (frontend agent flagged) — deliberate single-click for now; add a checkbox gate if user feedback says it's too easy to dismiss.
- **(low)** Concern A from Step 4 (capability check after FluentValidation in `PortalEndpointsController`) — not relevant to this surface; tracked for Step 4 follow-up.
- **(low)** Per-app rate-limit partition for portal write routes — public-launch nice-to-have.

## Test count

- `WebhookEngine.API.Tests`: **93 → 107** (+14: 12 contractual + 2 reviewer follow-up).
- Full solution: **238 → 252**, all passing.

## Build

```
Build succeeded.
    0 Warning(s)
    0 Error(s)
```

Frontend `bun run lint` / `typecheck` / `build` all clean (chunk-size warning is pre-existing — CodeMirror / Recharts).

## Test plan

- [x] `dotnet build WebhookEngine.sln` clean
- [x] `dotnet test WebhookEngine.sln` — Core 34, API 107, Worker 46, Infrastructure 65 (real Postgres via Testcontainers — `AddPortalRotatedAtToApplication` migration auto-applies cleanly)
- [x] Frontend `bun run lint` / `typecheck` / `build` clean
- [ ] CI green