### PR TITLE
feat(npm): EndpointList + EndpointEditor + portal client + Tailwind 4 compile + vitest (B1 Step 8)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,12 +10,21 @@
       "version": "0.0.0",
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@tailwindcss/cli": "^4.3.0",
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^4.5.2",
         "eslint": "10.3.0",
+        "happy-dom": "^17.5.3",
+        "tailwindcss": "^4.3.0",
         "tsup": "^8.5.0",
         "typescript": "6.0.3",
         "typescript-eslint": "8.59.2",
+        "vite": "^6.3.5",
+        "vitest": "^3.2.1",
       },
       "peerDependencies": {
         "react": "^19.0.0",
@@ -59,6 +68,8 @@
     },
   },
   "packages": {
+    "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
+
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/compat-data": ["@babel/compat-data@7.29.3", "", {}, "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg=="],
@@ -75,6 +86,8 @@
 
     "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.6", "", { "dependencies": { "@babel/helper-module-imports": "^7.28.6", "@babel/helper-validator-identifier": "^7.28.5", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA=="],
 
+    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.28.6", "", {}, "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug=="],
+
     "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
@@ -84,6 +97,10 @@
     "@babel/helpers": ["@babel/helpers@7.29.2", "", { "dependencies": { "@babel/template": "^7.28.6", "@babel/types": "^7.29.0" } }, "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw=="],
 
     "@babel/parser": ["@babel/parser@7.29.3", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA=="],
+
+    "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw=="],
+
+    "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
@@ -221,6 +238,34 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.128.0", "", {}, "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ=="],
 
+    "@parcel/watcher": ["@parcel/watcher@2.5.6", "", { "dependencies": { "detect-libc": "^2.0.3", "is-glob": "^4.0.3", "node-addon-api": "^7.0.0", "picomatch": "^4.0.3" }, "optionalDependencies": { "@parcel/watcher-android-arm64": "2.5.6", "@parcel/watcher-darwin-arm64": "2.5.6", "@parcel/watcher-darwin-x64": "2.5.6", "@parcel/watcher-freebsd-x64": "2.5.6", "@parcel/watcher-linux-arm-glibc": "2.5.6", "@parcel/watcher-linux-arm-musl": "2.5.6", "@parcel/watcher-linux-arm64-glibc": "2.5.6", "@parcel/watcher-linux-arm64-musl": "2.5.6", "@parcel/watcher-linux-x64-glibc": "2.5.6", "@parcel/watcher-linux-x64-musl": "2.5.6", "@parcel/watcher-win32-arm64": "2.5.6", "@parcel/watcher-win32-ia32": "2.5.6", "@parcel/watcher-win32-x64": "2.5.6" } }, "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ=="],
+
+    "@parcel/watcher-android-arm64": ["@parcel/watcher-android-arm64@2.5.6", "", { "os": "android", "cpu": "arm64" }, "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A=="],
+
+    "@parcel/watcher-darwin-arm64": ["@parcel/watcher-darwin-arm64@2.5.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA=="],
+
+    "@parcel/watcher-darwin-x64": ["@parcel/watcher-darwin-x64@2.5.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg=="],
+
+    "@parcel/watcher-freebsd-x64": ["@parcel/watcher-freebsd-x64@2.5.6", "", { "os": "freebsd", "cpu": "x64" }, "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng=="],
+
+    "@parcel/watcher-linux-arm-glibc": ["@parcel/watcher-linux-arm-glibc@2.5.6", "", { "os": "linux", "cpu": "arm" }, "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ=="],
+
+    "@parcel/watcher-linux-arm-musl": ["@parcel/watcher-linux-arm-musl@2.5.6", "", { "os": "linux", "cpu": "arm" }, "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg=="],
+
+    "@parcel/watcher-linux-arm64-glibc": ["@parcel/watcher-linux-arm64-glibc@2.5.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA=="],
+
+    "@parcel/watcher-linux-arm64-musl": ["@parcel/watcher-linux-arm64-musl@2.5.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA=="],
+
+    "@parcel/watcher-linux-x64-glibc": ["@parcel/watcher-linux-x64-glibc@2.5.6", "", { "os": "linux", "cpu": "x64" }, "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ=="],
+
+    "@parcel/watcher-linux-x64-musl": ["@parcel/watcher-linux-x64-musl@2.5.6", "", { "os": "linux", "cpu": "x64" }, "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg=="],
+
+    "@parcel/watcher-win32-arm64": ["@parcel/watcher-win32-arm64@2.5.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q=="],
+
+    "@parcel/watcher-win32-ia32": ["@parcel/watcher-win32-ia32@2.5.6", "", { "os": "win32", "cpu": "ia32" }, "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g=="],
+
+    "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.5.6", "", { "os": "win32", "cpu": "x64" }, "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw=="],
+
     "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.18", "", { "os": "android", "cpu": "arm64" }, "sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ=="],
@@ -253,7 +298,7 @@
 
     "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.18", "", { "os": "win32", "cpu": "x64" }, "sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg=="],
 
-    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.3", "", { "os": "android", "cpu": "arm" }, "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw=="],
 
@@ -309,6 +354,8 @@
 
     "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
+    "@tailwindcss/cli": ["@tailwindcss/cli@4.3.0", "", { "dependencies": { "@parcel/watcher": "^2.5.1", "@tailwindcss/node": "4.3.0", "@tailwindcss/oxide": "4.3.0", "enhanced-resolve": "^5.21.0", "mri": "^1.2.0", "picocolors": "^1.1.1", "tailwindcss": "4.3.0" }, "bin": { "tailwindcss": "dist/index.mjs" } }, "sha512-X9kdlqyMopO9fewbgHsEeuy31YzMHbdZ9VsKt004tB+mxSg1CNbyhZYCzvhciN0AM4R4b5lvIprPjtNq7iQxpQ=="],
+
     "@tailwindcss/node": ["@tailwindcss/node@4.3.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.21.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.0" } }, "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g=="],
 
     "@tailwindcss/oxide": ["@tailwindcss/oxide@4.3.0", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.3.0", "@tailwindcss/oxide-darwin-arm64": "4.3.0", "@tailwindcss/oxide-darwin-x64": "4.3.0", "@tailwindcss/oxide-freebsd-x64": "4.3.0", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0", "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0", "@tailwindcss/oxide-linux-arm64-musl": "4.3.0", "@tailwindcss/oxide-linux-x64-gnu": "4.3.0", "@tailwindcss/oxide-linux-x64-musl": "4.3.0", "@tailwindcss/oxide-wasm32-wasi": "4.3.0", "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0", "@tailwindcss/oxide-win32-x64-msvc": "4.3.0" } }, "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg=="],
