### PR TITLE
chore(release): prep v0.2.0 — embeddable customer portal (B1 Steps 1-5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ docs/*
 !docs/ROADMAP.md
 !docs/PRD.md
 !docs/PERFORMANCE.md
+!docs/PORTAL.md
 !docs/adr/
 docs/adr/*
 !docs/adr/*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-05-10
+
+The first minor release. Adds an embeddable customer-facing portal: SaaS operators can now hand customers a self-service `<EndpointManager />` React component that runs against a narrowed `/api/v1/portal/*` API surface, scoped per-application via short-lived HS256 JWTs minted by the host SaaS backend. The engine never mints these tokens — it only verifies them — and the per-app signing key is generated, rotated, and revoked from the operator dashboard. No breaking changes to the existing v1 surface; the `v1` route prefix and Standard Webhooks signature header names are preserved.
+
+### Added
+- **Embeddable customer portal — engine half** (B1 Steps 2-4). New `Application.PortalSigningKey` (HS256 secret, 64-char varchar) and `Application.AllowedPortalOriginsJson` (JSONB) columns; new `PortalTokenAuthMiddleware` validates short-lived HS256 JWTs (algorithm-pinned, 15-minute lifetime cap, capability-scoped via `endpoints:read|write|test` and `attempts:read`); new `PortalCorsMiddleware` does per-application dynamic CORS with RFC 6454-compliant ordinal-case-insensitive origin matching; new `/api/v1/portal/*` route group exposes a narrowed CRUD-and-test surface that silently strips admin-only fields (`transformExpression`, `allowedIpsJson`) on writes and never returns the signing key.
+- **Embeddable customer portal — operator dashboard** (B1 Step 5). New `DashboardPortalController` (`/api/v1/dashboard/applications/{appId}/portal/...`) with 5 cookie-authed actions (read, enable, rotate, disable, update-origins). New `<PortalAccessModal />` React component opened from the Applications page row actions: enable/rotate/disable controls with show-once secret reveal, chip-list editor for allowed CORS origins, copy-paste embed snippet for the host SaaS. Audit log records every mutating action with `PortalSigningKey` redacted to a `portalEnabled` boolean — the literal secret never enters the snapshot. Cache invalidation via `PortalLookupCache.InvalidateApplication(appId)` after every mutating write so rotations take effect within milliseconds rather than within the 60-second cache TTL.
+- **`Application.PortalRotatedAt`** column for surfacing "last rotated at" in the dashboard.
+- **`MessageRepository.ListAttemptsByEndpointAsync` / `CountAttemptsByEndpointAsync`** for the portal's per-endpoint attempt history feed; uses the existing `idx_attempts_endpoint_status` index, no new migration.
+- **Bun workspaces** (B1 Step 1). Root `package.json` declares `["src/dashboard", "packages/*"]` so the upcoming `@webhookengine/endpoint-manager` package can land at `packages/endpoint-manager/` without a second migration. Single `bun.lock` at the workspace root; Dockerfile and CI workflow updated. No source changes.
+
+### Changed
+- **`AuditLogsController` no longer bypasses the repository pattern.** New `AuditLogRepository.ListAsync(...)` carries the filter chain and pagination; the controller keeps the JSON hydration since that is HTTP response-shaping, not persistence. Behavior unchanged.
+- **`tailwindcss` and `@tailwindcss/vite` 4.2.4 → 4.3.0**, with the transitive `@tailwindcss/node` and `@tailwindcss/oxide` platform binaries.
+- **Dependabot npm PRs auto-sync `bun.lock`** via a new `pull_request_target`-triggered workflow gated on `github.actor == 'dependabot[bot]'`. Eliminates the manual `bun install + commit + push` that every minor / patch frontend bump previously required.
+- **Documentation drift sync.** `CLAUDE.md` and `README.md` stack lines updated to match `src/dashboard/package.json` (TypeScript 6 / Vite 8 / TanStack Query 5; previous wording said TypeScript 5.9 / Vite 7). ADR-003 (payload transformation) flipped from Proposed to Accepted with an Implementation section recording the three-phase rollout that shipped in v0.1.4.
+
+### Security
+- **HS256-only algorithm allowlist** on portal JWTs. `ValidAlgorithms = [HmacSha256]` is enforced via `Microsoft.IdentityModel.Tokens` 8.17.0; `alg=none` and `alg=HS384`/`HS512` tokens are rejected with `PORTAL_AUTH_INVALID_SIGNATURE`. Catch-ladder absorbs algorithm-rejection without echoing the rejected algorithm name.
+- **Per-app dynamic CORS** with explicit allowed-origins enumeration (no wildcards); `PortalCorsMiddleware` echoes the validated request `Origin` (never `*`) and is RFC 6454-compliant case-insensitive on host comparisons.
+- **App-scope isolation across the portal surface.** Every portal route reads `AppId` from the JWT, never from query/body/route. Cross-tenant probes return `404 PORTAL_NOT_FOUND` (not 403) so the response shape doesn't leak the existence of cross-tenant resources.
+- **`SecretOverride` entropy floor on portal writes.** The portal `Create`/`Update` endpoint validators require the `whsec_` prefix and a 32-128 char range so a customer cannot silently downgrade their HMAC secret to `password123`.
+- **Audit redaction** — `DashboardPortalController` writes audit-log snapshots with `PortalSigningKey` reduced to a boolean `portalEnabled` flag; the literal secret never enters `before_json` / `after_json`. Verified by a load-bearing negative test that scans the column for `whsec_` after a real enable call.
+
+### Fixed
+- (Nothing user-visible. Reviewer follow-ups for HS256 lifetime semantics, CORS origin case-sensitivity, and a missing-`nbf` guard landed alongside the originating PRs and have no user-facing change.)
+
 ## [0.1.6] - 2026-05-08
 
 A feature-and-polish cut covering eight new capabilities (per-resource overrides, IP allowlist, audit log, endpoint test webhook, SignalR endpoint health, validate-time URL guard), three rounds of dashboard polish (a11y, UX, TanStack Query data layer), three reviewer-finding fixes (transient DNS retry, cascade delete, polling debounce), and a backend correctness pass on the IP allowlist matcher, application rate-limiter sweep, and endpoint health tracker. No breaking changes — the `v1` route prefix and Standard Webhooks signature surface are preserved. Test count moved from 211 to 215.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Self-hosted webhook delivery platform with reliable at-least-once delivery, expo
 - **Real-time dashboard** -- React SPA with live delivery feed and circuit-state changes via SignalR; data layer on TanStack Query
 - **Single process** -- API + background workers + dashboard served from one ASP.NET Core host
 - **Data retention** -- automatic cleanup (delivered: 30 days, dead-letter: 90 days; per-app overrides supported)
+- **Embeddable customer portal** -- ship a `<EndpointManager />` React component into your own settings UI; per-application HS256 JWT auth minted by your backend, RFC 6454 dynamic CORS, capability scoping (`endpoints:read|write|test`, `attempts:read`); operator-managed signing key + allowed origins from the dashboard
 
 ## Tech Stack
 
@@ -110,6 +111,7 @@ Dashboard dev server runs on `http://localhost:5173` with API proxy to `localhos
 
 - [Getting Started](docs/GETTING-STARTED.md) — from zero to first webhook
 - [Self-Hosting Guide](docs/SELF-HOSTING.md) — production deployment and operations
+- [Customer Portal Guide](docs/PORTAL.md) — embeddable portal: operator setup, JWT minting, security model
 - [Release Guide](docs/RELEASE.md) — Docker Hub and NuGet publishing flow
 - [Roadmap](docs/ROADMAP.md) — current phase status and upcoming priorities
 - [PRD](docs/PRD.md) — product scope, goals, and requirement definitions

--- a/docs/PORTAL.md
+++ b/docs/PORTAL.md
@@ -1,0 +1,283 @@
+# Customer Portal Guide
+
+This guide covers the embeddable customer portal shipped in v0.2.0. It is written for two audiences: **SaaS operators** who run WebhookEngine and want to give their customers a self-service endpoint-management UI, and **host SaaS backend engineers** who need to mint portal JWTs and wire up the React component.
+
+---
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Architecture](#2-architecture)
+3. [Operator Setup](#3-operator-setup)
+4. [Host SaaS Integration](#4-host-sas-integration)
+5. [Component Usage (coming soon)](#5-component-usage-coming-soon)
+6. [Security Model](#6-security-model)
+7. [Configuration Reference](#7-configuration-reference)
+8. [Limits](#8-limits)
+
+---
+
+## 1. Overview
+
+The customer portal lets SaaS operators embed a self-service endpoint-management widget directly into their own product's settings UI. Your customers can create, update, test, and delete their webhook endpoints and browse delivery attempt history — without ever touching the WebhookEngine operator dashboard.
+
+**Who it is for:** any SaaS product built on top of WebhookEngine that wants to delegate endpoint management to its end users (tenants / customers). A typical deployment has one WebhookEngine `Application` per customer, and the portal scopes all operations to that application automatically.
+
+**What the engine provides:**
+
+- A narrowed `/api/v1/portal/*` API surface — CRUD on endpoints and event types, endpoint test-fire, attempt history — with admin-only fields (`transformExpression`, `allowedIpsJson`) stripped from reads and writes.
+- Per-application HS256 JWT verification middleware — the engine validates tokens but never mints them.
+- Per-application dynamic CORS — only origins explicitly approved by the operator are echoed back.
+- Full audit logging of every portal mutating action, with the signing key redacted.
+
+**What you build:**
+
+- A short-lived JWT minted by your backend and passed to the frontend component.
+- A settings page in your product that renders the `<EndpointManager />` component (shipping in a follow-up tag — see [Section 5](#5-component-usage-coming-soon)).
+
+---
+
+## 2. Architecture
+
+```
+Your SaaS Backend                     WebhookEngine
+─────────────────                     ─────────────────────────────────────
+  Customer settings page
+         │
+         │  1. Customer loads settings page
+         │  2. Frontend requests a portal token
+         ▼
+  POST /internal/portal-token         (your endpoint — not part of WebhookEngine)
+  ├── verify customer session
+  ├── look up their WebhookEngine appId
+  ├── sign HS256 JWT with PortalSigningKey
+  └── return { token, expiresAt }
+         │
+         │  3. Frontend receives token
+         ▼
+  <EndpointManager
+    apiBase="https://webhooks.yourproduct.com"
+    token={portalToken}
+    appId={appId}
+  />
+         │
+         │  4. Component calls portal API
+         │  Bearer: <token>
+         ▼
+  GET /api/v1/portal/endpoints        PortalTokenAuthMiddleware
+  POST /api/v1/portal/endpoints       ├── validate HS256 signature
+  PUT /api/v1/portal/endpoints/{id}   ├── verify algorithm = HS256
+  DELETE /api/v1/portal/endpoints/{id}├── check lifetime ≤ 15 min cap
+  POST /api/v1/portal/endpoints/{id}/test
+  GET /api/v1/portal/endpoints/{id}/attempts
+                                      ├── extract appId + capabilities from claims
+                                      └── scope all queries to that appId
+```
+
+The engine never talks back to your SaaS backend. JWT validation is local — the engine reads the `PortalSigningKey` from the database for the `appId` embedded in the token and verifies the signature in-process.
+
+---
+
+## 3. Operator Setup
+
+### 3.1 Enable the portal for an application
+
+1. Open the WebhookEngine operator dashboard.
+2. Navigate to **Applications** and find the application that maps to your customer.
+3. Click the row action menu and choose **Portal access**.
+4. Click **Enable portal**. The dashboard generates a random 64-character signing key and displays it **once**.
+5. Copy the key immediately — it is shown in plaintext exactly once. After you close the modal, the dashboard only shows a masked indicator that the portal is enabled.
+6. Store the key as a secret in your SaaS backend (e.g., an environment variable or secrets manager entry keyed to the customer's app ID).
+7. Add the allowed CORS origins for your SaaS frontend (e.g., `https://app.yourproduct.com`). Up to 50 origins per application; max 256 characters per origin.
+
+### 3.2 Rotate the signing key
+
+1. Open **Portal access** for the application.
+2. Click **Rotate key**. A new key is generated and shown once.
+3. Update the key in your SaaS backend before the old tokens expire. The cache invalidation is immediate (within milliseconds) so new tokens signed with the old key will fail as soon as you rotate.
+
+### 3.3 Disable the portal
+
+1. Open **Portal access** for the application.
+2. Click **Disable portal**. The signing key is cleared from the database. All in-flight tokens become invalid immediately.
+
+### 3.4 Update allowed CORS origins
+
+In the **Portal access** modal, edit the origin chip list and click **Save**. Changes take effect immediately.
+
+---
+
+## 4. Host SaaS Integration
+
+### 4.1 JWT minting
+
+Your backend is responsible for minting short-lived HS256 JWTs. The engine validates them but never generates them.
+
+**Node.js example using `jose`:**
+
+```js
+import { SignJWT } from 'jose'
+import { TextEncoder } from 'util'
+
+const PORTAL_SIGNING_KEY = process.env.WEBHOOK_ENGINE_PORTAL_KEY // stored per appId
+const APP_ID = 'app_abc123' // the WebhookEngine application ID for this customer
+
+async function mintPortalToken(capabilities = ['endpoints:read', 'endpoints:write', 'endpoints:test', 'attempts:read']) {
+  const secret = new TextEncoder().encode(PORTAL_SIGNING_KEY)
+  const now = Math.floor(Date.now() / 1000)
+
+  return new SignJWT({
+    sub: APP_ID,
+    appId: APP_ID,
+    cap: capabilities,
+  })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt(now)
+    .setNotBefore(now)
+    .setExpirationTime(now + 10 * 60) // 10 minutes; engine caps at 15 min
+    .sign(secret)
+}
+```
+
+**Required claims:**
+
+| Claim | Type | Description |
+|---|---|---|
+| `sub` | string | Must equal the WebhookEngine `appId` |
+| `appId` | string | Must equal the WebhookEngine `appId` (duplicate of `sub` for explicitness) |
+| `cap` | string[] | One or more capabilities (see below) |
+| `iat` | number | Issued-at (Unix epoch seconds) |
+| `nbf` | number | Not-before — set to the same value as `iat` |
+| `exp` | number | Expiry — must not exceed `iat + MaxLifetimeMinutes * 60` (default 15 min) |
+
+The algorithm header must be `HS256`. Tokens with `alg: none`, `HS384`, or `HS512` are rejected.
+
+### 4.2 Capability list
+
+Capabilities are additive. Include only the ones your customer's tier entitles them to.
+
+| Capability | Unlocks |
+|---|---|
+| `endpoints:read` | `GET /api/v1/portal/endpoints`, `GET /api/v1/portal/endpoints/{id}` |
+| `endpoints:write` | `POST /api/v1/portal/endpoints`, `PUT /api/v1/portal/endpoints/{id}`, `DELETE /api/v1/portal/endpoints/{id}` |
+| `endpoints:test` | `POST /api/v1/portal/endpoints/{id}/test` |
+| `attempts:read` | `GET /api/v1/portal/endpoints/{id}/attempts` |
+
+Attempting a route without the matching capability returns `403 PORTAL_CAPABILITY_MISSING`.
+
+### 4.3 Token lifetime guidance
+
+Use the shortest lifetime that gives a good user experience:
+
+- **5 minutes** — tight, suitable for high-security contexts. Requires a token refresh mechanism in the component.
+- **10 minutes** — good default for most SaaS settings pages.
+- **15 minutes** — the engine-enforced maximum (`MaxLifetimeMinutes`). Tokens with a longer `exp` are rejected with `PORTAL_AUTH_LIFETIME_EXCEEDED`.
+
+The engine applies a configurable clock skew tolerance (`ClockSkewSeconds`, default 30 s) when checking `nbf` and `exp`.
+
+### 4.4 Portal API routes
+
+All portal routes are under `/api/v1/portal/` and require `Authorization: Bearer <token>`. The `appId` is read exclusively from the JWT — query/body/route parameters cannot override it.
+
+| Method | Path | Capability | Description |
+|---|---|---|---|
+| `GET` | `/api/v1/portal/endpoints` | `endpoints:read` | List endpoints for the app |
+| `POST` | `/api/v1/portal/endpoints` | `endpoints:write` | Create endpoint (admin-only fields stripped) |
+| `GET` | `/api/v1/portal/endpoints/{id}` | `endpoints:read` | Get endpoint |
+| `PUT` | `/api/v1/portal/endpoints/{id}` | `endpoints:write` | Update endpoint (admin-only fields stripped) |
+| `DELETE` | `/api/v1/portal/endpoints/{id}` | `endpoints:write` | Delete endpoint |
+| `POST` | `/api/v1/portal/endpoints/{id}/test` | `endpoints:test` | Send a signed test delivery |
+| `GET` | `/api/v1/portal/endpoints/{id}/attempts` | `attempts:read` | List attempt history (paginated) |
+
+Admin-only fields stripped on portal writes and reads: `transformExpression`, `transformEnabled`, `transformValidatedAt`, `allowedIpsJson`.
+
+---
+
+## 5. Component Usage (coming soon)
+
+The `@webhookengine/endpoint-manager` React package is tracked under B1 Step 7 of the roadmap and will ship in a follow-up `portal-v0.1.0` tag after v0.2.0. It is not bundled in the engine release.
+
+When it ships, usage will look roughly like:
+
+```tsx
+import { EndpointManager } from '@webhookengine/endpoint-manager'
+
+<EndpointManager
+  apiBase="https://webhooks.yourproduct.com"
+  token={portalToken}
+/>
+```
+
+Watch the [GitHub roadmap](https://github.com/voyvodka/webhook-engine/blob/main/docs/ROADMAP.md) for the `portal-v0.1.0` tag.
+
+---
+
+## 6. Security Model
+
+### JWT signing key per application
+
+Each application has an independent 64-character HS256 signing key stored in the `portal_signing_key` column (varchar 64). Rotating or disabling one application's key has no effect on others. The key never appears in API responses, audit log `before_json` / `after_json`, or log output — only a `portalEnabled: true/false` boolean is written to the audit record.
+
+### Algorithm allowlist
+
+`PortalTokenAuthMiddleware` sets `ValidAlgorithms = ["HS256"]` via `Microsoft.IdentityModel.Tokens`. Tokens with any other algorithm (including `alg: none`, `HS384`, `HS512`, any RS/EC variant) are rejected with error code `PORTAL_AUTH_INVALID_SIGNATURE`. The catch-ladder does not echo the rejected algorithm name in the response body.
+
+### Lifetime cap
+
+The `exp` claim is validated against `iat + MaxLifetimeMinutes * 60` (default 15 minutes). Tokens with a longer lifetime are rejected with `PORTAL_AUTH_LIFETIME_EXCEEDED` regardless of the `exp` value the minting side set. This cap is not adjustable by the token itself — it is a server-side policy.
+
+### Dynamic CORS (RFC 6454)
+
+`PortalCorsMiddleware` reads the request `Origin` header, checks it against the application's `AllowedPortalOriginsJson` array using ordinal case-insensitive comparison on the scheme+host+port triple (RFC 6454 compliant), and echoes the validated origin in `Access-Control-Allow-Origin`. Wildcards (`*`) are never emitted. Origins not in the allowlist receive no CORS headers and the preflight returns `403`.
+
+### App-scope isolation
+
+Every portal route extracts `appId` from the validated JWT claims. Route parameters, query strings, and request bodies cannot override or supplement the app scope. A request for an endpoint that belongs to a different application returns `404 PORTAL_NOT_FOUND` — not `403` — so the response shape does not leak the existence of cross-tenant resources.
+
+### Secret entropy floor
+
+The portal `Create` and `Update` endpoint validators require:
+
+- The signing secret to carry the `whsec_` prefix (matching the Standard Webhooks convention).
+- The base64-encoded payload after the prefix to be 32–128 characters.
+
+This prevents customers from silently downgrading their HMAC secret to a short or trivially guessable value.
+
+### Signing key rotation flow
+
+1. Operator clicks **Rotate key** in the dashboard.
+2. `DashboardPortalController` generates a new key, writes it, and calls `PortalLookupCache.InvalidateApplication(appId)`.
+3. The in-memory cache entry is evicted immediately (not waiting for the 60-second TTL).
+4. All subsequent portal requests for this app load the new key from the database.
+5. Tokens signed with the old key are now invalid. In-flight requests that started before the rotation complete or fail based on whether their token was validated before the cache eviction.
+
+To avoid dropped requests during a rotation: mint a new token with the new key before rotating, then rotate. The component's token refresh cycle should be shorter than the token lifetime.
+
+---
+
+## 7. Configuration Reference
+
+The portal authentication options are under the `WebhookEngine:PortalAuth` configuration section.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `WebhookEngine:PortalAuth:MaxLifetimeMinutes` | int | `15` | Hard cap on portal JWT lifetime. Tokens whose `exp - iat` exceeds this value are rejected, regardless of what the minting side signed. |
+| `WebhookEngine:PortalAuth:ClockSkewSeconds` | int | `30` | Tolerance applied when validating `nbf` and `exp`. Accommodates minor clock drift between the token minter and the engine host. |
+| `WebhookEngine:PortalAuth:LookupCacheTtlSeconds` | int | `60` | How long the engine caches a resolved `(appId → signingKey + allowedOrigins)` pair in memory. A rotation calls `InvalidateApplication` to evict immediately, so this TTL only matters for cache warming after a cold start or eviction. |
+
+Environment variable equivalents use double-underscore notation: `WebhookEngine__PortalAuth__MaxLifetimeMinutes=10`.
+
+---
+
+## 8. Limits
+
+| Limit | Value |
+|---|---|
+| Max allowed CORS origins per application | 50 |
+| Max length per origin string | 256 characters |
+| Portal signing key length | 64 characters (fixed, generated by the engine) |
+| JWT lifetime cap | 15 minutes (configurable down via `MaxLifetimeMinutes`) |
+| Capability set (v0.2) | `endpoints:read`, `endpoints:write`, `endpoints:test`, `attempts:read` — fixed; no custom capabilities |
+| Attempt history page size | 50 per page (same as the rest of the message/attempt API) |
+
+The capability list is fixed for v0.2. Custom capability scopes and per-endpoint capability restrictions are unscheduled.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,11 +1,10 @@
-# Roadmap
 # WebhookEngine — Strategic Roadmap
 
-**Last Updated:** 2026-05-08
+**Last Updated:** 2026-05-10
 **Status:** Active — Phase 2 (Traction & Feedback)
-**Latest release:** v0.1.6 (2026-05-08) — feature & polish cut covering per-resource overrides, IP allowlist, audit log, dashboard a11y, and TanStack Query data layer.
+**Latest release:** v0.2.0 (2026-05-10) — first minor release; embeddable customer portal (B1 Steps 1-5): portal engine surface (`/api/v1/portal/*`), HS256 JWT middleware, per-app dynamic CORS, operator dashboard controls, and `<PortalAccessModal />` UI.
 
-> **Note:** Phase 1 is complete (launch posts and the engineering blog post remain deferred). Phase 2 core tasks (2.2, 2.3, 2.4, **2.5 payload transformation across all three rollout phases**, 2.7 application layer cleanup) are done. Phase 2 also gained eight follow-on features in v0.1.6 — endpoint test webhook, validate-time URL guard, per-resource overrides for retention / idempotency / rate limit, per-endpoint IP allowlist, audit log, SignalR endpoint health, and a TanStack Query dashboard data layer. Remaining Phase 2 items (TypeScript SDK gated on demand signal, comparison / best-practice blog posts) are planned.
+> **Note:** Phase 1 is complete (launch posts and the engineering blog post remain deferred). Phase 2 core tasks (2.2, 2.3, 2.4, **2.5 payload transformation across all three rollout phases**, 2.7 application layer cleanup) are done. v0.1.6 added eight follow-on features (endpoint test webhook, validate-time URL guard, per-resource overrides, IP allowlist, audit log, SignalR endpoint health, TanStack Query data layer). v0.2.0 adds the embeddable customer portal (engine + dashboard half). The `@webhookengine/endpoint-manager` npm package (B1 Step 7 / Step 11) lands in a follow-up `portal-v0.1.0` tag. Remaining Phase 2 items (TypeScript SDK gated on demand signal, comparison / best-practice blog posts) are planned.
 
 ---
 
@@ -136,6 +135,25 @@ Eight new features, three rounds of dashboard polish, three reviewer-finding fix
 | DPR-1 | Modal a11y (`role="dialog"` + ARIA + focus trap), reconnect-safe SignalR cache, awaited refetches, skeleton loaders | done |
 | DPR-2 | Shared `StatusBadge` / `inputClasses` / editor theme, lazy-loaded CodeMirror, `parseError` field-error routing | done |
 | DPR-3 | Modal `dvh` sizing, mobile filter grid, payload field error, SignalR Live / Offline header badge, URL field error wiring | done |
+
+---
+
+## v0.2.0 — Embeddable Customer Portal (2026-05-10)
+
+First minor release. The engine half and operator dashboard half of the embeddable customer portal land here. The `@webhookengine/endpoint-manager` React package lands in a follow-up `portal-v0.1.0` tag.
+
+| # | Task | Status |
+|---|------|--------|
+| B1 Step 1 | Bun workspaces — root `package.json` + single `bun.lock` + Dockerfile/CI plumbing | done |
+| B1 Step 2 | `Application.PortalSigningKey` + `AllowedPortalOriginsJson` migration | done |
+| B1 Step 3 | `PortalTokenAuthMiddleware` (HS256 algorithm-pinned, 15-min cap, capability-scoped) + `PortalCorsMiddleware` (RFC 6454 ordinal-case-insensitive) + `PortalLookupCache` + `PortalCapability` enum | done |
+| B1 Step 4 | `PortalEndpointsController` — 9 narrowed `/api/v1/portal/*` routes; `MessageRepository.ListAttemptsByEndpointAsync` / `CountAttemptsByEndpointAsync` | done |
+| B1 Step 5 | `DashboardPortalController` (5 routes) + `<PortalAccessModal />` + `Application.PortalRotatedAt` migration; audit log redacts signing key to boolean | done |
+| — | `AuditLogRepository` extract — `AuditLogsController` no longer bypasses repository pattern | done |
+| — | Tailwind 4.2.4 → 4.3.0 | done |
+| — | Dependabot npm `bun.lock` auto-sync workflow | done |
+| — | Documentation drift sync (ADR-003 Accepted, stack version lines) | done |
+| B1 Step 7 | `@webhookengine/endpoint-manager` npm package | planned (`portal-v0.1.0` tag) |
 
 ---
 
@@ -298,17 +316,3 @@ All: PostgreSQL-only, Docker Compose, MIT licensed, .NET native.
 - Kubernetes Helm chart
 - Embeddable endpoint management portal
 - A/B testing for notification content
-- Analytics (delivery rate, open rate, click rate)
-- Svix-compatible API (easy migration)
-
----
-
-## Metrics Dashboard
-
-| Metric | Phase 1 | Phase 2 | Phase 3 | Phase 4 |
-|--------|---------|---------|---------|---------|
-| GitHub stars | 50+ | 200+ | 1000+ | 1500+ |
-| Docker pulls | 100+ | 500+ | 5000+ | 10000+ |
-| NuGet downloads | 50+ | 500+ | 2000+ | 5000+ |
-| Contributors | 1 | 3+ | 10+ | 15+ |
-| Blog posts | 1 | 3+ | 5+ | 7+ |

--- a/src/WebhookEngine.Sdk/WebhookEngine.Sdk.csproj
+++ b/src/WebhookEngine.Sdk/WebhookEngine.Sdk.csproj
@@ -8,7 +8,7 @@
 
     <!-- NuGet package metadata -->
     <PackageId>WebhookEngine.Sdk</PackageId>
-    <Version>0.1.6</Version>
+    <Version>0.2.0</Version>
     <Authors>WebhookEngine</Authors>
     <Description>.NET SDK for WebhookEngine — self-hosted webhook delivery platform. Send webhooks, manage endpoints and event types, retry failed deliveries.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/dashboard/package.json
+++ b/src/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webhookengine-dashboard",
   "private": true,
-  "version": "0.1.6",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

The first **minor** release. Adds the engine + dashboard halves of the embeddable customer-facing portal (B1 Steps 1-5). The npm package (`@webhookengine/endpoint-manager`) is a separate `portal-v0.1.0` tag tracked under B1 Step 11 — **not** bundled here. **No breaking changes** to the existing `v1` surface; the route prefix and Standard Webhooks signature header names are preserved.

## What ships in v0.2.0

This release bundles 9 PRs since v0.1.6:

| PR | Title |
|---|---|
| #77 | docs: stack version sync + ADR-003 Accepted |
| #78 | chore(deps): tailwindcss 4.2.4 → 4.3.0 |
| #79 | refactor: AuditLogRepository extract |
| #80 | ci: Dependabot bun.lock auto-sync workflow |
| #81 | chore: Bun workspaces (B1 Step 1) |
| #82 | feat: `Application.PortalSigningKey` + `AllowedPortalOriginsJson` migration (B1 Step 2) |
| #83 | feat: `PortalTokenAuthMiddleware` + HS256 JWT + `PortalCorsMiddleware` (B1 Step 3) |
| #84 | feat: `PortalEndpointsController` with 9 narrow routes (B1 Step 4) |
| #85 | feat: `DashboardPortalController` + `<PortalAccessModal />` UI + `PortalRotatedAt` migration (B1 Step 5) |

The full user-facing narrative lives in `CHANGELOG.md` under `[0.2.0]`.

## What lands in this PR (release prep — no behavior change)

- **Version bumps:** `WebhookEngine.Sdk.csproj` `<Version>` 0.1.6 → 0.2.0; `src/dashboard/package.json` 0.1.6 → 0.2.0. The API/Core/Infrastructure/Worker projects carry no `<Version>` element by design (consistent with v0.1.5 and v0.1.6 — they pick up the assembly version implicitly).
- **`CHANGELOG.md`** — new `[0.2.0] - 2026-05-10` section above `[0.1.6]`, grouped `Added` / `Changed` / `Security` / `Fixed`.
- **`docs/PORTAL.md`** — NEW operator + integrator guide, 8 sections: Overview, Architecture, Operator Setup, Host SaaS Integration (with Node + jose JWT mint snippet), Component Usage (placeholder pointing to `portal-v0.1.0`), Security Model, Configuration Reference (`PortalAuth` options), Limits.
- **`README.md`** — new bullet in the Features list pointing at the portal; `docs/PORTAL.md` added to the Documentation section.
- **`docs/ROADMAP.md`** — header updated to v0.2.0, new v0.2.0 release table inserted, Phase 2 note updated to reflect the portal landing in this release with the npm package as a follow-up tag.
- **`.gitignore`** — added the `docs/PORTAL.md` whitelist (consistent with how `docs/PRD.md` was added in v0.1.4).

## Pre-release verification (all passing locally)

- [x] `dotnet build WebhookEngine.sln --configuration Release` → 0 warnings, 0 errors
- [x] `dotnet test WebhookEngine.sln --configuration Release` → Core 34, API 107, Worker 46, Infrastructure 65 (**252 total**, all green)
- [x] `cd src/dashboard && bun run lint && bun run typecheck && bun run build` → clean (chunk-size warning on codemirror/charts/vendor is pre-existing)
- [x] `dotnet pack src/WebhookEngine.Sdk/WebhookEngine.Sdk.csproj -c Release` → `WebhookEngine.Sdk.0.2.0.nupkg` produced cleanly

## After merge

I'll push the `v0.2.0` tag from `main`. `.github/workflows/release.yml` then publishes:
- Docker Hub `voyvodka/webhook-engine:0.2.0` (multi-arch `linux/amd64,linux/arm64`) + `:latest`
- NuGet `WebhookEngine.Sdk 0.2.0`
- GitHub Release with the CHANGELOG narrative

## Test plan

- [ ] CI green on this prep PR
- [ ] Tag push triggers release workflow
- [ ] Docker Hub multi-arch + NuGet published
- [ ] GitHub Release created from the tag