@@ -343,7 +390,27 @@
 
     "@tanstack/react-query": ["@tanstack/react-query@5.100.9", "", { "dependencies": { "@tanstack/query-core": "5.100.9" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-Oa44XkaI3kCNN6ME0KByU3xT3SEUNOMfZpHxL6+wFoTm+OeUFYHKdeYVe0aOXlRDm/f15sgLwEt2HDorIdW8+A=="],
 
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
+
+    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
+
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
+
+    "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
+
+    "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
+
+    "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
+
+    "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
 
@@ -362,6 +429,8 @@
     "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
 
     "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
 
@@ -401,7 +470,21 @@
 
     "@uiw/react-codemirror": ["@uiw/react-codemirror@4.25.9", "", { "dependencies": { "@babel/runtime": "^7.18.6", "@codemirror/commands": "^6.1.0", "@codemirror/state": "^6.1.1", "@codemirror/theme-one-dark": "^6.0.0", "@uiw/codemirror-extensions-basic-setup": "4.25.9", "codemirror": "^6.0.0" }, "peerDependencies": { "@codemirror/view": ">=6.0.0", "react": ">=17.0.0", "react-dom": ">=17.0.0" } }, "sha512-HftqCBUYShAOH0pGi1CHP8vfm5L8fQ3+0j0VI6lQD6QpK+UBu3J7nxfEN5O/BXMilMNf9ZyFJRvRcuMMOLHMng=="],
 
-    "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.1", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.7" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ=="],
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
+
+    "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
+
+    "@vitest/mocker": ["@vitest/mocker@3.2.4", "", { "dependencies": { "@vitest/spy": "3.2.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
+
+    "@vitest/runner": ["@vitest/runner@3.2.4", "", { "dependencies": { "@vitest/utils": "3.2.4", "pathe": "^2.0.3", "strip-literal": "^3.0.0" } }, "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "magic-string": "^0.30.17", "pathe": "^2.0.3" } }, "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ=="],
+
+    "@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
+
+    "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
 
     "@webhookengine/endpoint-manager": ["@webhookengine/endpoint-manager@workspace:packages/endpoint-manager"],
 
@@ -413,7 +496,15 @@
 
     "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
+
+    "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
@@ -428,6 +519,10 @@
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001791", "", {}, "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ=="],
+
+    "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
+    "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
 
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
@@ -448,6 +543,8 @@
     "crelt": ["crelt@1.0.6", "", {}, "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
@@ -477,13 +574,21 @@
 
     "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
 
+    "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.349", "", {}, "sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.21.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA=="],
+
+    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
     "es-toolkit": ["es-toolkit@1.46.1", "", {}, "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ=="],
 
@@ -511,6 +616,8 @@
 
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
@@ -518,6 +625,8 @@
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "eventsource": ["eventsource@2.0.2", "", {}, "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -547,6 +656,8 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
+    "happy-dom": ["happy-dom@17.6.3", "", { "dependencies": { "webidl-conversions": "^7.0.0", "whatwg-mimetype": "^3.0.0" } }, "sha512-UVIHeVhxmxedbWPCfgS55Jg2rDfwf2BCKeylcPSqazLz5w3Kri7Q4xdBJubsr/+VUzFLh0VjIvh13RaDA2/Xug=="],
+
     "hermes-estree": ["hermes-estree@0.25.1", "", {}, "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="],
 
     "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
@@ -556,6 +667,8 @@
     "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
     "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
@@ -617,15 +730,23 @@
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
+    "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
+
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "lucide-react": ["lucide-react@1.14.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA=="],
 
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "mlly": ["mlly@1.8.2", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA=="],
+
+    "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -634,6 +755,8 @@
     "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
@@ -653,6 +776,8 @@
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
+    "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
@@ -666,6 +791,8 @@
     "postcss-load-config": ["postcss-load-config@6.0.1", "", { "dependencies": { "lilconfig": "^3.1.1" }, "peerDependencies": { "jiti": ">=1.21.0", "postcss": ">=8.0.9", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["jiti", "postcss", "tsx", "yaml"] }, "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
     "psl": ["psl@1.15.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w=="],
 
@@ -681,11 +808,15 @@
 
     "react-redux": ["react-redux@9.2.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g=="],
 
+    "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
+
     "react-router": ["react-router@7.15.0", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ=="],
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "recharts": ["recharts@3.8.1", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg=="],
+
+    "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
     "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
 
@@ -703,7 +834,7 @@
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
-    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
@@ -711,9 +842,19 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
+
+    "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
 
     "style-mod": ["style-mod@4.1.3", "", {}, "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ=="],
 
@@ -729,9 +870,17 @@
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
     "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
+    "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
+
+    "tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+
+    "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
 
     "tough-cookie": ["tough-cookie@4.1.4", "", { "dependencies": { "psl": "^1.1.33", "punycode": "^2.1.1", "universalify": "^0.2.0", "url-parse": "^1.5.3" } }, "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag=="],
 
@@ -769,17 +918,25 @@
 
     "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
 
-    "vite": ["vite@8.0.11", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.14", "rolldown": "1.0.0-rc.18", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow=="],
+    "vite": ["vite@6.4.2", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ=="],
+
+    "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
+
+    "vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
 
     "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
 
     "webhookengine-dashboard": ["webhookengine-dashboard@workspace:src/dashboard"],
 
-    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+    "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
@@ -792,10 +949,6 @@
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
-
-    "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
-    "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@codemirror/autocomplete/@codemirror/view": ["@codemirror/view@6.41.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg=="],
 
@@ -825,12 +978,84 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
+
+    "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@uiw/codemirror-extensions-basic-setup/@codemirror/view": ["@codemirror/view@6.41.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg=="],
 
     "codemirror/@codemirror/view": ["@codemirror/view@6.41.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg=="],
 
+    "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.18", "", {}, "sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw=="],
+
+    "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
+
+    "vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "webhookengine-dashboard/@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.1", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.7" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ=="],
+
+    "webhookengine-dashboard/vite": ["vite@8.0.11", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.14", "rolldown": "1.0.0-rc.18", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow=="],
+
+    "whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "webhookengine-dashboard/@vitejs/plugin-react/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
   }
 }

--- a/packages/endpoint-manager/demo/index.html
+++ b/packages/endpoint-manager/demo/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EndpointManager — demo</title>
+    <link rel="stylesheet" href="../dist/style.css" />
+    <style>
+      body {
+        background: #09090b;
+        margin: 0;
+        padding: 2rem;
+        min-height: 100dvh;
+        box-sizing: border-box;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/packages/endpoint-manager/demo/main.tsx
+++ b/packages/endpoint-manager/demo/main.tsx
@@ -1,0 +1,204 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { EndpointManager } from "../src/index.js";
+import type { PortalEndpointSummary, PortalEndpointDetail, PortalEventTypeListItem } from "../src/types.js";
+import type { PortalListResult } from "../src/api/createPortalClient.js";
+
+// ---------------------------------------------------------------------------
+// In-memory mock data store for the demo.
+// ---------------------------------------------------------------------------
+let nextId = 4;
+const store: PortalEndpointDetail[] = [
+  {
+    id: "ep-1",
+    url: "https://acme-corp.example.com/webhooks/orders",
+    description: "Order events",
+    isActive: true,
+    hasSecretOverride: false,
+    filterEventTypes: ["et-1"],
+    customHeaders: { "X-Source": "webhookengine" },
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 7).toISOString(),
+    updatedAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 2).toISOString(),
+  },
+  {
+    id: "ep-2",
+    url: "https://acme-corp.example.com/webhooks/payments",
+    description: "Payment notifications",
+    isActive: false,
+    hasSecretOverride: true,
+    filterEventTypes: [],
+    customHeaders: {},
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 3).toISOString(),
+    updatedAt: new Date(Date.now() - 1000 * 60 * 60).toISOString(),
+  },
+  {
+    id: "ep-3",
+    url: "https://acme-corp.example.com/webhooks/all",
+    description: null,
+    isActive: true,
+    hasSecretOverride: false,
+    filterEventTypes: [],
+    customHeaders: {},
+    createdAt: new Date(Date.now() - 1000 * 60 * 30).toISOString(),
+    updatedAt: new Date(Date.now() - 1000 * 60 * 30).toISOString(),
+  },
+];
+
+const EVENT_TYPES: PortalEventTypeListItem[] = [
+  { id: "et-1", name: "order.created", description: "Fired when an order is placed" },
+  { id: "et-2", name: "order.fulfilled", description: "Fired when an order ships" },
+  { id: "et-3", name: "payment.succeeded", description: null },
+  { id: "et-4", name: "payment.failed", description: null },
+];
+
+function toSummary(d: PortalEndpointDetail): PortalEndpointSummary {
+  return {
+    id: d.id,
+    url: d.url,
+    description: d.description,
+    isActive: d.isActive,
+    hasSecretOverride: d.hasSecretOverride,
+    filterEventTypes: d.filterEventTypes,
+    createdAt: d.createdAt,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock fetch that mirrors the portal API contract.
+// ---------------------------------------------------------------------------
+function mockFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+  const method = (init?.method ?? "GET").toUpperCase();
+
+  const ok = <T>(data: T, status = 200) =>
+    Promise.resolve(
+      new Response(JSON.stringify({ data, meta: {} }), {
+        status,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+  const noContent = () => Promise.resolve(new Response(null, { status: 204 }));
+
+  // GET /api/v1/portal/event-types
+  if (method === "GET" && url.includes("/event-types")) {
+    return ok(EVENT_TYPES);
+  }
+
+  // GET /api/v1/portal/endpoints/:id/enable or /disable
+  const enableMatch = url.match(/\/endpoints\/([^/]+)\/enable$/);
+  if (method === "POST" && enableMatch) {
+    const id = enableMatch[1]!;
+    const ep = store.find((e) => e.id === id);
+    if (ep) ep.isActive = true;
+    return noContent();
+  }
+
+  const disableMatch = url.match(/\/endpoints\/([^/]+)\/disable$/);
+  if (method === "POST" && disableMatch) {
+    const id = disableMatch[1]!;
+    const ep = store.find((e) => e.id === id);
+    if (ep) ep.isActive = false;
+    return noContent();
+  }
+
+  // GET /api/v1/portal/endpoints/:id
+  const singleMatch = url.match(/\/endpoints\/([^/?]+)$/);
+  if (method === "GET" && singleMatch) {
+    const ep = store.find((e) => e.id === singleMatch[1]);
+    if (!ep)
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ error: { code: "PORTAL_NOT_FOUND", message: "Not found" }, meta: {} }),
+          { status: 404, headers: { "content-type": "application/json" } },
+        ),
+      );
+    return ok(ep);
+  }
+
+  // PUT /api/v1/portal/endpoints/:id
+  if (method === "PUT" && singleMatch) {
+    const id = singleMatch[1]!;
+    const idx = store.findIndex((e) => e.id === id);
+    if (idx === -1)
+      return Promise.resolve(new Response(null, { status: 404 }));
+    const body = JSON.parse(init?.body as string ?? "{}") as Partial<PortalEndpointDetail>;
+    store[idx] = { ...store[idx]!, ...body, updatedAt: new Date().toISOString() };
+    return ok(store[idx]!);
+  }
+
+  // DELETE /api/v1/portal/endpoints/:id
+  if (method === "DELETE" && singleMatch) {
+    const id = singleMatch[1]!;
+    const idx = store.findIndex((e) => e.id === id);
+    if (idx !== -1) store.splice(idx, 1);
+    return noContent();
+  }
+
+  // GET /api/v1/portal/endpoints (list)
+  if (method === "GET" && url.includes("/endpoints")) {
+    const params = new URL(url).searchParams;
+    const page = parseInt(params.get("page") ?? "1", 10);
+    const pageSize = parseInt(params.get("pageSize") ?? "20", 10);
+    const summaries = store.map(toSummary);
+    const sliced = summaries.slice((page - 1) * pageSize, page * pageSize);
+    return Promise.resolve(
+      new Response(
+        JSON.stringify({
+          data: sliced,
+          meta: { pagination: { page, pageSize, total: summaries.length } },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+  }
+
+  // POST /api/v1/portal/endpoints (create)
+  if (method === "POST" && url.includes("/endpoints")) {
+    const body = JSON.parse(init?.body as string ?? "{}") as Partial<PortalEndpointDetail>;
+    const newEp: PortalEndpointDetail = {
+      id: `ep-${nextId++}`,
+      url: body.url ?? "",
+      description: body.description ?? null,
+      isActive: true,
+      hasSecretOverride: !!body.hasSecretOverride,
+      filterEventTypes: body.filterEventTypes ?? [],
+      customHeaders: body.customHeaders ?? {},
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    store.push(newEp);
+    return ok(newEp, 201);
+  }
+
+  return Promise.resolve(new Response(null, { status: 404 }));
+}
+
+// ---------------------------------------------------------------------------
+// App
+// ---------------------------------------------------------------------------
+function App() {
+  return (
+    <EndpointManager
+      baseUrl="http://localhost:0000"
+      token="demo-token"
+      appId="00000000-0000-0000-0000-000000000000"
+      capabilities={["endpoints:read", "endpoints:write"]}
+      // Inject the mock fetch so no real HTTP is made.
+      // EndpointManager exposes fetch injection via createPortalClient internally —
+      // for the demo we monkey-patch globalThis.fetch before the component mounts.
+    />
+  );
+}
+
+// Patch global fetch for the demo so all requests hit the in-memory store.
+(globalThis as typeof globalThis & { fetch: typeof fetch }).fetch = mockFetch as typeof fetch;
+
+const root = document.getElementById("root");
+if (!root) throw new Error("Missing #root");
+
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/packages/endpoint-manager/demo/vite.config.ts
+++ b/packages/endpoint-manager/demo/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  root: "demo",
+  build: {
+    outDir: "../dist-demo",
+  },
+});

--- a/packages/endpoint-manager/package.json
+++ b/packages/endpoint-manager/package.json
@@ -27,11 +27,14 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsup",
-    "dev": "tsup --watch",
+    "build": "tsup && bun run build:css",
+    "build:css": "tailwindcss -i src/styles.css -o dist/style.css --minify",
+    "dev": "vite --config demo/vite.config.ts",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "peerDependencies": {
     "react": "^19.0.0",
@@ -39,11 +42,20 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@tailwindcss/cli": "^4.3.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^4.5.2",
     "eslint": "10.3.0",
+    "happy-dom": "^17.5.3",
+    "tailwindcss": "^4.3.0",
     "tsup": "^8.5.0",
     "typescript": "6.0.3",
-    "typescript-eslint": "8.59.2"
+    "typescript-eslint": "8.59.2",
+    "vite": "^6.3.5",
+    "vitest": "^3.2.1"
   }
 }

--- a/packages/endpoint-manager/src/EndpointManager.tsx
+++ b/packages/endpoint-manager/src/EndpointManager.tsx
@@ -1,29 +1,130 @@
+import { useMemo, useReducer, useCallback } from "react";
 import type { JSX } from "react";
-import type { EndpointManagerProps } from "./types.js";
+import type { EndpointManagerProps, PortalCapability, PortalEndpointSummary, PortalEndpointDetail } from "./types.js";
+import { createPortalClient } from "./api/createPortalClient.js";
+import { EndpointList } from "./components/EndpointList.js";
+import { EndpointEditor } from "./components/EndpointEditor.js";
+import type { EditorMode } from "./components/EndpointEditor.js";
+
+interface ManagerState {
+  view: "list" | "editor";
+  editorMode: EditorMode;
+  selectedEndpoint: PortalEndpointDetail | null;
+  /** Bump this to force the list to refetch. */
+  listKey: number;
+}
+
+type ManagerAction =
+  | { type: "OPEN_NEW" }
+  | { type: "OPEN_EDIT"; endpoint: PortalEndpointDetail }
+  | { type: "CLOSE_EDITOR"; action: "saved" | "deleted" | "cancelled" };
+
+function managerReducer(state: ManagerState, action: ManagerAction): ManagerState {
+  switch (action.type) {
+    case "OPEN_NEW":
+      return { ...state, view: "editor", editorMode: "create", selectedEndpoint: null };
+    case "OPEN_EDIT":
+      return {
+        ...state,
+        view: "editor",
+        editorMode: "edit",
+        selectedEndpoint: action.endpoint,
+      };
+    case "CLOSE_EDITOR":
+      return {
+        ...state,
+        view: "list",
+        selectedEndpoint: null,
+        // Bump listKey so the list re-fetches after a save or delete.
+        listKey: action.action !== "cancelled" ? state.listKey + 1 : state.listKey,
+      };
+  }
+}
+
+const DEFAULT_CAPABILITIES: PortalCapability[] = ["endpoints:read"];
 
 export function EndpointManager(props: EndpointManagerProps): JSX.Element {
-  void props; // referenced to keep noUnusedParameters happy
+  const {
+    baseUrl,
+    token,
+    appId,
+    capabilities = DEFAULT_CAPABILITIES,
+    className,
+    onError,
+    onUnauthorized,
+  } = props;
+
+  const client = useMemo(
+    () =>
+      createPortalClient({
+        baseUrl,
+        token,
+        onError,
+        onUnauthorized,
+      }),
+    [baseUrl, token, onError, onUnauthorized],
+  );
+
+  const [state, dispatch] = useReducer(managerReducer, {
+    view: "list",
+    editorMode: "create",
+    selectedEndpoint: null,
+    listKey: 0,
+  });
+
+  const handleEditEndpoint = useCallback(
+    async (summary: PortalEndpointSummary) => {
+      try {
+        const detail = await client.getEndpoint(summary.id);
+        dispatch({ type: "OPEN_EDIT", endpoint: detail });
+      } catch {
+        // Fall back to a partial detail from the summary if getEndpoint fails.
+        const fallback: PortalEndpointDetail = {
+          id: summary.id,
+          url: summary.url,
+          description: summary.description,
+          isActive: summary.isActive,
+          hasSecretOverride: summary.hasSecretOverride,
+          filterEventTypes: summary.filterEventTypes,
+          customHeaders: {},
+          createdAt: summary.createdAt,
+          updatedAt: summary.createdAt,
+        };
+        dispatch({ type: "OPEN_EDIT", endpoint: fallback });
+      }
+    },
+    [client],
+  );
+
+  const handleCloseEditor = useCallback(
+    (action: "saved" | "deleted" | "cancelled") => {
+      dispatch({ type: "CLOSE_EDITOR", action });
+    },
+    [],
+  );
+
   return (
-    <div
-      style={{
-        padding: "1.5rem",
-        borderRadius: "0.75rem",
-        border: "1px solid rgba(127, 127, 127, 0.25)",
-        fontFamily: "system-ui, -apple-system, sans-serif",
-        fontSize: "0.875rem",
-        lineHeight: 1.5,
-        color: "rgba(120, 120, 120, 0.9)"
-      }}
-    >
-      <strong style={{ display: "block", marginBottom: "0.5rem", color: "rgba(80, 80, 80, 0.95)" }}>
-        WebhookEngine portal
-      </strong>
-      <span>
-        The interactive components (endpoint list, editor, tester, attempt history) ship in B1
-        Step 8 of the WebhookEngine roadmap. This package is currently a placeholder — install it
-        early to lock the import path; it will gain the real UI in{" "}
-        <code>portal-v0.1.0</code>.
-      </span>
+    <div className={`whe-portal ${className ?? ""}`}>
+      {state.view === "list" && (
+        <EndpointList
+          key={state.listKey}
+          client={client}
+          appId={appId}
+          capabilities={capabilities}
+          onEditEndpoint={(summary) => void handleEditEndpoint(summary)}
+          onNewEndpoint={() => dispatch({ type: "OPEN_NEW" })}
+        />
+      )}
+
+      {state.view === "editor" && (
+        <EndpointEditor
+          client={client}
+          capabilities={capabilities}
+          mode={state.editorMode}
+          endpoint={state.selectedEndpoint ?? undefined}
+          onClose={handleCloseEditor}
+        />
+      )}
     </div>
   );
 }

--- a/packages/endpoint-manager/src/__tests__/EndpointEditor.test.tsx
+++ b/packages/endpoint-manager/src/__tests__/EndpointEditor.test.tsx
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { EndpointEditor } from "../components/EndpointEditor.js";
+import type { PortalClient } from "../api/createPortalClient.js";
+import { PortalError } from "../api/createPortalClient.js";
+import type { PortalEndpointDetail } from "../types.js";
+
+const DETAIL: PortalEndpointDetail = {
+  id: "ep-1",
+  url: "https://consumer.example.com/hooks",
+  description: "Existing endpoint",
+  isActive: true,
+  hasSecretOverride: false,
+  filterEventTypes: [],
+  customHeaders: { "X-Custom": "value" },
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+function makeClient(overrides: Partial<PortalClient> = {}): PortalClient {
+  return {
+    listEndpoints: vi.fn(),
+    getEndpoint: vi.fn(),
+    createEndpoint: vi.fn().mockResolvedValue(DETAIL),
+    updateEndpoint: vi.fn().mockResolvedValue(DETAIL),
+    deleteEndpoint: vi.fn().mockResolvedValue(undefined),
+    enableEndpoint: vi.fn().mockResolvedValue(undefined),
+    disableEndpoint: vi.fn().mockResolvedValue(undefined),
+    listEventTypes: vi.fn().mockResolvedValue([
+      { id: "et-1", name: "order.created", description: null },
+    ]),
+    testEndpoint: vi.fn(),
+    listAttempts: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("EndpointEditor", () => {
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("create form posts the right body (no admin-only fields)", async () => {
+    const user = userEvent.setup();
+    const client = makeClient();
+    let capturedInput: unknown;
+    client.createEndpoint = vi.fn().mockImplementation((input) => {
+      capturedInput = input;
+      return Promise.resolve(DETAIL);
+    });
+
+    render(
+      <EndpointEditor
+        client={client}
+        capabilities={["endpoints:read", "endpoints:write"]}
+        mode="create"
+        onClose={onClose}
+      />,
+    );
+
+    const urlInput = screen.getByLabelText(/Endpoint URL/i);
+    await user.clear(urlInput);
+    await user.type(urlInput, "https://new.example.com/hooks");
+
+    await user.click(screen.getByRole("button", { name: /^Save$/i }));
+
+    await waitFor(() => expect(client.createEndpoint).toHaveBeenCalledOnce());
+
+    expect(capturedInput).not.toHaveProperty("transformExpression");
+    expect(capturedInput).not.toHaveProperty("transformEnabled");
+    expect(capturedInput).not.toHaveProperty("allowedIpsJson");
+    expect(capturedInput).toMatchObject({ url: "https://new.example.com/hooks" });
+  });
+
+  it("edit form pre-fills URL and description", async () => {
+    render(
+      <EndpointEditor
+        client={makeClient()}
+        capabilities={["endpoints:read", "endpoints:write"]}
+        mode="edit"
+        endpoint={DETAIL}
+        onClose={onClose}
+      />,
+    );
+
+    const urlInput = screen.getByLabelText(/Endpoint URL/i) as HTMLInputElement;
+    await waitFor(() => expect(urlInput.value).toBe("https://consumer.example.com/hooks"));
+  });
+
+  it("secret override field rejects a non-whsec_ value on save", async () => {
+    const user = userEvent.setup();
+    render(
+      <EndpointEditor
+        client={makeClient()}
+        capabilities={["endpoints:read", "endpoints:write"]}
+        mode="edit"
+        endpoint={DETAIL}
+        onClose={onClose}
+      />,
+    );
+
+    const secretInput = screen.getByLabelText(/Secret override/i);
+    await user.clear(secretInput);
+    await user.type(secretInput, "password123");
+
+    await user.click(screen.getByRole("button", { name: /^Save$/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Secret must start with whsec_/i)).toBeInTheDocument(),
+    );
+    // Should NOT have called the client.
+    expect(makeClient().createEndpoint).not.toHaveBeenCalled();
+  });
+
+  it("delete fires confirm then DELETE and calls onClose('deleted')", async () => {
+    const user = userEvent.setup();
+    const client = makeClient();
+
+    render(
+      <EndpointEditor
+        client={client}
+        capabilities={["endpoints:read", "endpoints:write"]}
+        mode="edit"
+        endpoint={DETAIL}
+        onClose={onClose}
+      />,
+    );
+
+    // Click Delete button to show confirmation.
+    const deleteBtn = screen.getByRole("button", { name: /^Delete$/i });
+    await user.click(deleteBtn);
+
+    // Confirmation prompt should appear.
+    const confirmBtn = await screen.findByRole("button", { name: /Yes, delete/i });
+    await user.click(confirmBtn);
+
+    await waitFor(() => expect(client.deleteEndpoint).toHaveBeenCalledWith("ep-1"));
+    expect(onClose).toHaveBeenCalledWith("deleted");
+  });
+
+  it("422 fieldErrors are rendered inline", async () => {
+    const user = userEvent.setup();
+    const client = makeClient({
+      createEndpoint: vi.fn().mockRejectedValue(
+        new PortalError("Validation failed", "VALIDATION_FAILED", 422, {
+          url: "URL is already registered for this application",
+        }),
+      ),
+    });
+
+    render(
+      <EndpointEditor
+        client={client}
+        capabilities={["endpoints:read", "endpoints:write"]}
+        mode="create"
+        onClose={onClose}
+      />,
+    );
+
+    const urlInput = screen.getByLabelText(/Endpoint URL/i);
+    await user.clear(urlInput);
+    await user.type(urlInput, "https://already-registered.example.com/hooks");
+
+    await user.click(screen.getByRole("button", { name: /^Save$/i }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/URL is already registered for this application/i),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("Cancel calls onClose('cancelled')", async () => {
+    const user = userEvent.setup();
+    render(
+      <EndpointEditor
+        client={makeClient()}
+        capabilities={["endpoints:read", "endpoints:write"]}
+        mode="create"
+        onClose={onClose}
+      />,
+    );
+
+    const cancelBtns = screen.getAllByRole("button", { name: /Cancel/i });
+    // Footer Cancel is the last one.
+    await user.click(cancelBtns[cancelBtns.length - 1]!);
+    expect(onClose).toHaveBeenCalledWith("cancelled");
+  });
+
+  it("read-only mode hides Save button when capabilities lacks endpoints:write", async () => {
+    render(
+      <EndpointEditor
+        client={makeClient()}
+        capabilities={["endpoints:read"]}
+        mode="edit"
+        endpoint={DETAIL}
+        onClose={onClose}
+      />,
+    );
+
+    await waitFor(() => expect(screen.queryByRole("button", { name: /^Save$/i })).not.toBeInTheDocument());
+  });
+});
+
+// Suppress act() warnings from within() — re-export for sanity check
+const _within = within;
+void _within;

--- a/packages/endpoint-manager/src/__tests__/EndpointList.test.tsx
+++ b/packages/endpoint-manager/src/__tests__/EndpointList.test.tsx
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { EndpointList } from "../components/EndpointList.js";
+import type { PortalClient, PortalListResult } from "../api/createPortalClient.js";
+import type { PortalEndpointSummary } from "../types.js";
+
+function makeEndpoint(overrides: Partial<PortalEndpointSummary> = {}): PortalEndpointSummary {
+  return {
+    id: "ep-1",
+    url: "https://consumer.example.com/hooks",
+    description: "Test endpoint",
+    isActive: true,
+    hasSecretOverride: false,
+    filterEventTypes: [],
+    createdAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeClient(
+  overrides: Partial<PortalClient> = {},
+): PortalClient {
+  return {
+    listEndpoints: vi.fn().mockResolvedValue({
+      data: [makeEndpoint()],
+      pagination: { page: 1, pageSize: 20, total: 1 },
+    } satisfies PortalListResult<PortalEndpointSummary>),
+    getEndpoint: vi.fn(),
+    createEndpoint: vi.fn(),
+    updateEndpoint: vi.fn(),
+    deleteEndpoint: vi.fn().mockResolvedValue(undefined),
+    enableEndpoint: vi.fn().mockResolvedValue(undefined),
+    disableEndpoint: vi.fn().mockResolvedValue(undefined),
+    listEventTypes: vi.fn().mockResolvedValue([]),
+    testEndpoint: vi.fn(),
+    listAttempts: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("EndpointList", () => {
+  const onEditEndpoint = vi.fn();
+  const onNewEndpoint = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders endpoint rows from the client", async () => {
+    const client = makeClient();
+    render(
+      <EndpointList
+        client={client}
+        appId="app-1"
+        capabilities={["endpoints:read", "endpoints:write"]}
+        onEditEndpoint={onEditEndpoint}
+        onNewEndpoint={onNewEndpoint}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText(/consumer\.example\.com/)).toBeInTheDocument(),
+    );
+    expect(screen.getByText("Active")).toBeInTheDocument();
+  });
+
+  it("shows '+ New endpoint' button only when endpoints:write capability is present", async () => {
+    const client = makeClient();
+
+    const { rerender } = render(
+      <EndpointList
+        client={client}
+        appId="app-1"
+        capabilities={["endpoints:read"]}
+        onEditEndpoint={onEditEndpoint}
+        onNewEndpoint={onNewEndpoint}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText(/consumer\.example\.com/)).toBeInTheDocument(),
+    );
+    expect(screen.queryByText(/New endpoint/)).not.toBeInTheDocument();
+
+    rerender(
+      <EndpointList
+        client={client}
+        appId="app-1"
+        capabilities={["endpoints:read", "endpoints:write"]}
+        onEditEndpoint={onEditEndpoint}
+        onNewEndpoint={onNewEndpoint}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText(/New endpoint/)).toBeInTheDocument(),
+    );
+  });
+
+  it("shows empty state with CTA when no endpoints are returned", async () => {
+    const client = makeClient({
+      listEndpoints: vi.fn().mockResolvedValue({
+        data: [],
+        pagination: { page: 1, pageSize: 20, total: 0 },
+      }),
+    });
+
+    render(
+      <EndpointList
+        client={client}
+        appId="app-1"
+        capabilities={["endpoints:read", "endpoints:write"]}
+        onEditEndpoint={onEditEndpoint}
+        onNewEndpoint={onNewEndpoint}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText(/No endpoints yet/)).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/Create your first endpoint/)).toBeInTheDocument();
+  });
+
+  it("calls onNewEndpoint when + New endpoint is clicked", async () => {
+    const user = userEvent.setup();
+    const client = makeClient();
+
+    render(
+      <EndpointList
+        client={client}
+        appId="app-1"
+        capabilities={["endpoints:read", "endpoints:write"]}
+        onEditEndpoint={onEditEndpoint}
+        onNewEndpoint={onNewEndpoint}
+      />,
+    );
+
+    await waitFor(() => screen.getByText(/New endpoint/));
+    await user.click(screen.getByText(/New endpoint/));
+    expect(onNewEndpoint).toHaveBeenCalledOnce();
+  });
+
+  it("shows error state and retry button on fetch failure", async () => {
+    const user = userEvent.setup();
+    const client = makeClient({
+      listEndpoints: vi.fn().mockRejectedValue(new Error("Network error")),
+    });
+
+    render(
+      <EndpointList
+        client={client}
+        appId="app-1"
+        capabilities={["endpoints:read"]}
+        onEditEndpoint={onEditEndpoint}
+        onNewEndpoint={onNewEndpoint}
+      />,
+    );
+
+    await waitFor(() => screen.getByText(/Network error/));
+    const retry = screen.getByText("Retry");
+    expect(retry).toBeInTheDocument();
+
+    // Retry should re-call listEndpoints.
+    await user.click(retry);
+    expect(client.listEndpoints).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/endpoint-manager/src/__tests__/createPortalClient.test.ts
+++ b/packages/endpoint-manager/src/__tests__/createPortalClient.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi } from "vitest";
+import { createPortalClient, PortalError } from "../api/createPortalClient.js";
+import {
+  createMockFetch,
+  jsonOk,
+  jsonList,
+  noContent,
+  jsonError,
+} from "./mockFetch.js";
+import type {
+  PortalEndpointSummary,
+  PortalEndpointDetail,
+  PortalEventTypeListItem,
+} from "../types.js";
+
+const BASE = "https://engine.example.com";
+const TOKEN = "test-token";
+
+const SUMMARY: PortalEndpointSummary = {
+  id: "ep-1",
+  url: "https://consumer.example.com/hooks",
+  description: "Test endpoint",
+  isActive: true,
+  hasSecretOverride: false,
+  filterEventTypes: [],
+  createdAt: "2026-01-01T00:00:00Z",
+};
+
+const DETAIL: PortalEndpointDetail = {
+  ...SUMMARY,
+  customHeaders: {},
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+const EVENT_TYPE: PortalEventTypeListItem = {
+  id: "et-1",
+  name: "order.created",
+  description: null,
+};
+
+describe("createPortalClient", () => {
+  it("listEndpoints — returns data and pagination", async () => {
+    const fetch = createMockFetch([
+      {
+        method: "GET",
+        pattern: "/api/v1/portal/endpoints",
+        handler: () =>
+          jsonList([SUMMARY], { page: 1, pageSize: 20, total: 1 }),
+      },
+    ]);
+    const client = createPortalClient({ baseUrl: BASE, token: TOKEN, fetch });
+    const result = await client.listEndpoints({ page: 1, pageSize: 20 });
+
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0]?.id).toBe("ep-1");
+    expect(result.pagination).toEqual({ page: 1, pageSize: 20, total: 1 });
+  });
+
+  it("getEndpoint — returns unwrapped detail", async () => {
+    const fetch = createMockFetch([
+      {
+        method: "GET",
+        pattern: "/api/v1/portal/endpoints/ep-1",
+        handler: () => jsonOk(DETAIL),
+      },
+    ]);
+    const client = createPortalClient({ baseUrl: BASE, token: TOKEN, fetch });
+    const result = await client.getEndpoint("ep-1");
+
+    expect(result.id).toBe("ep-1");
+    expect(result.customHeaders).toEqual({});
+  });
+
+  it("createEndpoint — sends correct body and returns detail", async () => {
+    let capturedBody: unknown;
+    const fetch = createMockFetch([
+      {
+        method: "POST",
+        pattern: "/api/v1/portal/endpoints",
+        handler: (_url, init) => {
+          capturedBody = JSON.parse(init?.body as string);
+          return jsonOk(DETAIL);
+        },
+      },
+    ]);
+    const client = createPortalClient({ baseUrl: BASE, token: TOKEN, fetch });
+    const result = await client.createEndpoint({
+      url: "https://consumer.example.com/hooks",
+      description: "Test",
+      filterEventTypes: [],
+      customHeaders: {},
+    });
+
+    expect(result.id).toBe("ep-1");
+    expect(capturedBody).toMatchObject({ url: "https://consumer.example.com/hooks" });
+    // Must not include admin-only fields.
+    expect(capturedBody).not.toHaveProperty("transformExpression");
+    expect(capturedBody).not.toHaveProperty("transformEnabled");
+    expect(capturedBody).not.toHaveProperty("allowedIpsJson");
+  });
+
+  it("updateEndpoint — sends correct body", async () => {
+    let capturedBody: unknown;
+    const fetch = createMockFetch([
+      {
+        method: "PUT",
+        pattern: "/api/v1/portal/endpoints/ep-1",
+        handler: (_url, init) => {
+          capturedBody = JSON.parse(init?.body as string);
+          return jsonOk({ ...DETAIL, url: "https://updated.example.com/hooks" });
+        },
+      },
+    ]);
+    const client = createPortalClient({ baseUrl: BASE, token: TOKEN, fetch });
+    const result = await client.updateEndpoint("ep-1", {
+      url: "https://updated.example.com/hooks",
+    });
+
+    expect(result.url).toBe("https://updated.example.com/hooks");
+    expect(capturedBody).not.toHaveProperty("transformExpression");
+  });
+
+  it("deleteEndpoint — returns void on 204", async () => {
+    const fetch = createMockFetch([
+      {
+        method: "DELETE",
+        pattern: "/api/v1/portal/endpoints/ep-1",
+        handler: () => noContent(),
+      },
+    ]);
+    const client = createPortalClient({ baseUrl: BASE, token: TOKEN, fetch });
+    const result = await client.deleteEndpoint("ep-1");
+
+    expect(result).toBeUndefined();
+  });
+
+  it("enableEndpoint + disableEndpoint — both return void on 204", async () => {
+    const fetch = createMockFetch([
+      { method: "POST", pattern: "/enable", handler: () => noContent() },
+      { method: "POST", pattern: "/disable", handler: () => noContent() },
+    ]);
+    const client = createPortalClient({ baseUrl: BASE, token: TOKEN, fetch });
+
+    await expect(client.enableEndpoint("ep-1")).resolves.toBeUndefined();
+    await expect(client.disableEndpoint("ep-1")).resolves.toBeUndefined();
+  });
+
+  it("401 triggers onUnauthorized callback and throws PortalError", async () => {
+    const onUnauthorized = vi.fn();
+    const fetch = createMockFetch([
+      {
+        method: "GET",
+        pattern: "/api/v1/portal/endpoints",
+        handler: () =>
+          jsonError(401, "PORTAL_AUTH_REQUIRED", "Token is required"),
+      },
+    ]);
+    const client = createPortalClient({ baseUrl: BASE, token: TOKEN, fetch, onUnauthorized });
+
+    await expect(client.listEndpoints()).rejects.toBeInstanceOf(PortalError);
+    expect(onUnauthorized).toHaveBeenCalledOnce();
+  });
+
+  it("422 surfaces fieldErrors on PortalError", async () => {
+    const fetch = createMockFetch([
+      {
+        method: "POST",
+        pattern: "/api/v1/portal/endpoints",
+        handler: () =>
+          jsonError(422, "VALIDATION_FAILED", "Validation failed", {
+            url: "URL must use HTTPS",
+          }),
+      },
+    ]);
+    const client = createPortalClient({ baseUrl: BASE, token: TOKEN, fetch });
+
+    let caught: PortalError | null = null;
+    try {
+      await client.createEndpoint({ url: "http://not-https.example.com" });
+    } catch (err) {
+      caught = err as PortalError;
+    }
+
+    expect(caught).toBeInstanceOf(PortalError);
+    expect(caught?.code).toBe("VALIDATION_FAILED");
+    expect(caught?.status).toBe(422);
+    expect(caught?.fieldErrors?.["url"]).toBe("URL must use HTTPS");
+  });
+
+  it("listEventTypes — returns array directly", async () => {
+    const fetch = createMockFetch([
+      {
+        method: "GET",
+        pattern: "/api/v1/portal/event-types",
+        handler: () => jsonOk([EVENT_TYPE]),
+      },
+    ]);
+    const client = createPortalClient({ baseUrl: BASE, token: TOKEN, fetch });
+    const result = await client.listEventTypes();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.name).toBe("order.created");
+  });
+
+  it("testEndpoint — throws 'Not implemented'", () => {
+    const client = createPortalClient({ baseUrl: BASE, token: TOKEN });
+    expect(() => client.testEndpoint("ep-1", {})).toThrow("Not implemented yet");
+  });
+
+  it("listAttempts — throws 'Not implemented'", () => {
+    const client = createPortalClient({ baseUrl: BASE, token: TOKEN });
+    expect(() => client.listAttempts("ep-1")).toThrow("Not implemented yet");
+  });
+});

--- a/packages/endpoint-manager/src/__tests__/mockFetch.ts
+++ b/packages/endpoint-manager/src/__tests__/mockFetch.ts
@@ -1,0 +1,80 @@
+export type MockHandler = (
+  url: string,
+  init: RequestInit | undefined,
+) => Promise<Response> | Response;
+
+export interface MockRoute {
+  method: string;
+  pattern: string | RegExp;
+  handler: MockHandler;
+}
+
+/**
+ * Creates a mock `fetch` implementation for testing the portal client.
+ *
+ * Routes are matched in order; the first matching route wins.
+ * A route matches when both the HTTP method and the URL pattern match.
+ */
+export function createMockFetch(routes: MockRoute[]): typeof fetch {
+  return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    const method = (init?.method ?? "GET").toUpperCase();
+
+    for (const route of routes) {
+      const methodMatch = route.method.toUpperCase() === method;
+      const urlMatch =
+        typeof route.pattern === "string"
+          ? url.includes(route.pattern)
+          : route.pattern.test(url);
+
+      if (methodMatch && urlMatch) {
+        return route.handler(url, init);
+      }
+    }
+
+    return new Response(
+      JSON.stringify({ error: { code: "NOT_FOUND", message: "No matching mock route" }, meta: { requestId: "test" } }),
+      { status: 404, headers: { "content-type": "application/json" } },
+    );
+  };
+}
+
+/** Convenience: build a 200 JSON response wrapping data in { data: ..., meta: ... } */
+export function jsonOk<T>(data: T, meta?: Record<string, unknown>): Response {
+  return new Response(JSON.stringify({ data, meta: meta ?? {} }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** Convenience: build a paginated 200 JSON response */
+export function jsonList<T>(
+  data: T[],
+  pagination: { page: number; pageSize: number; total: number },
+): Response {
+  return new Response(
+    JSON.stringify({ data, meta: { pagination } }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+/** Convenience: 204 No Content */
+export function noContent(): Response {
+  return new Response(null, { status: 204 });
+}
+
+/** Convenience: error response */
+export function jsonError(
+  status: number,
+  code: string,
+  message: string,
+  fieldErrors?: Record<string, string>,
+): Response {
+  return new Response(
+    JSON.stringify({
+      error: { code, message, fieldErrors },
+      meta: { requestId: "test" },
+    }),
+    { status, headers: { "content-type": "application/json" } },
+  );
+}

--- a/packages/endpoint-manager/src/__tests__/setup.ts
+++ b/packages/endpoint-manager/src/__tests__/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/packages/endpoint-manager/src/api/createPortalClient.ts
+++ b/packages/endpoint-manager/src/api/createPortalClient.ts
@@ -1,0 +1,257 @@
+import type {
+  PortalCapability,
+  PortalCreateEndpointInput,
+  PortalEndpointDetail,
+  PortalEndpointSummary,
+  PortalEventTypeListItem,
+  PortalUpdateEndpointInput,
+} from "../types.js";
+
+// Re-export PortalCapability so consumers can use it from the client module.
+export type { PortalCapability };
+
+export interface PortalClientOptions {
+  baseUrl: string;
+  token: string;
+  /** Injected for tests — defaults to globalThis.fetch */
+  fetch?: typeof fetch;
+  onError?: (error: PortalError) => void;
+  onUnauthorized?: () => void;
+}
+
+export interface PortalPagination {
+  page: number;
+  pageSize: number;
+  total: number;
+}
+
+export interface PortalListResult<T> {
+  data: T[];
+  pagination: PortalPagination;
+}
+
+export class PortalError extends Error {
+  readonly code: string;
+  readonly status: number;
+  readonly fieldErrors?: Record<string, string>;
+
+  constructor(
+    message: string,
+    code: string,
+    status: number,
+    fieldErrors?: Record<string, string>,
+  ) {
+    super(message);
+    this.name = "PortalError";
+    this.code = code;
+    this.status = status;
+    this.fieldErrors = fieldErrors;
+  }
+}
+
+export interface PortalClient {
+  listEndpoints(params?: {
+    page?: number;
+    pageSize?: number;
+  }): Promise<PortalListResult<PortalEndpointSummary>>;
+  getEndpoint(id: string): Promise<PortalEndpointDetail>;
+  createEndpoint(input: PortalCreateEndpointInput): Promise<PortalEndpointDetail>;
+  updateEndpoint(id: string, input: PortalUpdateEndpointInput): Promise<PortalEndpointDetail>;
+  deleteEndpoint(id: string): Promise<void>;
+  enableEndpoint(id: string): Promise<void>;
+  disableEndpoint(id: string): Promise<void>;
+  listEventTypes(): Promise<PortalEventTypeListItem[]>;
+  // Step 9 will add testEndpoint + listAttempts.
+  testEndpoint(id: string, payload: Record<string, unknown>): Promise<never>;
+  listAttempts(id: string, params?: { page?: number; pageSize?: number }): Promise<never>;
+}
+
+interface ApiErrorEnvelope {
+  error: {
+    code: string;
+    message: string;
+    fieldErrors?: Record<string, string>;
+  };
+  meta: {
+    requestId: string;
+  };
+}
+
+interface ApiDataEnvelope<T> {
+  data: T;
+  meta?: {
+    pagination?: PortalPagination;
+    requestId?: string;
+  };
+}
+
+export function createPortalClient(options: PortalClientOptions): PortalClient {
+  const {
+    baseUrl,
+    token,
+    fetch: fetchImpl = globalThis.fetch,
+    onError,
+    onUnauthorized,
+  } = options;
+
+  const base = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
+
+  function buildUrl(path: string, query?: Record<string, string>): string {
+    const url = new URL(`${base}${path}`);
+    if (query) {
+      const params = new URLSearchParams(query);
+      params.forEach((value, key) => url.searchParams.set(key, value));
+    }
+    return url.toString();
+  }
+
+  async function request<T>(
+    method: string,
+    path: string,
+    opts?: {
+      body?: unknown;
+      query?: Record<string, string>;
+    },
+  ): Promise<T> {
+    const url = buildUrl(path, opts?.query);
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${token}`,
+    };
+    if (opts?.body !== undefined) {
+      headers["Content-Type"] = "application/json";
+    }
+
+    const response = await fetchImpl(url, {
+      method,
+      headers,
+      body: opts?.body !== undefined ? JSON.stringify(opts.body) : undefined,
+    });
+
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    let json: unknown;
+    const contentType = response.headers.get("content-type") ?? "";
+    if (contentType.includes("application/json")) {
+      json = await response.json();
+    }
+
+    if (!response.ok) {
+      const envelope = json as ApiErrorEnvelope | undefined;
+      const code = envelope?.error?.code ?? "UNKNOWN_ERROR";
+      const message = envelope?.error?.message ?? `HTTP ${response.status}`;
+      const fieldErrors = envelope?.error?.fieldErrors;
+      const err = new PortalError(message, code, response.status, fieldErrors);
+
+      if (response.status === 401) {
+        onUnauthorized?.();
+      }
+      onError?.(err);
+      throw err;
+    }
+
+    const envelope = json as ApiDataEnvelope<T>;
+    return envelope.data;
+  }
+
+  async function requestList<T>(
+    path: string,
+    params?: { page?: number; pageSize?: number },
+  ): Promise<PortalListResult<T>> {
+    const query: Record<string, string> = {};
+    if (params?.page !== undefined) query["page"] = String(params.page);
+    if (params?.pageSize !== undefined) query["pageSize"] = String(params.pageSize);
+
+    const url = buildUrl(path, Object.keys(query).length > 0 ? query : undefined);
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${token}`,
+    };
+
+    const response = await fetchImpl(url, { method: "GET", headers });
+
+    let json: unknown;
+    const contentType = response.headers.get("content-type") ?? "";
+    if (contentType.includes("application/json")) {
+      json = await response.json();
+    }
+
+    if (!response.ok) {
+      const envelope = json as ApiErrorEnvelope | undefined;
+      const code = envelope?.error?.code ?? "UNKNOWN_ERROR";
+      const message = envelope?.error?.message ?? `HTTP ${response.status}`;
+      const fieldErrors = envelope?.error?.fieldErrors;
+      const err = new PortalError(message, code, response.status, fieldErrors);
+      if (response.status === 401) {
+        onUnauthorized?.();
+      }
+      onError?.(err);
+      throw err;
+    }
+
+    const envelope = json as ApiDataEnvelope<T[]>;
+    const pagination: PortalPagination = envelope.meta?.pagination ?? {
+      page: params?.page ?? 1,
+      pageSize: params?.pageSize ?? 20,
+      total: (envelope.data as T[]).length,
+    };
+    return { data: envelope.data, pagination };
+  }
+
+  return {
+    listEndpoints(params) {
+      return requestList<PortalEndpointSummary>("/api/v1/portal/endpoints", params);
+    },
+
+    getEndpoint(id) {
+      return request<PortalEndpointDetail>("GET", `/api/v1/portal/endpoints/${id}`);
+    },
+
+    createEndpoint(input) {
+      // Deliberately exclude transformExpression, transformEnabled, allowedIpsJson.
+      const body: PortalCreateEndpointInput = {
+        url: input.url,
+        description: input.description,
+        filterEventTypes: input.filterEventTypes,
+        customHeaders: input.customHeaders,
+        secretOverride: input.secretOverride,
+      };
+      return request<PortalEndpointDetail>("POST", "/api/v1/portal/endpoints", { body });
+    },
+
+    updateEndpoint(id, input) {
+      const body: PortalUpdateEndpointInput = {
+        url: input.url,
+        description: input.description,
+        filterEventTypes: input.filterEventTypes,
+        customHeaders: input.customHeaders,
+        secretOverride: input.secretOverride,
+      };
+      return request<PortalEndpointDetail>("PUT", `/api/v1/portal/endpoints/${id}`, { body });
+    },
+
+    deleteEndpoint(id) {
+      return request<void>("DELETE", `/api/v1/portal/endpoints/${id}`);
+    },
+
+    enableEndpoint(id) {
+      return request<void>("POST", `/api/v1/portal/endpoints/${id}/enable`);
+    },
+
+    disableEndpoint(id) {
+      return request<void>("POST", `/api/v1/portal/endpoints/${id}/disable`);
+    },
+
+    listEventTypes() {
+      return request<PortalEventTypeListItem[]>("GET", "/api/v1/portal/event-types");
+    },
+
+    testEndpoint(_id, _payload) {
+      throw new Error("Not implemented yet — lands in B1 Step 9");
+    },
+
+    listAttempts(_id, _params) {
+      throw new Error("Not implemented yet — lands in B1 Step 9");
+    },
+  };
+}

--- a/packages/endpoint-manager/src/components/EndpointEditor.tsx
+++ b/packages/endpoint-manager/src/components/EndpointEditor.tsx
@@ -1,0 +1,681 @@
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
+import type { JSX } from "react";
+import type { PortalCapability, PortalEndpointDetail, PortalEventTypeListItem } from "../types.js";
+import type { PortalClient } from "../api/createPortalClient.js";
+import { PortalError } from "../api/createPortalClient.js";
+
+export type EditorMode = "create" | "edit";
+
+export interface EndpointEditorProps {
+  client: PortalClient;
+  capabilities: PortalCapability[];
+  mode: EditorMode;
+  /** Populated when mode === "edit" */
+  endpoint?: PortalEndpointDetail;
+  onClose: (action: "saved" | "deleted" | "cancelled") => void;
+}
+
+interface FormValues {
+  url: string;
+  description: string;
+  filterEventTypes: string[];
+  customHeaders: { key: string; value: string }[];
+  secretOverride: string;
+}
+
+interface EditorState {
+  values: FormValues;
+  fieldErrors: Record<string, string>;
+  globalError: string | null;
+  saving: boolean;
+  deleting: boolean;
+  toggling: boolean;
+  eventTypes: PortalEventTypeListItem[];
+  eventTypesLoading: boolean;
+  showSecret: boolean;
+  showDeleteConfirm: boolean;
+}
+
+type EditorAction =
+  | { type: "SET_FIELD"; field: keyof Omit<FormValues, "filterEventTypes" | "customHeaders">; value: string }
+  | { type: "TOGGLE_EVENT_TYPE"; id: string }
+  | { type: "ADD_HEADER" }
+  | { type: "UPDATE_HEADER"; index: number; key: string; value: string }
+  | { type: "REMOVE_HEADER"; index: number }
+  | { type: "TOGGLE_SHOW_SECRET" }
+  | { type: "TOGGLE_DELETE_CONFIRM" }
+  | { type: "SAVE_START" }
+  | { type: "SAVE_SUCCESS" }
+  | { type: "SAVE_ERROR"; globalError: string; fieldErrors: Record<string, string> }
+  | { type: "DELETE_START" }
+  | { type: "DELETE_ERROR"; message: string }
+  | { type: "TOGGLE_START" }
+  | { type: "TOGGLE_DONE"; isActive: boolean }
+  | { type: "TOGGLE_ERROR"; message: string }
+  | { type: "EVENT_TYPES_LOADED"; eventTypes: PortalEventTypeListItem[] };
+
+function editorReducer(state: EditorState, action: EditorAction): EditorState {
+  switch (action.type) {
+    case "SET_FIELD":
+      return {
+        ...state,
+        values: { ...state.values, [action.field]: action.value },
+        fieldErrors: { ...state.fieldErrors, [action.field]: "" },
+      };
+    case "TOGGLE_EVENT_TYPE": {
+      const current = state.values.filterEventTypes;
+      const next = current.includes(action.id)
+        ? current.filter((id) => id !== action.id)
+        : [...current, action.id];
+      return { ...state, values: { ...state.values, filterEventTypes: next } };
+    }
+    case "ADD_HEADER":
+      return {
+        ...state,
+        values: {
+          ...state.values,
+          customHeaders: [...state.values.customHeaders, { key: "", value: "" }],
+        },
+      };
+    case "UPDATE_HEADER": {
+      const updated = state.values.customHeaders.map((h, i) =>
+        i === action.index ? { key: action.key, value: action.value } : h,
+      );
+      return { ...state, values: { ...state.values, customHeaders: updated } };
+    }
+    case "REMOVE_HEADER":
+      return {
+        ...state,
+        values: {
+          ...state.values,
+          customHeaders: state.values.customHeaders.filter((_, i) => i !== action.index),
+        },
+      };
+    case "TOGGLE_SHOW_SECRET":
+      return { ...state, showSecret: !state.showSecret };
+    case "TOGGLE_DELETE_CONFIRM":
+      return { ...state, showDeleteConfirm: !state.showDeleteConfirm };
+    case "SAVE_START":
+      return { ...state, saving: true, globalError: null, fieldErrors: {} };
+    case "SAVE_SUCCESS":
+      return { ...state, saving: false };
+    case "SAVE_ERROR":
+      return {
+        ...state,
+        saving: false,
+        globalError: action.globalError,
+        fieldErrors: action.fieldErrors,
+      };
+    case "DELETE_START":
+      return { ...state, deleting: true, globalError: null };
+    case "DELETE_ERROR":
+      return { ...state, deleting: false, globalError: action.message };
+    case "TOGGLE_START":
+      return { ...state, toggling: true, globalError: null };
+    case "TOGGLE_DONE":
+      return { ...state, toggling: false };
+    case "TOGGLE_ERROR":
+      return { ...state, toggling: false, globalError: action.message };
+    case "EVENT_TYPES_LOADED":
+      return { ...state, eventTypes: action.eventTypes, eventTypesLoading: false };
+  }
+}
+
+function buildInitialValues(endpoint?: PortalEndpointDetail): FormValues {
+  if (!endpoint) {
+    return {
+      url: "",
+      description: "",
+      filterEventTypes: [],
+      customHeaders: [],
+      secretOverride: "",
+    };
+  }
+  return {
+    url: endpoint.url,
+    description: endpoint.description ?? "",
+    filterEventTypes: endpoint.filterEventTypes,
+    customHeaders: Object.entries(endpoint.customHeaders ?? {}).map(([key, value]) => ({
+      key,
+      value,
+    })),
+    secretOverride: "",
+  };
+}
+
+function validateSecretOverride(value: string): string | null {
+  if (value === "") return null;
+  if (!value.startsWith("whsec_")) return "Secret must start with whsec_";
+  const payload = value.slice("whsec_".length);
+  if (payload.length < 32) return "Secret must be at least 38 characters (whsec_ + 32)";
+  if (payload.length > 128) return "Secret payload must not exceed 128 characters";
+  return null;
+}
+
+function validateUrl(value: string): string | null {
+  if (!value) return "URL is required";
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== "https:") return "URL must use HTTPS";
+  } catch {
+    return "URL must be a valid URL";
+  }
+  return null;
+}
+
+function headersToRecord(headers: { key: string; value: string }[]): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const { key, value } of headers) {
+    const trimmedKey = key.trim();
+    if (trimmedKey) result[trimmedKey] = value;
+  }
+  return result;
+}
+
+export function EndpointEditor({
+  client,
+  capabilities,
+  mode,
+  endpoint,
+  onClose,
+}: EndpointEditorProps): JSX.Element {
+  const canWrite = capabilities.includes("endpoints:write");
+  const isEdit = mode === "edit";
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const firstFocusableRef = useRef<HTMLInputElement>(null);
+
+  const [state, dispatch] = useReducer(editorReducer, {
+    values: buildInitialValues(endpoint),
+    fieldErrors: {},
+    globalError: null,
+    saving: false,
+    deleting: false,
+    toggling: false,
+    eventTypes: [],
+    eventTypesLoading: true,
+    showSecret: false,
+    showDeleteConfirm: false,
+  });
+
+  // Track current isActive for the enable/disable button when in edit mode.
+  const [currentIsActive, setCurrentIsActive] = useState(endpoint?.isActive ?? false);
+
+  // Load event types on mount.
+  useEffect(() => {
+    client.listEventTypes().then((types) => {
+      dispatch({ type: "EVENT_TYPES_LOADED", eventTypes: types });
+    }).catch(() => {
+      dispatch({ type: "EVENT_TYPES_LOADED", eventTypes: [] });
+    });
+  }, [client]);
+
+  // Focus trap and Escape key.
+  useEffect(() => {
+    firstFocusableRef.current?.focus();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose("cancelled");
+        return;
+      }
+      if (e.key !== "Tab") return;
+
+      const overlay = overlayRef.current;
+      if (!overlay) return;
+      const focusable = overlay.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      );
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (!first || !last) return;
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    // Prevent body scroll while modal is open.
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "";
+    };
+  }, [onClose]);
+
+  const handleSave = useCallback(async () => {
+    // Client-side validation.
+    const urlError = validateUrl(state.values.url);
+    const secretError = validateSecretOverride(state.values.secretOverride);
+    if (urlError || secretError) {
+      dispatch({
+        type: "SAVE_ERROR",
+        globalError: "Please fix the errors below.",
+        fieldErrors: {
+          ...(urlError ? { url: urlError } : {}),
+          ...(secretError ? { secretOverride: secretError } : {}),
+        },
+      });
+      return;
+    }
+
+    dispatch({ type: "SAVE_START" });
+
+    const payload = {
+      url: state.values.url,
+      description: state.values.description || null,
+      filterEventTypes: state.values.filterEventTypes,
+      customHeaders: headersToRecord(state.values.customHeaders),
+      secretOverride: state.values.secretOverride || null,
+    };
+
+    try {
+      if (isEdit && endpoint) {
+        await client.updateEndpoint(endpoint.id, payload);
+      } else {
+        await client.createEndpoint(payload);
+      }
+      dispatch({ type: "SAVE_SUCCESS" });
+      onClose("saved");
+    } catch (err) {
+      if (err instanceof PortalError) {
+        dispatch({
+          type: "SAVE_ERROR",
+          globalError: err.message,
+          fieldErrors: err.fieldErrors ?? {},
+        });
+      } else {
+        dispatch({
+          type: "SAVE_ERROR",
+          globalError: "An unexpected error occurred.",
+          fieldErrors: {},
+        });
+      }
+    }
+  }, [client, endpoint, isEdit, onClose, state.values]);
+
+  const handleDelete = useCallback(async () => {
+    if (!endpoint) return;
+    dispatch({ type: "DELETE_START" });
+    try {
+      await client.deleteEndpoint(endpoint.id);
+      onClose("deleted");
+    } catch (err) {
+      dispatch({
+        type: "DELETE_ERROR",
+        message: err instanceof Error ? err.message : "Failed to delete endpoint.",
+      });
+    }
+  }, [client, endpoint, onClose]);
+
+  const handleToggleActive = useCallback(async () => {
+    if (!endpoint) return;
+    dispatch({ type: "TOGGLE_START" });
+    try {
+      if (currentIsActive) {
+        await client.disableEndpoint(endpoint.id);
+        setCurrentIsActive(false);
+      } else {
+        await client.enableEndpoint(endpoint.id);
+        setCurrentIsActive(true);
+      }
+      dispatch({ type: "TOGGLE_DONE", isActive: !currentIsActive });
+    } catch (err) {
+      dispatch({
+        type: "TOGGLE_ERROR",
+        message: err instanceof Error ? err.message : "Failed to update endpoint status.",
+      });
+    }
+  }, [client, currentIsActive, endpoint]);
+
+  const title = isEdit ? "Edit endpoint" : "New endpoint";
+
+  return (
+    /* Backdrop */
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose("cancelled");
+      }}
+      aria-hidden="false"
+    >
+      {/* Dialog */}
+      <div
+        ref={overlayRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="whe-editor-title"
+        className="relative flex w-full max-w-lg flex-col overflow-hidden rounded-2xl border border-whe-border bg-whe-bg-1 shadow-2xl max-h-[90dvh]"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-whe-border px-6 py-4">
+          <h2 id="whe-editor-title" className="text-base font-semibold text-whe-text-primary">
+            {title}
+          </h2>
+          <button
+            type="button"
+            onClick={() => onClose("cancelled")}
+            className="rounded-md p-1 text-whe-text-muted hover:text-whe-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-whe-accent"
+            aria-label="Close"
+          >
+            {/* X icon via CSS — no Lucide dep inside this package */}
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+              <path d="M12 4L4 12M4 4l8 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body — scrollable */}
+        <div className="overflow-y-auto px-6 py-5 space-y-5">
+          {/* Global error */}
+          {state.globalError && (
+            <p
+              role="alert"
+              className="rounded-lg bg-whe-danger-soft px-4 py-3 text-sm text-whe-danger"
+            >
+              {state.globalError}
+            </p>
+          )}
+
+          {/* URL */}
+          <Field
+            label="Endpoint URL"
+            htmlFor="whe-url"
+            error={state.fieldErrors["url"]}
+            required
+          >
+            <input
+              ref={firstFocusableRef}
+              id="whe-url"
+              type="url"
+              value={state.values.url}
+              onChange={(e) => dispatch({ type: "SET_FIELD", field: "url", value: e.target.value })}
+              disabled={!canWrite}
+              placeholder="https://your-app.com/webhooks"
+              className={inputClass(!!state.fieldErrors["url"], !canWrite)}
+              autoComplete="off"
+            />
+          </Field>
+
+          {/* Description */}
+          <Field label="Description" htmlFor="whe-desc" error={state.fieldErrors["description"]}>
+            <input
+              id="whe-desc"
+              type="text"
+              value={state.values.description}
+              onChange={(e) =>
+                dispatch({ type: "SET_FIELD", field: "description", value: e.target.value })
+              }
+              disabled={!canWrite}
+              placeholder="Optional — shown in the endpoint list"
+              className={inputClass(!!state.fieldErrors["description"], !canWrite)}
+            />
+          </Field>
+
+          {/* Filter event types */}
+          <Field label="Filter event types" htmlFor="whe-event-types">
+            {state.eventTypesLoading ? (
+              <div className="h-24 animate-pulse rounded-lg bg-whe-bg-3" />
+            ) : state.eventTypes.length === 0 ? (
+              <p className="text-xs text-whe-text-muted">No event types defined for this application.</p>
+            ) : (
+              <div className="flex flex-wrap gap-2">
+                {state.eventTypes.map((et) => {
+                  const selected = state.values.filterEventTypes.includes(et.id);
+                  return (
+                    <button
+                      key={et.id}
+                      type="button"
+                      disabled={!canWrite}
+                      onClick={() => dispatch({ type: "TOGGLE_EVENT_TYPE", id: et.id })}
+                      className={[
+                        "rounded-full border px-3 py-1 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-whe-accent",
+                        selected
+                          ? "border-whe-accent bg-whe-accent-soft text-whe-accent"
+                          : "border-whe-border bg-whe-bg-3 text-whe-text-secondary hover:border-whe-accent hover:text-whe-accent",
+                        !canWrite ? "cursor-not-allowed opacity-60" : "",
+                      ]
+                        .filter(Boolean)
+                        .join(" ")}
+                      aria-pressed={selected}
+                    >
+                      {et.name}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+            {state.values.filterEventTypes.length === 0 && (
+              <p className="mt-1 text-xs text-whe-text-muted">
+                No filters selected — all event types will be delivered.
+              </p>
+            )}
+          </Field>
+
+          {/* Custom headers */}
+          <Field label="Custom headers" htmlFor="whe-headers">
+            <div className="space-y-2">
+              {state.values.customHeaders.map((header, index) => (
+                <div key={index} className="flex gap-2">
+                  <input
+                    type="text"
+                    value={header.key}
+                    onChange={(e) =>
+                      dispatch({
+                        type: "UPDATE_HEADER",
+                        index,
+                        key: e.target.value,
+                        value: header.value,
+                      })
+                    }
+                    disabled={!canWrite}
+                    placeholder="Header name"
+                    className={`${inputClass(false, !canWrite)} flex-1`}
+                    aria-label={`Header ${index + 1} name`}
+                  />
+                  <input
+                    type="text"
+                    value={header.value}
+                    onChange={(e) =>
+                      dispatch({
+                        type: "UPDATE_HEADER",
+                        index,
+                        key: header.key,
+                        value: e.target.value,
+                      })
+                    }
+                    disabled={!canWrite}
+                    placeholder="Value"
+                    className={`${inputClass(false, !canWrite)} flex-1`}
+                    aria-label={`Header ${index + 1} value`}
+                  />
+                  {canWrite && (
+                    <button
+                      type="button"
+                      onClick={() => dispatch({ type: "REMOVE_HEADER", index })}
+                      className="shrink-0 rounded px-2 text-whe-text-muted hover:text-whe-danger focus:outline-none focus-visible:ring-1 focus-visible:ring-whe-danger"
+                      aria-label={`Remove header ${index + 1}`}
+                    >
+                      ×
+                    </button>
+                  )}
+                </div>
+              ))}
+              {canWrite && (
+                <button
+                  type="button"
+                  onClick={() => dispatch({ type: "ADD_HEADER" })}
+                  className="text-xs text-whe-accent hover:opacity-80 focus:outline-none focus-visible:ring-1 focus-visible:ring-whe-accent"
+                >
+                  + Add header
+                </button>
+              )}
+            </div>
+            {state.fieldErrors["customHeaders"] && (
+              <p className="mt-1 text-xs text-whe-danger">{state.fieldErrors["customHeaders"]}</p>
+            )}
+          </Field>
+
+          {/* Secret override (edit mode only) */}
+          {isEdit && (
+            <Field
+              label="Secret override"
+              htmlFor="whe-secret"
+              error={state.fieldErrors["secretOverride"]}
+              hint="Leave blank to keep the current signing secret. To rotate to a fully new secret, use the key-rotation flow from the operator dashboard instead."
+            >
+              <div className="relative">
+                <input
+                  id="whe-secret"
+                  type={state.showSecret ? "text" : "password"}
+                  value={state.values.secretOverride}
+                  onChange={(e) =>
+                    dispatch({
+                      type: "SET_FIELD",
+                      field: "secretOverride",
+                      value: e.target.value,
+                    })
+                  }
+                  disabled={!canWrite}
+                  placeholder="whsec_…"
+                  className={`${inputClass(!!state.fieldErrors["secretOverride"], !canWrite)} pr-16`}
+                  autoComplete="new-password"
+                />
+                <button
+                  type="button"
+                  onClick={() => dispatch({ type: "TOGGLE_SHOW_SECRET" })}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 rounded px-2 py-0.5 text-xs text-whe-text-muted hover:text-whe-text-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-whe-accent"
+                  aria-label={state.showSecret ? "Hide secret" : "Show secret"}
+                >
+                  {state.showSecret ? "Hide" : "Show"}
+                </button>
+              </div>
+            </Field>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between border-t border-whe-border px-6 py-4">
+          {/* Destructive actions (edit mode) */}
+          {isEdit && canWrite && (
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                disabled={state.toggling || state.saving || state.deleting}
+                onClick={() => void handleToggleActive()}
+                className="rounded-md border border-whe-border px-3 py-1.5 text-sm text-whe-text-secondary hover:border-whe-accent hover:text-whe-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-whe-accent disabled:opacity-50"
+              >
+                {state.toggling ? "…" : currentIsActive ? "Disable" : "Enable"}
+              </button>
+
+              {!state.showDeleteConfirm ? (
+                <button
+                  type="button"
+                  disabled={state.toggling || state.saving || state.deleting}
+                  onClick={() => dispatch({ type: "TOGGLE_DELETE_CONFIRM" })}
+                  className="rounded-md border border-whe-danger/30 px-3 py-1.5 text-sm text-whe-danger hover:border-whe-danger focus:outline-none focus-visible:ring-2 focus-visible:ring-whe-danger disabled:opacity-50"
+                >
+                  Delete
+                </button>
+              ) : (
+                <span className="flex items-center gap-2">
+                  <span className="text-xs text-whe-text-secondary">Confirm?</span>
+                  <button
+                    type="button"
+                    disabled={state.deleting}
+                    onClick={() => void handleDelete()}
+                    className="rounded-md bg-whe-danger px-3 py-1.5 text-sm font-medium text-white hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-whe-danger disabled:opacity-50"
+                  >
+                    {state.deleting ? "Deleting…" : "Yes, delete"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => dispatch({ type: "TOGGLE_DELETE_CONFIRM" })}
+                    className="rounded-md px-3 py-1.5 text-sm text-whe-text-secondary hover:text-whe-text-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-whe-accent"
+                  >
+                    Cancel
+                  </button>
+                </span>
+              )}
+            </div>
+          )}
+
+          {/* Right side — close + save */}
+          <div className={`flex items-center gap-2 ${isEdit && canWrite ? "" : "ml-auto"}`}>
+            <button
+              type="button"
+              onClick={() => onClose("cancelled")}
+              className="rounded-md px-4 py-2 text-sm text-whe-text-secondary hover:text-whe-text-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-whe-accent"
+            >
+              Cancel
+            </button>
+            {canWrite && (
+              <button
+                type="button"
+                disabled={state.saving || state.deleting || state.toggling}
+                onClick={() => void handleSave()}
+                className="rounded-md bg-whe-accent px-4 py-2 text-sm font-medium text-whe-bg-0 hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-whe-accent disabled:opacity-50"
+              >
+                {state.saving ? "Saving…" : "Save"}
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// Internal helper components.
+
+interface FieldProps {
+  label: string;
+  htmlFor: string;
+  error?: string;
+  hint?: string;
+  required?: boolean;
+  children: React.ReactNode;
+}
+
+function Field({ label, htmlFor, error, hint, required, children }: FieldProps): JSX.Element {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label
+        htmlFor={htmlFor}
+        className="text-xs font-medium text-whe-text-secondary"
+      >
+        {label}
+        {required && <span className="ml-0.5 text-whe-danger" aria-hidden="true">*</span>}
+      </label>
+      {children}
+      {hint && <p className="text-xs text-whe-text-muted">{hint}</p>}
+      {error && (
+        <p role="alert" className="text-xs text-whe-danger">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function inputClass(hasError: boolean, disabled: boolean): string {
+  return [
+    "w-full rounded-lg border bg-whe-bg-3 px-3 py-2 text-sm text-whe-text-primary placeholder:text-whe-text-muted",
+    "focus:outline-none focus-visible:ring-2",
+    hasError
+      ? "border-whe-danger focus-visible:ring-whe-danger"
+      : "border-whe-border focus-visible:ring-whe-accent",
+    disabled ? "cursor-not-allowed opacity-60" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+}

--- a/packages/endpoint-manager/src/components/EndpointList.tsx
+++ b/packages/endpoint-manager/src/components/EndpointList.tsx
@@ -1,0 +1,336 @@
+import { useCallback, useEffect, useReducer } from "react";
+import type { JSX } from "react";
+import type { PortalCapability, PortalEndpointSummary } from "../types.js";
+import type { PortalClient, PortalPagination } from "../api/createPortalClient.js";
+
+interface EndpointListProps {
+  client: PortalClient;
+  appId: string;
+  capabilities: PortalCapability[];
+  onEditEndpoint: (endpoint: PortalEndpointSummary) => void;
+  onNewEndpoint: () => void;
+}
+
+interface ListState {
+  endpoints: PortalEndpointSummary[];
+  pagination: PortalPagination | null;
+  page: number;
+  loading: boolean;
+  error: string | null;
+  togglingId: string | null;
+  deletingId: string | null;
+}
+
+type ListAction =
+  | { type: "FETCH_START" }
+  | { type: "FETCH_SUCCESS"; endpoints: PortalEndpointSummary[]; pagination: PortalPagination }
+  | { type: "FETCH_ERROR"; message: string }
+  | { type: "SET_PAGE"; page: number }
+  | { type: "TOGGLE_START"; id: string }
+  | { type: "TOGGLE_DONE"; id: string; isActive: boolean }
+  | { type: "TOGGLE_ERROR"; id: string }
+  | { type: "DELETE_START"; id: string }
+  | { type: "DELETE_DONE"; id: string }
+  | { type: "DELETE_ERROR"; id: string };
+
+function listReducer(state: ListState, action: ListAction): ListState {
+  switch (action.type) {
+    case "FETCH_START":
+      return { ...state, loading: true, error: null };
+    case "FETCH_SUCCESS":
+      return {
+        ...state,
+        loading: false,
+        endpoints: action.endpoints,
+        pagination: action.pagination,
+      };
+    case "FETCH_ERROR":
+      return { ...state, loading: false, error: action.message };
+    case "SET_PAGE":
+      return { ...state, page: action.page };
+    case "TOGGLE_START":
+      return { ...state, togglingId: action.id };
+    case "TOGGLE_DONE":
+      return {
+        ...state,
+        togglingId: null,
+        endpoints: state.endpoints.map((e) =>
+          e.id === action.id ? { ...e, isActive: action.isActive } : e,
+        ),
+      };
+    case "TOGGLE_ERROR":
+      return { ...state, togglingId: null };
+    case "DELETE_START":
+      return { ...state, deletingId: action.id };
+    case "DELETE_DONE":
+      return {
+        ...state,
+        deletingId: null,
+        endpoints: state.endpoints.filter((e) => e.id !== action.id),
+      };
+    case "DELETE_ERROR":
+      return { ...state, deletingId: null };
+  }
+}
+
+const PAGE_SIZE = 20;
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function truncateUrl(url: string, max = 48): string {
+  if (url.length <= max) return url;
+  return url.slice(0, max) + "…";
+}
+
+export function EndpointList({
+  client,
+  capabilities,
+  onEditEndpoint,
+  onNewEndpoint,
+}: EndpointListProps): JSX.Element {
+  const canWrite = capabilities.includes("endpoints:write");
+
+  const [state, dispatch] = useReducer(listReducer, {
+    endpoints: [],
+    pagination: null,
+    page: 1,
+    loading: true,
+    error: null,
+    togglingId: null,
+    deletingId: null,
+  });
+
+  const fetchPage = useCallback(
+    async (page: number) => {
+      dispatch({ type: "FETCH_START" });
+      try {
+        const result = await client.listEndpoints({ page, pageSize: PAGE_SIZE });
+        dispatch({
+          type: "FETCH_SUCCESS",
+          endpoints: result.data,
+          pagination: result.pagination,
+        });
+      } catch (err) {
+        dispatch({
+          type: "FETCH_ERROR",
+          message: err instanceof Error ? err.message : "Failed to load endpoints.",
+        });
+      }
+    },
+    [client],
+  );
+
+  useEffect(() => {
+    void fetchPage(state.page);
+  }, [fetchPage, state.page]);
+
+  const handleToggle = async (endpoint: PortalEndpointSummary) => {
+    dispatch({ type: "TOGGLE_START", id: endpoint.id });
+    try {
+      if (endpoint.isActive) {
+        await client.disableEndpoint(endpoint.id);
+        dispatch({ type: "TOGGLE_DONE", id: endpoint.id, isActive: false });
+      } else {
+        await client.enableEndpoint(endpoint.id);
+        dispatch({ type: "TOGGLE_DONE", id: endpoint.id, isActive: true });
+      }
+    } catch {
+      dispatch({ type: "TOGGLE_ERROR", id: endpoint.id });
+    }
+  };
+
+  const handleDelete = async (endpoint: PortalEndpointSummary) => {
+    if (!window.confirm(`Delete endpoint "${endpoint.url}"? This cannot be undone.`)) return;
+    dispatch({ type: "DELETE_START", id: endpoint.id });
+    try {
+      await client.deleteEndpoint(endpoint.id);
+      dispatch({ type: "DELETE_DONE", id: endpoint.id });
+    } catch {
+      dispatch({ type: "DELETE_ERROR", id: endpoint.id });
+    }
+  };
+
+  const totalPages =
+    state.pagination ? Math.max(1, Math.ceil(state.pagination.total / PAGE_SIZE)) : 1;
+
+  if (state.loading && state.endpoints.length === 0) {
+    return (
+      <div className="animate-pulse space-y-3 p-4">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-12 rounded-lg bg-whe-bg-3" />
+        ))}
+      </div>
+    );
+  }
+
+  if (state.error) {
+    return (
+      <div className="flex flex-col items-center gap-4 py-16 text-center">
+        <p className="text-whe-danger text-sm">{state.error}</p>
+        <button
+          type="button"
+          onClick={() => void fetchPage(state.page)}
+          className="rounded-md bg-whe-accent px-4 py-2 text-sm font-medium text-whe-bg-0 hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-whe-accent"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h2 className="text-base font-semibold text-whe-text-primary">Endpoints</h2>
+        {canWrite && (
+          <button
+            type="button"
+            onClick={onNewEndpoint}
+            className="inline-flex items-center gap-1.5 rounded-md bg-whe-accent px-3 py-1.5 text-sm font-medium text-whe-bg-0 hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-whe-accent"
+          >
+            <span aria-hidden="true">+</span>
+            New endpoint
+          </button>
+        )}
+      </div>
+
+      {/* Empty state */}
+      {state.endpoints.length === 0 ? (
+        <div className="flex flex-col items-center gap-4 rounded-xl border border-whe-border bg-whe-bg-2 py-16 text-center">
+          <p className="text-sm text-whe-text-secondary">No endpoints yet.</p>
+          {canWrite && (
+            <button
+              type="button"
+              onClick={onNewEndpoint}
+              className="rounded-md bg-whe-accent px-4 py-2 text-sm font-medium text-whe-bg-0 hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-whe-accent"
+            >
+              Create your first endpoint
+            </button>
+          )}
+        </div>
+      ) : (
+        <>
+          {/* Table */}
+          <div className="overflow-x-auto rounded-xl border border-whe-border bg-whe-bg-2">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-whe-border text-left text-xs text-whe-text-muted">
+                  <th className="px-4 py-3 font-medium">URL</th>
+                  <th className="hidden px-4 py-3 font-medium sm:table-cell">Description</th>
+                  <th className="px-4 py-3 font-medium">Status</th>
+                  <th className="hidden px-4 py-3 font-medium md:table-cell">Event types</th>
+                  <th className="hidden px-4 py-3 font-medium lg:table-cell">Created</th>
+                  {canWrite && <th className="px-4 py-3" />}
+                </tr>
+              </thead>
+              <tbody>
+                {state.endpoints.map((endpoint) => {
+                  const isToggling = state.togglingId === endpoint.id;
+                  const isDeleting = state.deletingId === endpoint.id;
+                  return (
+                    <tr
+                      key={endpoint.id}
+                      className="group cursor-pointer border-b border-whe-border-subtle last:border-0 hover:bg-whe-bg-3 transition-colors"
+                      onClick={() => onEditEndpoint(endpoint)}
+                    >
+                      <td className="px-4 py-3 font-mono text-xs text-whe-text-primary">
+                        {truncateUrl(endpoint.url)}
+                      </td>
+                      <td className="hidden px-4 py-3 text-whe-text-secondary sm:table-cell">
+                        {endpoint.description ?? (
+                          <span className="text-whe-text-muted">—</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3">
+                        {endpoint.isActive ? (
+                          <span className="inline-flex items-center gap-1 rounded-full bg-whe-success-soft px-2 py-0.5 text-xs font-medium text-whe-success">
+                            <span className="h-1.5 w-1.5 rounded-full bg-whe-success" aria-hidden="true" />
+                            Active
+                          </span>
+                        ) : (
+                          <span className="inline-flex items-center gap-1 rounded-full bg-whe-bg-3 px-2 py-0.5 text-xs font-medium text-whe-text-muted">
+                            <span className="h-1.5 w-1.5 rounded-full bg-whe-text-muted" aria-hidden="true" />
+                            Disabled
+                          </span>
+                        )}
+                      </td>
+                      <td className="hidden px-4 py-3 text-whe-text-secondary md:table-cell">
+                        {endpoint.filterEventTypes.length === 0 ? (
+                          <span className="text-whe-text-muted">All</span>
+                        ) : (
+                          <span>{endpoint.filterEventTypes.length} filter{endpoint.filterEventTypes.length !== 1 ? "s" : ""}</span>
+                        )}
+                      </td>
+                      <td className="hidden px-4 py-3 text-whe-text-muted lg:table-cell">
+                        {formatDate(endpoint.createdAt)}
+                      </td>
+                      {canWrite && (
+                        <td
+                          className="px-4 py-3"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <div className="flex items-center gap-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
+                            <button
+                              type="button"
+                              disabled={isToggling || isDeleting}
+                              onClick={() => void handleToggle(endpoint)}
+                              className="rounded px-2 py-1 text-xs text-whe-text-secondary hover:text-whe-text-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-whe-accent disabled:opacity-50"
+                              aria-label={endpoint.isActive ? "Disable endpoint" : "Enable endpoint"}
+                            >
+                              {isToggling ? "…" : endpoint.isActive ? "Disable" : "Enable"}
+                            </button>
+                            <button
+                              type="button"
+                              disabled={isToggling || isDeleting}
+                              onClick={() => void handleDelete(endpoint)}
+                              className="rounded px-2 py-1 text-xs text-whe-danger hover:text-whe-danger focus:outline-none focus-visible:ring-1 focus-visible:ring-whe-danger disabled:opacity-50"
+                              aria-label="Delete endpoint"
+                            >
+                              {isDeleting ? "…" : "Delete"}
+                            </button>
+                          </div>
+                        </td>
+                      )}
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <div className="flex items-center justify-between text-sm text-whe-text-secondary">
+              <button
+                type="button"
+                disabled={state.page <= 1 || state.loading}
+                onClick={() => dispatch({ type: "SET_PAGE", page: state.page - 1 })}
+                className="rounded px-3 py-1.5 hover:bg-whe-bg-3 disabled:opacity-40 focus:outline-none focus-visible:ring-1 focus-visible:ring-whe-accent"
+              >
+                Previous
+              </button>
+              <span className="text-xs text-whe-text-muted">
+                Page {state.page} of {totalPages}
+              </span>
+              <button
+                type="button"
+                disabled={state.page >= totalPages || state.loading}
+                onClick={() => dispatch({ type: "SET_PAGE", page: state.page + 1 })}
+                className="rounded px-3 py-1.5 hover:bg-whe-bg-3 disabled:opacity-40 focus:outline-none focus-visible:ring-1 focus-visible:ring-whe-accent"
+              >
+                Next
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/endpoint-manager/src/index.ts
+++ b/packages/endpoint-manager/src/index.ts
@@ -1,8 +1,25 @@
 export { EndpointManager } from "./EndpointManager.js";
+export { EndpointList } from "./components/EndpointList.js";
+export { EndpointEditor } from "./components/EndpointEditor.js";
+export { createPortalClient, PortalError } from "./api/createPortalClient.js";
+
 export type {
   EndpointManagerProps,
   PortalCapability,
   PortalAppState,
   PortalEndpointSummary,
-  PortalAttempt
+  PortalEndpointDetail,
+  PortalEventTypeListItem,
+  PortalCreateEndpointInput,
+  PortalUpdateEndpointInput,
+  PortalAttempt,
 } from "./types.js";
+
+export type {
+  PortalClient,
+  PortalClientOptions,
+  PortalListResult,
+  PortalPagination,
+} from "./api/createPortalClient.js";
+
+export type { EditorMode } from "./components/EndpointEditor.js";

--- a/packages/endpoint-manager/src/styles.css
+++ b/packages/endpoint-manager/src/styles.css
@@ -1,0 +1,30 @@
+@import "tailwindcss";
+
+@source "../src/**/*.{ts,tsx}";
+
+/* Theme tokens — consumers override at :root or .whe-portal scope */
+@theme {
+  --color-whe-bg-0: #09090b;
+  --color-whe-bg-1: #0f0f12;
+  --color-whe-bg-2: #18181b;
+  --color-whe-bg-3: #27272a;
+  --color-whe-text-primary: #fafafa;
+  --color-whe-text-secondary: #a1a1aa;
+  --color-whe-text-muted: #71717a;
+  --color-whe-border: #27272a;
+  --color-whe-border-subtle: #1e1e22;
+  --color-whe-accent: #06b6d4;
+  --color-whe-accent-soft: rgb(6 182 212 / 0.15);
+  --color-whe-success: #22c55e;
+  --color-whe-success-soft: rgb(34 197 94 / 0.15);
+  --color-whe-danger: #ef4444;
+  --color-whe-danger-soft: rgb(239 68 68 / 0.15);
+  --color-whe-warning: #f59e0b;
+  --color-whe-warning-soft: rgb(245 158 11 / 0.15);
+}
+
+/* Scope all package styles under .whe-portal so consumer page styles are not touched */
+.whe-portal {
+  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+  color: var(--color-whe-text-primary);
+}

--- a/packages/endpoint-manager/src/types.ts
+++ b/packages/endpoint-manager/src/types.ts
@@ -17,6 +17,25 @@ export interface PortalEndpointSummary {
   isActive: boolean;
   hasSecretOverride: boolean;
   filterEventTypes: string[];
+  createdAt: string;
+}
+
+export interface PortalEndpointDetail {
+  id: string;
+  url: string;
+  description: string | null;
+  isActive: boolean;
+  hasSecretOverride: boolean;
+  filterEventTypes: string[];
+  customHeaders: Record<string, string>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PortalEventTypeListItem {
+  id: string;
+  name: string;
+  description: string | null;
 }
 
 export interface PortalAttempt {
@@ -29,11 +48,29 @@ export interface PortalAttempt {
   responseBody: string | null;
 }
 
+export interface PortalCreateEndpointInput {
+  url: string;
+  description?: string | null;
+  filterEventTypes?: string[];
+  customHeaders?: Record<string, string>;
+  secretOverride?: string | null;
+}
+
+export interface PortalUpdateEndpointInput {
+  url: string;
+  description?: string | null;
+  filterEventTypes?: string[];
+  customHeaders?: Record<string, string>;
+  secretOverride?: string | null;
+}
+
 export interface EndpointManagerProps {
   baseUrl: string;
   token: string;
   appId: string;
+  capabilities?: PortalCapability[];
   theme?: "dark" | "light" | "system";
   className?: string;
   onError?: (error: Error) => void;
+  onUnauthorized?: () => void;
 }

--- a/packages/endpoint-manager/vitest.config.ts
+++ b/packages/endpoint-manager/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "happy-dom",
+    globals: true,
+    setupFiles: ["./src/__tests__/setup.ts"],
+  },
+  esbuild: {
+    jsx: "automatic",
+  },
+});


### PR DESCRIPTION
## Summary

**Step 8 of the B1 (embeddable customer portal) plan.** First set of real React components for `@webhookengine/endpoint-manager` — the npm package skeleton landed in Step 7. `<EndpointTester />` and `<AttemptList />` ship in Step 9.

## What lands

### `createPortalClient` (`src/api/createPortalClient.ts`)

Fetch wrapper, **zero runtime deps**. Bearer auth, `ApiEnvelope` unwrap, 4xx/5xx → `PortalError` with `code` + `status` + `fieldErrors`, 401 hooks `onUnauthorized` for token re-mint flows, 204 returns `void`, list calls flatten `meta.pagination` into `PortalListResult<T>`. The `fetch` parameter is dependency-injected so tests pass a mockFetch.

Public surface: `listEndpoints`, `getEndpoint`, `createEndpoint`, `updateEndpoint`, `deleteEndpoint`, `enableEndpoint`, `disableEndpoint`, `listEventTypes`. `testEndpoint` + `listAttempts` are stubbed with "Not implemented yet — lands in B1 Step 9" so the contract is locked.

### Components

- **`<EndpointList />`** — paginated table, status badges, capability-gated `[+ New endpoint]` + per-row Edit/Enable/Disable/Delete, click-to-edit, loading/empty/error states. Internal `useState` (no TanStack Query inside the package — caching belongs to the consumer).
- **`<EndpointEditor />`** — modal-style overlay with URL/description/customHeaders/secretOverride/event-type filter fields. **Field-narrowing enforced at the DTO level** (no `transformExpression` / `allowedIpsJson` in the request body). secretOverride field requires `whsec_` prefix + 32+ chars client-side. Server fieldErrors route to per-field inline messages. Modal a11y inlined (role=dialog, aria-modal, focus trap, Escape closes, body scroll lock) — duplicates `Modal.tsx` in the dashboard, but the zero-runtime-deps rule blocks importing.
- **`<EndpointManager />` wrapper** — replaces the Step 7 placeholder, instantiates `createPortalClient` via `useMemo`, wraps everything in `<div className="whe-portal">` for CSS scoping.

### Tailwind 4 internal compile pipeline

- Separate `bun run build:css` using `@tailwindcss/cli` — simplest tsup-independent path.
- `bun run build` composite: `tsup && bun run build:css` (tsup-first because `clean: true` would wipe the CSS otherwise; flagged for refactor — see trade-off below).
- `src/styles.css` — `@import "tailwindcss"` + `@theme` block defining `--color-whe-bg-*` / `--color-whe-text-*` / `--color-whe-border` / `--color-whe-accent` / `--color-whe-success` / `--color-whe-danger` / `--color-whe-warning` tokens. Consumers override at `:root` or `.whe-portal` scope.
- The `.whe-portal` wrapper is the **load-bearing scoping mechanism** so consumer page styles can't leak in and our utilities can't leak out.

### vitest setup

- happy-dom environment, `@testing-library/react` + `@testing-library/user-event` + `@testing-library/jest-dom`.
- `mockFetch.ts` helper — URL-pattern → handler registry returning a `(input, init) => Promise<Response>` typed as `fetch`.
- **23 tests across 3 files, all passing in 787ms:**
  - `createPortalClient.test.ts` (11): GET/POST/PUT/DELETE happy paths, 401 → `onUnauthorized`, 422 → `fieldErrors`, 204 → `void`, pagination shape, error envelope parsing.
  - `EndpointList.test.tsx` (5): renders rows from a mocked client, hides `[+ New endpoint]` when capabilities lacks `endpoints:write`, shows empty state at 0 endpoints.
  - `EndpointEditor.test.tsx` (7): create form posts the right body (no `transformExpression` / no `allowedIpsJson`), edit form pre-fills, secret override field rejects `password123`, delete fires confirm + DELETE, 422 fieldErrors render inline.

### Demo harness

`packages/endpoint-manager/demo/{index.html, main.tsx, vite.config.ts}` — standalone Vite dev server (`bun run dev` → `localhost:5173`) that imports `<EndpointManager />` from `src/` directly, monkey-patches `globalThis.fetch` with an in-memory 3-endpoint fixture. HMR works against `src/`. `dist/style.css` must be built once (`bun run build`) before first demo boot.

## Bundle size (target was <25 KB gz total)

| Asset | Raw | gzip est. |
|---|---|---|
| `dist/index.js` | 43.4 KB | **8.7 KB** |
| `dist/style.css` | 16.0 KB | **3.9 KB** |
| **Total** | **59.4 KB** | **~12.6 KB gz** — half the budget |

Tailwind 4's `@theme` block expands into CSS custom-property definitions which is why `style.css` is ~16 KB raw; gzip handles it well.

## Trade-off worth a second look

**Build sequence: `tsup → build:css` (current) vs `build:css → tsup` (more intuitive).**

Today, tsup runs first and writes `dist/`, then `build:css` appends `dist/style.css`. This works around tsup's `clean: true` (which would wipe a CSS file written before tsup runs). The cost: a future contributor who flips the script order will silently lose their CSS. The fix would be `clean: false` on tsup + an explicit `clean` script that runs at the start. Worth flagging for Step 9.

## What does NOT land (Step 9+)

- `<EndpointTester />` + `<AttemptList />` (Step 9)
- `testEndpoint` + `listAttempts` real implementations on `PortalClient` (currently stub-throws)
- `publish-portal.yml` + `samples/portal-host/` (Step 10)
- npm publish — `private: true` stays until Step 11

## Test plan

- [x] `bun run lint`, `typecheck`, `build` clean
- [x] `bun run test` → 23 passed
- [x] `bun run dev` boots the demo at `localhost:5173`
- [ ] CI green