### PR TITLE
feat(npm): EndpointTester + AttemptList + portal client testEndpoint/listAttempts (B1 Step 9)

### DIFF
--- a/packages/endpoint-manager/demo/main.tsx
+++ b/packages/endpoint-manager/demo/main.tsx
@@ -1,7 +1,13 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { EndpointManager } from "../src/index.js";
-import type { PortalEndpointSummary, PortalEndpointDetail, PortalEventTypeListItem } from "../src/types.js";
+import type {
+  PortalEndpointSummary,
+  PortalEndpointDetail,
+  PortalEventTypeListItem,
+  PortalAttempt,
+  PortalTestResult,
+} from "../src/types.js";
 import type { PortalListResult } from "../src/api/createPortalClient.js";
 
 // ---------------------------------------------------------------------------
@@ -51,6 +57,86 @@ const EVENT_TYPES: PortalEventTypeListItem[] = [
   { id: "et-4", name: "payment.failed", description: null },
 ];
 
+// Synthetic attempt history — mix of success/failure, various latencies.
+const ATTEMPTS_STORE: Record<string, PortalAttempt[]> = {
+  "ep-1": [
+    {
+      id: "att-1",
+      messageId: "msg-001",
+      attemptNumber: 1,
+      status: "success",
+      statusCode: 200,
+      error: null,
+      latencyMs: 124,
+      createdAt: new Date(Date.now() - 1000 * 60 * 5).toISOString(),
+    },
+    {
+      id: "att-2",
+      messageId: "msg-002",
+      attemptNumber: 1,
+      status: "failure",
+      statusCode: 503,
+      error: "Service temporarily unavailable",
+      latencyMs: 3001,
+      createdAt: new Date(Date.now() - 1000 * 60 * 30).toISOString(),
+    },
+    {
+      id: "att-3",
+      messageId: "msg-002",
+      attemptNumber: 2,
+      status: "success",
+      statusCode: 200,
+      error: null,
+      latencyMs: 89,
+      createdAt: new Date(Date.now() - 1000 * 60 * 25).toISOString(),
+    },
+    {
+      id: "att-4",
+      messageId: "msg-003",
+      attemptNumber: 1,
+      status: "failure",
+      statusCode: null,
+      error: "connect ECONNREFUSED 203.0.113.42:443",
+      latencyMs: 5000,
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(),
+    },
+    {
+      id: "att-5",
+      messageId: "msg-004",
+      attemptNumber: 1,
+      status: "success",
+      statusCode: 201,
+      error: null,
+      latencyMs: 201,
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 5).toISOString(),
+    },
+    {
+      id: "att-6",
+      messageId: "msg-005",
+      attemptNumber: 1,
+      status: "failure",
+      statusCode: 404,
+      error: "Not Found",
+      latencyMs: 55,
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 8).toISOString(),
+    },
+    {
+      id: "att-7",
+      messageId: "msg-006",
+      attemptNumber: 1,
+      status: "success",
+      statusCode: 200,
+      error: null,
+      latencyMs: 310,
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(),
+    },
+  ],
+};
+
+function getAttempts(endpointId: string): PortalAttempt[] {
+  return ATTEMPTS_STORE[endpointId] ?? [];
+}
+
 function toSummary(d: PortalEndpointDetail): PortalEndpointSummary {
   return {
     id: d.id,
@@ -85,7 +171,60 @@ function mockFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Respon
     return ok(EVENT_TYPES);
   }
 
-  // GET /api/v1/portal/endpoints/:id/enable or /disable
+  // POST /api/v1/portal/endpoints/:id/test
+  const testMatch = url.match(/\/endpoints\/([^/]+)\/test$/);
+  if (method === "POST" && testMatch) {
+    const id = testMatch[1]!;
+    const ep = store.find((e) => e.id === id);
+    if (!ep) {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ error: { code: "PORTAL_NOT_FOUND", message: "Not found" }, meta: {} }),
+          { status: 404, headers: { "content-type": "application/json" } },
+        ),
+      );
+    }
+    const result: PortalTestResult = {
+      success: true,
+      statusCode: 200,
+      latencyMs: 87,
+      responseBody: "ok",
+      error: null,
+      request: {
+        url: ep.url,
+        headers: {
+          "webhook-id": `msg_${Math.random().toString(36).slice(2, 10)}`,
+          "webhook-timestamp": String(Math.floor(Date.now() / 1000)),
+          "webhook-signature": `v1,${btoa("demo-signature-placeholder")}`,
+          "Content-Type": "application/json",
+        },
+        body: init?.body as string ?? "{}",
+      },
+    };
+    return ok(result);
+  }
+
+  // GET /api/v1/portal/endpoints/:id/attempts
+  const attemptsMatch = url.match(/\/endpoints\/([^/]+)\/attempts/);
+  if (method === "GET" && attemptsMatch) {
+    const id = attemptsMatch[1]!;
+    const params = new URL(url).searchParams;
+    const page = parseInt(params.get("page") ?? "1", 10);
+    const pageSize = parseInt(params.get("pageSize") ?? "20", 10);
+    const all = getAttempts(id);
+    const sliced = all.slice((page - 1) * pageSize, page * pageSize);
+    return Promise.resolve(
+      new Response(
+        JSON.stringify({
+          data: sliced,
+          meta: { pagination: { page, pageSize, total: all.length } },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+  }
+
+  // POST /api/v1/portal/endpoints/:id/enable
   const enableMatch = url.match(/\/endpoints\/([^/]+)\/enable$/);
   if (method === "POST" && enableMatch) {
     const id = enableMatch[1]!;
@@ -94,6 +233,7 @@ function mockFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Respon
     return noContent();
   }
 
+  // POST /api/v1/portal/endpoints/:id/disable
   const disableMatch = url.match(/\/endpoints\/([^/]+)\/disable$/);
   if (method === "POST" && disableMatch) {
     const id = disableMatch[1]!;
@@ -102,7 +242,7 @@ function mockFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Respon
     return noContent();
   }
 
-  // GET /api/v1/portal/endpoints/:id
+  // GET /api/v1/portal/endpoints/:id (single)
   const singleMatch = url.match(/\/endpoints\/([^/?]+)$/);
   if (method === "GET" && singleMatch) {
     const ep = store.find((e) => e.id === singleMatch[1]);
@@ -174,6 +314,10 @@ function mockFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Respon
   return Promise.resolve(new Response(null, { status: 404 }));
 }
 
+// Type alias just to keep the cast clean.
+type ListResult<T> = PortalListResult<T>;
+void (null as unknown as ListResult<unknown>);
+
 // ---------------------------------------------------------------------------
 // App
 // ---------------------------------------------------------------------------
@@ -183,10 +327,8 @@ function App() {
       baseUrl="http://localhost:0000"
       token="demo-token"
       appId="00000000-0000-0000-0000-000000000000"
-      capabilities={["endpoints:read", "endpoints:write"]}
+      capabilities={["endpoints:read", "endpoints:write", "endpoints:test", "attempts:read"]}
       // Inject the mock fetch so no real HTTP is made.
-      // EndpointManager exposes fetch injection via createPortalClient internally —
-      // for the demo we monkey-patch globalThis.fetch before the component mounts.
     />
   );
 }

--- a/packages/endpoint-manager/package.json
+++ b/packages/endpoint-manager/package.json
@@ -27,7 +27,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsup && bun run build:css",
+    "build": "bun run clean && bun run build:css && tsup",
     "build:css": "tailwindcss -i src/styles.css -o dist/style.css --minify",
     "dev": "vite --config demo/vite.config.ts",
     "typecheck": "tsc --noEmit",

--- a/packages/endpoint-manager/src/__tests__/AttemptList.test.tsx
+++ b/packages/endpoint-manager/src/__tests__/AttemptList.test.tsx
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AttemptList } from "../components/AttemptList.js";
+import type { PortalClient, PortalListResult } from "../api/createPortalClient.js";
+import type { PortalAttempt, PortalEndpointSummary } from "../types.js";
+
+const ENDPOINT: PortalEndpointSummary = {
+  id: "ep-1",
+  url: "https://consumer.example.com/hooks",
+  description: "Test endpoint",
+  isActive: true,
+  hasSecretOverride: false,
+  filterEventTypes: [],
+  createdAt: "2026-01-01T00:00:00Z",
+};
+
+function makeAttempt(overrides: Partial<PortalAttempt> = {}): PortalAttempt {
+  return {
+    id: "att-1",
+    messageId: "msg-1",
+    attemptNumber: 1,
+    status: "success",
+    statusCode: 200,
+    error: null,
+    latencyMs: 142,
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeClient(overrides: Partial<PortalClient> = {}): PortalClient {
+  return {
+    listEndpoints: vi.fn(),
+    getEndpoint: vi.fn(),
+    createEndpoint: vi.fn(),
+    updateEndpoint: vi.fn(),
+    deleteEndpoint: vi.fn(),
+    enableEndpoint: vi.fn(),
+    disableEndpoint: vi.fn(),
+    listEventTypes: vi.fn(),
+    testEndpoint: vi.fn(),
+    listAttempts: vi.fn().mockResolvedValue({
+      data: [makeAttempt()],
+      pagination: { page: 1, pageSize: 20, total: 1 },
+    } satisfies PortalListResult<PortalAttempt>),
+    ...overrides,
+  };
+}
+
+describe("AttemptList", () => {
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders attempt rows from client.listAttempts", async () => {
+    const client = makeClient();
+    render(
+      <AttemptList
+        client={client}
+        endpoint={ENDPOINT}
+        capabilities={["attempts:read"]}
+        onClose={onClose}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText("200")).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/142 ms/i)).toBeInTheDocument();
+  });
+
+  it("status badge is green for Success, red for Failure", async () => {
+    const client = makeClient({
+      listAttempts: vi.fn().mockResolvedValue({
+        data: [
+          makeAttempt({ id: "att-1", status: "success" }),
+          makeAttempt({ id: "att-2", status: "failure", statusCode: 500 }),
+        ],
+        pagination: { page: 1, pageSize: 20, total: 2 },
+      }),
+    });
+    render(
+      <AttemptList
+        client={client}
+        endpoint={ENDPOINT}
+        capabilities={["attempts:read"]}
+        onClose={onClose}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("Success")).toBeInTheDocument());
+    expect(screen.getByText("Failure")).toBeInTheDocument();
+
+    const successBadge = screen.getByText("Success").closest("span");
+    const failureBadge = screen.getByText("Failure").closest("span");
+
+    expect(successBadge?.className).toContain("whe-success");
+    expect(failureBadge?.className).toContain("whe-danger");
+  });
+
+  it("Previous is disabled on page 1", async () => {
+    const client = makeClient({
+      listAttempts: vi.fn().mockResolvedValue({
+        data: Array.from({ length: 20 }, (_, i) =>
+          makeAttempt({ id: `att-${i}`, attemptNumber: i + 1 }),
+        ),
+        pagination: { page: 1, pageSize: 20, total: 50 },
+      }),
+    });
+    render(
+      <AttemptList
+        client={client}
+        endpoint={ENDPOINT}
+        capabilities={["attempts:read"]}
+        onClose={onClose}
+      />,
+    );
+
+    await waitFor(() => screen.getByRole("button", { name: /Previous/i }));
+    expect(screen.getByRole("button", { name: /Previous/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /Next/i })).not.toBeDisabled();
+  });
+
+  it("Next is disabled on the last page", async () => {
+    const user = userEvent.setup();
+    const listAttempts = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: Array.from({ length: 20 }, (_, i) =>
+          makeAttempt({ id: `att-${i}`, attemptNumber: i + 1 }),
+        ),
+        pagination: { page: 1, pageSize: 20, total: 25 },
+      })
+      .mockResolvedValueOnce({
+        data: Array.from({ length: 5 }, (_, i) =>
+          makeAttempt({ id: `att-page2-${i}`, attemptNumber: i + 21 }),
+        ),
+        pagination: { page: 2, pageSize: 20, total: 25 },
+      });
+
+    const client = makeClient({ listAttempts });
+    render(
+      <AttemptList
+        client={client}
+        endpoint={ENDPOINT}
+        capabilities={["attempts:read"]}
+        onClose={onClose}
+      />,
+    );
+
+    await waitFor(() => screen.getByRole("button", { name: /Next/i }));
+    await user.click(screen.getByRole("button", { name: /Next/i }));
+    await waitFor(() => expect(listAttempts).toHaveBeenCalledTimes(2));
+
+    expect(screen.getByRole("button", { name: /Next/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /Previous/i })).not.toBeDisabled();
+  });
+
+  it("renders empty state when 0 attempts are returned", async () => {
+    const client = makeClient({
+      listAttempts: vi.fn().mockResolvedValue({
+        data: [],
+        pagination: { page: 1, pageSize: 20, total: 0 },
+      }),
+    });
+    render(
+      <AttemptList
+        client={client}
+        endpoint={ENDPOINT}
+        capabilities={["attempts:read"]}
+        onClose={onClose}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/No delivery attempts recorded/i),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("renders capability banner when attempts:read is missing", async () => {
+    const client = makeClient();
+    render(
+      <AttemptList
+        client={client}
+        endpoint={ENDPOINT}
+        capabilities={["endpoints:read"]}
+        onClose={onClose}
+      />,
+    );
+
+    expect(screen.getByText(/Capability required/i)).toBeInTheDocument();
+    expect(screen.getByText(/attempts:read/i)).toBeInTheDocument();
+    // listAttempts should NOT have been called.
+    expect(client.listAttempts).not.toHaveBeenCalled();
+  });
+
+  it("Close button calls onClose", async () => {
+    const user = userEvent.setup();
+    const client = makeClient();
+    render(
+      <AttemptList
+        client={client}
+        endpoint={ENDPOINT}
+        capabilities={["attempts:read"]}
+        onClose={onClose}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Close/i }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/endpoint-manager/src/__tests__/EndpointTester.test.tsx
+++ b/packages/endpoint-manager/src/__tests__/EndpointTester.test.tsx
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { EndpointTester } from "../components/EndpointTester.js";
+import type { PortalClient } from "../api/createPortalClient.js";
+import type { PortalEndpointSummary, PortalTestResult } from "../types.js";
+
+const ENDPOINT: PortalEndpointSummary = {
+  id: "ep-1",
+  url: "https://consumer.example.com/hooks",
+  description: "Test endpoint",
+  isActive: true,
+  hasSecretOverride: false,
+  filterEventTypes: [],
+  createdAt: "2026-01-01T00:00:00Z",
+};
+
+const TEST_RESULT: PortalTestResult = {
+  success: true,
+  statusCode: 200,
+  latencyMs: 87,
+  responseBody: "ok",
+  error: null,
+  request: {
+    url: "https://consumer.example.com/hooks",
+    headers: {
+      "webhook-id": "msg_abc123",
+      "webhook-timestamp": "1715363400",
+      "webhook-signature": "v1,abc123def456==",
+      "Content-Type": "application/json",
+    },
+    body: '{"orderId":"abc123"}',
+  },
+};
+
+function makeClient(overrides: Partial<PortalClient> = {}): PortalClient {
+  return {
+    listEndpoints: vi.fn(),
+    getEndpoint: vi.fn(),
+    createEndpoint: vi.fn(),
+    updateEndpoint: vi.fn(),
+    deleteEndpoint: vi.fn(),
+    enableEndpoint: vi.fn(),
+    disableEndpoint: vi.fn(),
+    listEventTypes: vi.fn().mockResolvedValue([
+      { id: "et-1", name: "order.created", description: null },
+      { id: "et-2", name: "payment.failed", description: null },
+    ]),
+    testEndpoint: vi.fn().mockResolvedValue(TEST_RESULT),
+    listAttempts: vi.fn(),
+    ...overrides,
+  };
+}
+
+/** Set textarea value using fireEvent to avoid user-event brace escaping issues */
+function setTextarea(textarea: HTMLElement, value: string) {
+  fireEvent.change(textarea, { target: { value } });
+  fireEvent.blur(textarea);
+}
+
+describe("EndpointTester", () => {
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the request form when endpoints:test capability is present", async () => {
+    const client = makeClient();
+    render(
+      <EndpointTester
+        client={client}
+        endpoint={ENDPOINT}
+        capabilities={["endpoints:read", "endpoints:test"]}
+        onClose={onClose}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole("combobox")).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: /Send test/i })).toBeInTheDocument();
+  });
+
+  it("renders capability banner instead of form when endpoints:test is missing", async () => {
+    const client = makeClient();
+    render(
+      <EndpointTester
+        client={client}
+        endpoint={ENDPOINT}
+        capabilities={["endpoints:read"]}
+        onClose={onClose}
+      />,
+    );
+
+    // Wait for any async state from listEventTypes to settle before asserting.
+    await waitFor(() => expect(client.listEventTypes).toHaveBeenCalled());
+
+    expect(screen.getByText(/Capability required/i)).toBeInTheDocument();
+    expect(screen.getByText(/endpoints:test/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Send test/i })).not.toBeInTheDocument();
+    // Footer should have "Close" text (not Cancel).
+    expect(screen.getByText("Close")).toBeInTheDocument();
+  });
+
+  it("invalid JSON in payload textarea surfaces inline error and disables Send test", async () => {
+    const client = makeClient();
+    render(
+      <EndpointTester
+        client={client}
+        endpoint={ENDPOINT}
+        capabilities={["endpoints:test"]}
+        onClose={onClose}
+      />,
+    );
+
+    await waitFor(() => screen.getByRole("combobox"));
+
+    const textarea = screen.getByRole("textbox");
+    setTextarea(textarea, "not valid json{");
+
+    await waitFor(() =>
+      expect(screen.getByText(/Invalid JSON/i)).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: /Send test/i })).toBeDisabled();
+  });
+
+  it("submitting fires client.testEndpoint with correct body shape", async () => {
+    const user = userEvent.setup();
+    const client = makeClient();
+    render(
+      <EndpointTester
+        client={client}
+        endpoint={ENDPOINT}
+        capabilities={["endpoints:test"]}
+        onClose={onClose}
+      />,
+    );
+
+    // Wait for event types to load and first option to be auto-selected.
+    await waitFor(() =>
+      expect((screen.getByRole("combobox") as HTMLSelectElement).value).toBe("et-1"),
+    );
+
+    // Set payload via fireEvent to avoid brace-escaping in user-event.
+    const textarea = screen.getByRole("textbox");
+    setTextarea(textarea, '{"orderId":"abc123"}');
+
+    await user.click(screen.getByRole("button", { name: /Send test/i }));
+
+    await waitFor(() => expect(client.testEndpoint).toHaveBeenCalledOnce());
+
+    const [calledId, calledInput] = (
+      client.testEndpoint as ReturnType<typeof vi.fn>
+    ).mock.calls[0] as [string, { eventType: string; payload: Record<string, unknown> }];
+    expect(calledId).toBe("ep-1");
+    expect(calledInput.eventType).toBe("et-1");
+    expect(calledInput.payload).toEqual({ orderId: "abc123" });
+  });
+
+  it("response panel renders status code, latency, and body after successful send", async () => {
+    const user = userEvent.setup();
+    const client = makeClient();
+    render(
+      <EndpointTester
+        client={client}
+        endpoint={ENDPOINT}
+        capabilities={["endpoints:test"]}
+        onClose={onClose}
+      />,
+    );
+
+    await waitFor(() =>
+      expect((screen.getByRole("combobox") as HTMLSelectElement).value).toBe("et-1"),
+    );
+
+    const textarea = screen.getByRole("textbox");
+    setTextarea(textarea, '{"key":"val"}');
+
+    await user.click(screen.getByRole("button", { name: /Send test/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText("200")).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/87 ms/i)).toBeInTheDocument();
+    expect(screen.getByText("ok")).toBeInTheDocument();
+  });
+
+  it("signed-request preview is collapsible and shows webhook-signature header", async () => {
+    const user = userEvent.setup();
+    const client = makeClient();
+    render(
+      <EndpointTester
+        client={client}
+        endpoint={ENDPOINT}
+        capabilities={["endpoints:test"]}
+        onClose={onClose}
+      />,
+    );
+
+    await waitFor(() =>
+      expect((screen.getByRole("combobox") as HTMLSelectElement).value).toBe("et-1"),
+    );
+
+    const textarea = screen.getByRole("textbox");
+    setTextarea(textarea, '{"k":"v"}');
+
+    await user.click(screen.getByRole("button", { name: /Send test/i }));
+
+    // Wait for result panel to appear.
+    await waitFor(() => screen.getByText("200"));
+
+    // Expand the signed-request preview.
+    const previewBtn = screen.getByRole("button", { name: /Signed request preview/i });
+    await user.click(previewBtn);
+
+    await waitFor(() =>
+      expect(screen.getByText(/webhook-signature/i)).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/v1,abc123def456/i)).toBeInTheDocument();
+  });
+
+  it("Cancel button in footer calls onClose", async () => {
+    const user = userEvent.setup();
+    render(
+      <EndpointTester
+        client={makeClient()}
+        endpoint={ENDPOINT}
+        capabilities={["endpoints:test"]}
+        onClose={onClose}
+      />,
+    );
+
+    await waitFor(() => screen.getByRole("combobox"));
+    // Footer cancel button (has text "Cancel", not aria-label "Close").
+    await user.click(screen.getByRole("button", { name: /^Cancel$/i }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/endpoint-manager/src/__tests__/createPortalClient.test.ts
+++ b/packages/endpoint-manager/src/__tests__/createPortalClient.test.ts
@@ -11,6 +11,8 @@ import type {
   PortalEndpointSummary,
   PortalEndpointDetail,
   PortalEventTypeListItem,
+  PortalAttempt,
+  PortalTestResult,
 } from "../types.js";
 
 const BASE = "https://engine.example.com";
@@ -36,6 +38,35 @@ const EVENT_TYPE: PortalEventTypeListItem = {
   id: "et-1",
   name: "order.created",
   description: null,
+};
+
+const ATTEMPT: PortalAttempt = {
+  id: "att-1",
+  messageId: "msg-1",
+  attemptNumber: 1,
+  status: "success",
+  statusCode: 200,
+  error: null,
+  latencyMs: 142,
+  createdAt: "2026-05-10T18:30:00Z",
+};
+
+const TEST_RESULT: PortalTestResult = {
+  success: true,
+  statusCode: 200,
+  latencyMs: 87,
+  responseBody: "ok",
+  error: null,
+  request: {
+    url: "https://consumer.example.com/hooks",
+    headers: {
+      "webhook-id": "msg_abc123",
+      "webhook-timestamp": "1715363400",
+      "webhook-signature": "v1,abc123def456",
+      "Content-Type": "application/json",
+    },
+    body: '{"orderId":"abc123"}',
+  },
 };
 
 describe("createPortalClient", () => {
@@ -202,13 +233,160 @@ describe("createPortalClient", () => {
     expect(result[0]?.name).toBe("order.created");
   });
 
-  it("testEndpoint — throws 'Not implemented'", () => {
-    const client = createPortalClient({ baseUrl: BASE, token: TOKEN });
-    expect(() => client.testEndpoint("ep-1", {})).toThrow("Not implemented yet");
+  // ── testEndpoint ──────────────────────────────────────────────────────────
+
+  it("testEndpoint — POSTs to correct URL and returns PortalTestResult", async () => {
+    let capturedUrl = "";
+    let capturedBody: unknown;
+    const fetch = createMockFetch([
+      {
+        method: "POST",
+        pattern: "/api/v1/portal/endpoints/ep-1/test",
+        handler: (url, init) => {
+          capturedUrl = url;
+          capturedBody = JSON.parse(init?.body as string);
+          return jsonOk(TEST_RESULT);
+        },
+      },
+    ]);
+    const client = createPortalClient({ baseUrl: BASE, token: TOKEN, fetch });
+    const result = await client.testEndpoint("ep-1", {
+      eventType: "order.created",
+      payload: { orderId: "abc123" },
+    });
+
+    expect(capturedUrl).toContain("/api/v1/portal/endpoints/ep-1/test");
+    expect(capturedBody).toMatchObject({
+      eventType: "order.created",
+      payload: { orderId: "abc123" },
+    });
+    expect(result.statusCode).toBe(200);
+    expect(result.latencyMs).toBe(87);
+    expect(result.responseBody).toBe("ok");
+    expect(result.request.headers["webhook-signature"]).toMatch(/^v1,/);
   });
 
-  it("listAttempts — throws 'Not implemented'", () => {
-    const client = createPortalClient({ baseUrl: BASE, token: TOKEN });
-    expect(() => client.listAttempts("ep-1")).toThrow("Not implemented yet");
+  it("testEndpoint — includes customHeaders in body when provided", async () => {
+    let capturedBody: unknown;
+    const fetch = createMockFetch([
+      {
+        method: "POST",
+        pattern: "/test",
+        handler: (_url, init) => {
+          capturedBody = JSON.parse(init?.body as string);
+          return jsonOk(TEST_RESULT);
+        },
+      },
+    ]);
+    const client = createPortalClient({ baseUrl: BASE, token: TOKEN, fetch });
+    await client.testEndpoint("ep-1", {
+      eventType: "order.created",
+      payload: {},
+      customHeaders: { "X-Custom": "value" },
+    });
+
+    expect(capturedBody).toMatchObject({ customHeaders: { "X-Custom": "value" } });
+  });
+
+  it("testEndpoint — 403 throws PortalError with PORTAL_INSUFFICIENT_CAPABILITY", async () => {
+    const fetch = createMockFetch([
+      {
+        method: "POST",
+        pattern: "/test",
+        handler: () =>
+          jsonError(403, "PORTAL_INSUFFICIENT_CAPABILITY", "Insufficient capability"),
+      },
+    ]);
+    const client = createPortalClient({ baseUrl: BASE, token: TOKEN, fetch });
+
+    let caught: PortalError | null = null;
+    try {
+      await client.testEndpoint("ep-1", { eventType: "order.created", payload: {} });
+    } catch (err) {
+      caught = err as PortalError;
+    }
+
+    expect(caught).toBeInstanceOf(PortalError);
+    expect(caught?.code).toBe("PORTAL_INSUFFICIENT_CAPABILITY");
+    expect(caught?.status).toBe(403);
+  });
+
+  it("testEndpoint — 422 populates fieldErrors", async () => {
+    const fetch = createMockFetch([
+      {
+        method: "POST",
+        pattern: "/test",
+        handler: () =>
+          jsonError(422, "VALIDATION_FAILED", "Validation failed", {
+            eventType: "Event type is required",
+          }),
+      },
+    ]);
+    const client = createPortalClient({ baseUrl: BASE, token: TOKEN, fetch });
+
+    let caught: PortalError | null = null;
+    try {
+      await client.testEndpoint("ep-1", { eventType: "", payload: {} });
+    } catch (err) {
+      caught = err as PortalError;
+    }
+
+    expect(caught?.fieldErrors?.["eventType"]).toBe("Event type is required");
+  });
+
+  // ── listAttempts ──────────────────────────────────────────────────────────
+
+  it("listAttempts — GETs correct URL with pagination params", async () => {
+    let capturedUrl = "";
+    const fetch = createMockFetch([
+      {
+        method: "GET",
+        pattern: "/attempts",
+        handler: (url) => {
+          capturedUrl = url;
+          return jsonList([ATTEMPT], { page: 2, pageSize: 10, total: 47 });
+        },
+      },
+    ]);
+    const client = createPortalClient({ baseUrl: BASE, token: TOKEN, fetch });
+    const result = await client.listAttempts("ep-1", { page: 2, pageSize: 10 });
+
+    expect(capturedUrl).toContain("/api/v1/portal/endpoints/ep-1/attempts");
+    expect(capturedUrl).toContain("page=2");
+    expect(capturedUrl).toContain("pageSize=10");
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0]?.id).toBe("att-1");
+  });
+
+  it("listAttempts — pagination shape is flattened into result.pagination", async () => {
+    const fetch = createMockFetch([
+      {
+        method: "GET",
+        pattern: "/attempts",
+        handler: () =>
+          jsonList([ATTEMPT], { page: 2, pageSize: 10, total: 47 }),
+      },
+    ]);
+    const client = createPortalClient({ baseUrl: BASE, token: TOKEN, fetch });
+    const result = await client.listAttempts("ep-1", { page: 2, pageSize: 10 });
+
+    expect(result.pagination).toEqual({ page: 2, pageSize: 10, total: 47 });
+  });
+
+  it("listAttempts — 403 throws PortalError with PORTAL_INSUFFICIENT_CAPABILITY", async () => {
+    const fetch = createMockFetch([
+      {
+        method: "GET",
+        pattern: "/attempts",
+        handler: () =>
+          jsonError(403, "PORTAL_INSUFFICIENT_CAPABILITY", "Insufficient capability"),
+      },
+    ]);
+    const client = createPortalClient({ baseUrl: BASE, token: TOKEN, fetch });
+
+    await expect(client.listAttempts("ep-1")).rejects.toMatchObject({
+      code: "PORTAL_INSUFFICIENT_CAPABILITY",
+      status: 403,
+    });
   });
 });

--- a/packages/endpoint-manager/src/api/createPortalClient.ts
+++ b/packages/endpoint-manager/src/api/createPortalClient.ts
@@ -1,9 +1,11 @@
 import type {
+  PortalAttempt,
   PortalCapability,
   PortalCreateEndpointInput,
   PortalEndpointDetail,
   PortalEndpointSummary,
   PortalEventTypeListItem,
+  PortalTestResult,
   PortalUpdateEndpointInput,
 } from "../types.js";
 
@@ -49,6 +51,12 @@ export class PortalError extends Error {
   }
 }
 
+export interface PortalTestEndpointInput {
+  eventType: string;
+  payload: Record<string, unknown>;
+  customHeaders?: Record<string, string>;
+}
+
 export interface PortalClient {
   listEndpoints(params?: {
     page?: number;
@@ -61,9 +69,8 @@ export interface PortalClient {
   enableEndpoint(id: string): Promise<void>;
   disableEndpoint(id: string): Promise<void>;
   listEventTypes(): Promise<PortalEventTypeListItem[]>;
-  // Step 9 will add testEndpoint + listAttempts.
-  testEndpoint(id: string, payload: Record<string, unknown>): Promise<never>;
-  listAttempts(id: string, params?: { page?: number; pageSize?: number }): Promise<never>;
+  testEndpoint(id: string, input: PortalTestEndpointInput): Promise<PortalTestResult>;
+  listAttempts(id: string, params?: { page?: number; pageSize?: number }): Promise<PortalListResult<PortalAttempt>>;
 }
 
 interface ApiErrorEnvelope {
@@ -246,12 +253,18 @@ export function createPortalClient(options: PortalClientOptions): PortalClient {
       return request<PortalEventTypeListItem[]>("GET", "/api/v1/portal/event-types");
     },
 
-    testEndpoint(_id, _payload) {
-      throw new Error("Not implemented yet — lands in B1 Step 9");
+    testEndpoint(id, input) {
+      return request<PortalTestResult>("POST", `/api/v1/portal/endpoints/${id}/test`, {
+        body: {
+          eventType: input.eventType,
+          payload: input.payload,
+          ...(input.customHeaders !== undefined ? { customHeaders: input.customHeaders } : {}),
+        },
+      });
     },
 
-    listAttempts(_id, _params) {
-      throw new Error("Not implemented yet — lands in B1 Step 9");
+    listAttempts(id, params) {
+      return requestList<PortalAttempt>(`/api/v1/portal/endpoints/${id}/attempts`, params);
     },
   };
 }

--- a/packages/endpoint-manager/src/components/AttemptList.tsx
+++ b/packages/endpoint-manager/src/components/AttemptList.tsx
@@ -1,0 +1,402 @@
+import { Fragment, useCallback, useEffect, useReducer, useRef } from "react";
+import type { JSX } from "react";
+import type { PortalAttempt, PortalCapability, PortalEndpointSummary } from "../types.js";
+import type { PortalClient, PortalPagination } from "../api/createPortalClient.js";
+
+export interface AttemptListProps {
+  client: PortalClient;
+  endpoint: PortalEndpointSummary;
+  capabilities: PortalCapability[];
+  onClose: () => void;
+}
+
+interface AttemptListState {
+  attempts: PortalAttempt[];
+  pagination: PortalPagination | null;
+  page: number;
+  loading: boolean;
+  error: string | null;
+  expandedId: string | null;
+}
+
+type AttemptListAction =
+  | { type: "FETCH_START" }
+  | { type: "FETCH_SUCCESS"; attempts: PortalAttempt[]; pagination: PortalPagination }
+  | { type: "FETCH_ERROR"; message: string }
+  | { type: "SET_PAGE"; page: number }
+  | { type: "TOGGLE_EXPAND"; id: string };
+
+function attemptReducer(state: AttemptListState, action: AttemptListAction): AttemptListState {
+  switch (action.type) {
+    case "FETCH_START":
+      return { ...state, loading: true, error: null };
+    case "FETCH_SUCCESS":
+      return {
+        ...state,
+        loading: false,
+        attempts: action.attempts,
+        pagination: action.pagination,
+      };
+    case "FETCH_ERROR":
+      return { ...state, loading: false, error: action.message };
+    case "SET_PAGE":
+      return { ...state, page: action.page };
+    case "TOGGLE_EXPAND":
+      return { ...state, expandedId: state.expandedId === action.id ? null : action.id };
+  }
+}
+
+const PAGE_SIZE = 20;
+
+function formatRelativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const seconds = Math.floor(diff / 1000);
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function StatusBadge({ status }: { status: string }): JSX.Element {
+  const isSuccess = status.toLowerCase() === "success";
+  return (
+    <span
+      className={[
+        "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium",
+        isSuccess
+          ? "bg-whe-success-soft text-whe-success"
+          : "bg-whe-danger-soft text-whe-danger",
+      ].join(" ")}
+    >
+      <span
+        className={`h-1.5 w-1.5 rounded-full ${isSuccess ? "bg-whe-success" : "bg-whe-danger"}`}
+        aria-hidden="true"
+      />
+      {isSuccess ? "Success" : "Failure"}
+    </span>
+  );
+}
+
+function SkeletonRow(): JSX.Element {
+  return (
+    <tr>
+      <td className="px-4 py-3"><div className="h-4 w-20 animate-pulse rounded bg-whe-bg-3" /></td>
+      <td className="px-4 py-3"><div className="h-4 w-16 animate-pulse rounded bg-whe-bg-3" /></td>
+      <td className="px-4 py-3"><div className="h-4 w-10 animate-pulse rounded bg-whe-bg-3" /></td>
+      <td className="px-4 py-3"><div className="h-4 w-12 animate-pulse rounded bg-whe-bg-3" /></td>
+      <td className="hidden px-4 py-3 sm:table-cell"><div className="h-4 w-32 animate-pulse rounded bg-whe-bg-3" /></td>
+    </tr>
+  );
+}
+
+function TableHead(): JSX.Element {
+  return (
+    <tr className="border-b border-whe-border text-left text-xs text-whe-text-muted">
+      <th className="px-4 py-3 font-medium">When</th>
+      <th className="px-4 py-3 font-medium">Status</th>
+      <th className="px-4 py-3 font-medium">HTTP</th>
+      <th className="px-4 py-3 font-medium">Latency</th>
+      <th className="hidden px-4 py-3 font-medium sm:table-cell">Error</th>
+    </tr>
+  );
+}
+
+function truncateUrl(url: string, max = 48): string {
+  if (url.length <= max) return url;
+  return url.slice(0, max) + "…";
+}
+
+export function AttemptList({
+  client,
+  endpoint,
+  capabilities,
+  onClose,
+}: AttemptListProps): JSX.Element {
+  const canRead = capabilities.includes("attempts:read");
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const firstFocusableRef = useRef<HTMLButtonElement>(null);
+
+  const [state, dispatch] = useReducer(attemptReducer, {
+    attempts: [],
+    pagination: null,
+    page: 1,
+    loading: true,
+    error: null,
+    expandedId: null,
+  });
+
+  // Focus trap and Escape key.
+  useEffect(() => {
+    firstFocusableRef.current?.focus();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (e.key !== "Tab") return;
+
+      const overlay = overlayRef.current;
+      if (!overlay) return;
+      const focusable = overlay.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      );
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (!first || !last) return;
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "";
+    };
+  }, [onClose]);
+
+  const fetchPage = useCallback(
+    async (page: number) => {
+      dispatch({ type: "FETCH_START" });
+      try {
+        const result = await client.listAttempts(endpoint.id, { page, pageSize: PAGE_SIZE });
+        dispatch({
+          type: "FETCH_SUCCESS",
+          attempts: result.data,
+          pagination: result.pagination,
+        });
+      } catch (err) {
+        dispatch({
+          type: "FETCH_ERROR",
+          message: err instanceof Error ? err.message : "Failed to load attempts.",
+        });
+      }
+    },
+    [client, endpoint.id],
+  );
+
+  useEffect(() => {
+    if (canRead) {
+      void fetchPage(state.page);
+    } else {
+      dispatch({
+        type: "FETCH_SUCCESS",
+        attempts: [],
+        pagination: { page: 1, pageSize: PAGE_SIZE, total: 0 },
+      });
+    }
+  }, [fetchPage, state.page, canRead]);
+
+  const totalPages = state.pagination
+    ? Math.max(1, Math.ceil(state.pagination.total / PAGE_SIZE))
+    : 1;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        ref={overlayRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="whe-attempts-title"
+        className="relative flex w-full max-w-3xl flex-col overflow-hidden rounded-2xl border border-whe-border bg-whe-bg-1 shadow-2xl max-h-[90dvh]"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-whe-border px-6 py-4">
+          <div>
+            <h2 id="whe-attempts-title" className="text-base font-semibold text-whe-text-primary">
+              Delivery attempts
+            </h2>
+            <p className="mt-0.5 text-xs text-whe-text-muted font-mono">
+              {truncateUrl(endpoint.url)}
+            </p>
+          </div>
+          <button
+            ref={firstFocusableRef}
+            type="button"
+            onClick={onClose}
+            className="rounded-md p-1 text-whe-text-muted hover:text-whe-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-whe-accent"
+            aria-label="Close"
+          >
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+              <path d="M12 4L4 12M4 4l8 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="overflow-y-auto px-6 py-5">
+          {/* Capability gate */}
+          {!canRead ? (
+            <div className="rounded-lg border border-whe-warning/30 bg-whe-warning-soft px-4 py-4 text-sm text-whe-warning">
+              <p className="font-medium">Capability required</p>
+              <p className="mt-1 text-xs text-whe-text-secondary">
+                Your portal token does not include the{" "}
+                <code className="rounded bg-whe-bg-3 px-1 py-0.5 font-mono text-xs">
+                  attempts:read
+                </code>{" "}
+                capability. Contact the application operator to request access.
+              </p>
+            </div>
+          ) : state.error ? (
+            <div className="flex flex-col items-center gap-4 py-12 text-center">
+              <p className="text-sm text-whe-danger">{state.error}</p>
+              <button
+                type="button"
+                onClick={() => void fetchPage(state.page)}
+                className="rounded-md bg-whe-accent px-4 py-2 text-sm font-medium text-whe-bg-0 hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-whe-accent"
+              >
+                Retry
+              </button>
+            </div>
+          ) : state.loading ? (
+            <div className="overflow-x-auto rounded-xl border border-whe-border bg-whe-bg-2">
+              <table className="w-full text-sm">
+                <thead>
+                  <TableHead />
+                </thead>
+                <tbody>
+                  <SkeletonRow />
+                  <SkeletonRow />
+                  <SkeletonRow />
+                </tbody>
+              </table>
+            </div>
+          ) : state.attempts.length === 0 ? (
+            <div className="flex flex-col items-center gap-2 py-16 text-center">
+              <p className="text-sm text-whe-text-muted">
+                No delivery attempts recorded for this endpoint yet.
+              </p>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-4">
+              <div className="overflow-x-auto rounded-xl border border-whe-border bg-whe-bg-2">
+                <table className="w-full text-sm">
+                  <thead>
+                    <TableHead />
+                  </thead>
+                  <tbody>
+                    {state.attempts.map((attempt) => {
+                      const isExpanded = state.expandedId === attempt.id;
+                      return (
+                        <Fragment key={attempt.id}>
+                          <tr
+                            className="cursor-pointer border-b border-whe-border-subtle last:border-0 hover:bg-whe-bg-3 transition-colors"
+                            onClick={() => dispatch({ type: "TOGGLE_EXPAND", id: attempt.id })}
+                          >
+                            <td className="px-4 py-3">
+                              <time
+                                dateTime={attempt.createdAt}
+                                title={attempt.createdAt}
+                                className="text-xs text-whe-text-secondary"
+                              >
+                                {formatRelativeTime(attempt.createdAt)}
+                              </time>
+                            </td>
+                            <td className="px-4 py-3">
+                              <StatusBadge status={attempt.status} />
+                            </td>
+                            <td className="px-4 py-3 text-xs text-whe-text-secondary">
+                              {attempt.statusCode ?? "—"}
+                            </td>
+                            <td className="px-4 py-3 text-xs text-whe-text-secondary">
+                              {attempt.latencyMs} ms
+                            </td>
+                            <td className="hidden px-4 py-3 sm:table-cell">
+                              {attempt.error ? (
+                                <span
+                                  className="text-xs text-whe-danger"
+                                  title={attempt.error}
+                                >
+                                  {attempt.error.length > 60
+                                    ? attempt.error.slice(0, 60) + "…"
+                                    : attempt.error}
+                                </span>
+                              ) : (
+                                <span className="text-xs text-whe-text-muted">—</span>
+                              )}
+                            </td>
+                          </tr>
+                          {isExpanded && (
+                            <tr
+                              key={`${attempt.id}-expanded`}
+                              className="border-b border-whe-border-subtle last:border-0 bg-whe-bg-2"
+                            >
+                              <td colSpan={5} className="px-4 py-3">
+                                <div className="rounded-lg bg-whe-bg-3 px-3 py-3">
+                                  <p className="mb-1 text-xs font-medium text-whe-text-secondary">
+                                    Error detail
+                                  </p>
+                                  {attempt.error ? (
+                                    <pre className="whitespace-pre-wrap break-words font-mono text-xs text-whe-danger">
+                                      {attempt.error}
+                                    </pre>
+                                  ) : (
+                                    <p className="text-xs italic text-whe-text-muted">
+                                      No error detail available.
+                                    </p>
+                                  )}
+                                </div>
+                              </td>
+                            </tr>
+                          )}
+                        </Fragment>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+
+              {/* Pagination footer */}
+              <div className="flex items-center justify-between text-sm text-whe-text-secondary">
+                <span className="text-xs text-whe-text-muted">
+                  Showing {state.attempts.length} of {state.pagination?.total ?? 0} attempts
+                </span>
+                <div className="flex items-center gap-3">
+                  <button
+                    type="button"
+                    disabled={state.page <= 1 || state.loading}
+                    onClick={() => dispatch({ type: "SET_PAGE", page: state.page - 1 })}
+                    className="rounded px-3 py-1.5 hover:bg-whe-bg-3 disabled:opacity-40 focus:outline-none focus-visible:ring-1 focus-visible:ring-whe-accent"
+                  >
+                    Previous
+                  </button>
+                  <span className="text-xs text-whe-text-muted">
+                    Page {state.page} of {totalPages}
+                  </span>
+                  <button
+                    type="button"
+                    disabled={state.page >= totalPages || state.loading}
+                    onClick={() => dispatch({ type: "SET_PAGE", page: state.page + 1 })}
+                    className="rounded px-3 py-1.5 hover:bg-whe-bg-3 disabled:opacity-40 focus:outline-none focus-visible:ring-1 focus-visible:ring-whe-accent"
+                  >
+                    Next
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/endpoint-manager/src/components/EndpointList.tsx
+++ b/packages/endpoint-manager/src/components/EndpointList.tsx
@@ -1,7 +1,9 @@
-import { useCallback, useEffect, useReducer } from "react";
+import { useCallback, useEffect, useReducer, useState } from "react";
 import type { JSX } from "react";
 import type { PortalCapability, PortalEndpointSummary } from "../types.js";
 import type { PortalClient, PortalPagination } from "../api/createPortalClient.js";
+import { EndpointTester } from "./EndpointTester.js";
+import { AttemptList } from "./AttemptList.js";
 
 interface EndpointListProps {
   client: PortalClient;
@@ -88,6 +90,31 @@ function truncateUrl(url: string, max = 48): string {
   return url.slice(0, max) + "…";
 }
 
+// Inline lightning-bolt SVG (no Lucide dep inside this package).
+function TestIcon(): JSX.Element {
+  return (
+    <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path
+        d="M9.5 2L4 9h5l-2.5 5L14 7H9L9.5 2z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+// Inline clock/history SVG.
+function ClockIcon(): JSX.Element {
+  return (
+    <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.5" />
+      <path d="M8 5v3l2 1.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
 export function EndpointList({
   client,
   capabilities,
@@ -95,6 +122,9 @@ export function EndpointList({
   onNewEndpoint,
 }: EndpointListProps): JSX.Element {
   const canWrite = capabilities.includes("endpoints:write");
+  const canTest = capabilities.includes("endpoints:test");
+  const canReadAttempts = capabilities.includes("attempts:read");
+  const showActionColumn = canWrite || canTest || canReadAttempts;
 
   const [state, dispatch] = useReducer(listReducer, {
     endpoints: [],
@@ -105,6 +135,10 @@ export function EndpointList({
     togglingId: null,
     deletingId: null,
   });
+
+  // Modal state — one per modal type.
+  const [testerEndpoint, setTesterEndpoint] = useState<PortalEndpointSummary | null>(null);
+  const [attemptsEndpoint, setAttemptsEndpoint] = useState<PortalEndpointSummary | null>(null);
 
   const fetchPage = useCallback(
     async (page: number) => {
@@ -185,152 +219,205 @@ export function EndpointList({
   }
 
   return (
-    <div className="flex flex-col gap-4">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <h2 className="text-base font-semibold text-whe-text-primary">Endpoints</h2>
-        {canWrite && (
-          <button
-            type="button"
-            onClick={onNewEndpoint}
-            className="inline-flex items-center gap-1.5 rounded-md bg-whe-accent px-3 py-1.5 text-sm font-medium text-whe-bg-0 hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-whe-accent"
-          >
-            <span aria-hidden="true">+</span>
-            New endpoint
-          </button>
-        )}
-      </div>
-
-      {/* Empty state */}
-      {state.endpoints.length === 0 ? (
-        <div className="flex flex-col items-center gap-4 rounded-xl border border-whe-border bg-whe-bg-2 py-16 text-center">
-          <p className="text-sm text-whe-text-secondary">No endpoints yet.</p>
+    <>
+      <div className="flex flex-col gap-4">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <h2 className="text-base font-semibold text-whe-text-primary">Endpoints</h2>
           {canWrite && (
             <button
               type="button"
               onClick={onNewEndpoint}
-              className="rounded-md bg-whe-accent px-4 py-2 text-sm font-medium text-whe-bg-0 hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-whe-accent"
+              className="inline-flex items-center gap-1.5 rounded-md bg-whe-accent px-3 py-1.5 text-sm font-medium text-whe-bg-0 hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-whe-accent"
             >
-              Create your first endpoint
+              <span aria-hidden="true">+</span>
+              New endpoint
             </button>
           )}
         </div>
-      ) : (
-        <>
-          {/* Table */}
-          <div className="overflow-x-auto rounded-xl border border-whe-border bg-whe-bg-2">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b border-whe-border text-left text-xs text-whe-text-muted">
-                  <th className="px-4 py-3 font-medium">URL</th>
-                  <th className="hidden px-4 py-3 font-medium sm:table-cell">Description</th>
-                  <th className="px-4 py-3 font-medium">Status</th>
-                  <th className="hidden px-4 py-3 font-medium md:table-cell">Event types</th>
-                  <th className="hidden px-4 py-3 font-medium lg:table-cell">Created</th>
-                  {canWrite && <th className="px-4 py-3" />}
-                </tr>
-              </thead>
-              <tbody>
-                {state.endpoints.map((endpoint) => {
-                  const isToggling = state.togglingId === endpoint.id;
-                  const isDeleting = state.deletingId === endpoint.id;
-                  return (
-                    <tr
-                      key={endpoint.id}
-                      className="group cursor-pointer border-b border-whe-border-subtle last:border-0 hover:bg-whe-bg-3 transition-colors"
-                      onClick={() => onEditEndpoint(endpoint)}
-                    >
-                      <td className="px-4 py-3 font-mono text-xs text-whe-text-primary">
-                        {truncateUrl(endpoint.url)}
-                      </td>
-                      <td className="hidden px-4 py-3 text-whe-text-secondary sm:table-cell">
-                        {endpoint.description ?? (
-                          <span className="text-whe-text-muted">—</span>
-                        )}
-                      </td>
-                      <td className="px-4 py-3">
-                        {endpoint.isActive ? (
-                          <span className="inline-flex items-center gap-1 rounded-full bg-whe-success-soft px-2 py-0.5 text-xs font-medium text-whe-success">
-                            <span className="h-1.5 w-1.5 rounded-full bg-whe-success" aria-hidden="true" />
-                            Active
-                          </span>
-                        ) : (
-                          <span className="inline-flex items-center gap-1 rounded-full bg-whe-bg-3 px-2 py-0.5 text-xs font-medium text-whe-text-muted">
-                            <span className="h-1.5 w-1.5 rounded-full bg-whe-text-muted" aria-hidden="true" />
-                            Disabled
-                          </span>
-                        )}
-                      </td>
-                      <td className="hidden px-4 py-3 text-whe-text-secondary md:table-cell">
-                        {endpoint.filterEventTypes.length === 0 ? (
-                          <span className="text-whe-text-muted">All</span>
-                        ) : (
-                          <span>{endpoint.filterEventTypes.length} filter{endpoint.filterEventTypes.length !== 1 ? "s" : ""}</span>
-                        )}
-                      </td>
-                      <td className="hidden px-4 py-3 text-whe-text-muted lg:table-cell">
-                        {formatDate(endpoint.createdAt)}
-                      </td>
-                      {canWrite && (
-                        <td
-                          className="px-4 py-3"
-                          onClick={(e) => e.stopPropagation()}
-                        >
-                          <div className="flex items-center gap-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
-                            <button
-                              type="button"
-                              disabled={isToggling || isDeleting}
-                              onClick={() => void handleToggle(endpoint)}
-                              className="rounded px-2 py-1 text-xs text-whe-text-secondary hover:text-whe-text-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-whe-accent disabled:opacity-50"
-                              aria-label={endpoint.isActive ? "Disable endpoint" : "Enable endpoint"}
-                            >
-                              {isToggling ? "…" : endpoint.isActive ? "Disable" : "Enable"}
-                            </button>
-                            <button
-                              type="button"
-                              disabled={isToggling || isDeleting}
-                              onClick={() => void handleDelete(endpoint)}
-                              className="rounded px-2 py-1 text-xs text-whe-danger hover:text-whe-danger focus:outline-none focus-visible:ring-1 focus-visible:ring-whe-danger disabled:opacity-50"
-                              aria-label="Delete endpoint"
-                            >
-                              {isDeleting ? "…" : "Delete"}
-                            </button>
-                          </div>
-                        </td>
-                      )}
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
 
-          {/* Pagination */}
-          {totalPages > 1 && (
-            <div className="flex items-center justify-between text-sm text-whe-text-secondary">
+        {/* Empty state */}
+        {state.endpoints.length === 0 ? (
+          <div className="flex flex-col items-center gap-4 rounded-xl border border-whe-border bg-whe-bg-2 py-16 text-center">
+            <p className="text-sm text-whe-text-secondary">No endpoints yet.</p>
+            {canWrite && (
               <button
                 type="button"
-                disabled={state.page <= 1 || state.loading}
-                onClick={() => dispatch({ type: "SET_PAGE", page: state.page - 1 })}
-                className="rounded px-3 py-1.5 hover:bg-whe-bg-3 disabled:opacity-40 focus:outline-none focus-visible:ring-1 focus-visible:ring-whe-accent"
+                onClick={onNewEndpoint}
+                className="rounded-md bg-whe-accent px-4 py-2 text-sm font-medium text-whe-bg-0 hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-whe-accent"
               >
-                Previous
+                Create your first endpoint
               </button>
-              <span className="text-xs text-whe-text-muted">
-                Page {state.page} of {totalPages}
-              </span>
-              <button
-                type="button"
-                disabled={state.page >= totalPages || state.loading}
-                onClick={() => dispatch({ type: "SET_PAGE", page: state.page + 1 })}
-                className="rounded px-3 py-1.5 hover:bg-whe-bg-3 disabled:opacity-40 focus:outline-none focus-visible:ring-1 focus-visible:ring-whe-accent"
-              >
-                Next
-              </button>
+            )}
+          </div>
+        ) : (
+          <>
+            {/* Table */}
+            <div className="overflow-x-auto rounded-xl border border-whe-border bg-whe-bg-2">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-whe-border text-left text-xs text-whe-text-muted">
+                    <th className="px-4 py-3 font-medium">URL</th>
+                    <th className="hidden px-4 py-3 font-medium sm:table-cell">Description</th>
+                    <th className="px-4 py-3 font-medium">Status</th>
+                    <th className="hidden px-4 py-3 font-medium md:table-cell">Event types</th>
+                    <th className="hidden px-4 py-3 font-medium lg:table-cell">Created</th>
+                    {showActionColumn && <th className="px-4 py-3" />}
+                  </tr>
+                </thead>
+                <tbody>
+                  {state.endpoints.map((endpoint) => {
+                    const isToggling = state.togglingId === endpoint.id;
+                    const isDeleting = state.deletingId === endpoint.id;
+                    return (
+                      <tr
+                        key={endpoint.id}
+                        className="group cursor-pointer border-b border-whe-border-subtle last:border-0 hover:bg-whe-bg-3 transition-colors"
+                        onClick={() => onEditEndpoint(endpoint)}
+                      >
+                        <td className="px-4 py-3 font-mono text-xs text-whe-text-primary">
+                          {truncateUrl(endpoint.url)}
+                        </td>
+                        <td className="hidden px-4 py-3 text-whe-text-secondary sm:table-cell">
+                          {endpoint.description ?? (
+                            <span className="text-whe-text-muted">—</span>
+                          )}
+                        </td>
+                        <td className="px-4 py-3">
+                          {endpoint.isActive ? (
+                            <span className="inline-flex items-center gap-1 rounded-full bg-whe-success-soft px-2 py-0.5 text-xs font-medium text-whe-success">
+                              <span className="h-1.5 w-1.5 rounded-full bg-whe-success" aria-hidden="true" />
+                              Active
+                            </span>
+                          ) : (
+                            <span className="inline-flex items-center gap-1 rounded-full bg-whe-bg-3 px-2 py-0.5 text-xs font-medium text-whe-text-muted">
+                              <span className="h-1.5 w-1.5 rounded-full bg-whe-text-muted" aria-hidden="true" />
+                              Disabled
+                            </span>
+                          )}
+                        </td>
+                        <td className="hidden px-4 py-3 text-whe-text-secondary md:table-cell">
+                          {endpoint.filterEventTypes.length === 0 ? (
+                            <span className="text-whe-text-muted">All</span>
+                          ) : (
+                            <span>
+                              {endpoint.filterEventTypes.length} filter
+                              {endpoint.filterEventTypes.length !== 1 ? "s" : ""}
+                            </span>
+                          )}
+                        </td>
+                        <td className="hidden px-4 py-3 text-whe-text-muted lg:table-cell">
+                          {formatDate(endpoint.createdAt)}
+                        </td>
+                        {showActionColumn && (
+                          <td
+                            className="px-4 py-3"
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
+                              {canTest && (
+                                <button
+                                  type="button"
+                                  disabled={isToggling || isDeleting}
+                                  onClick={() => setTesterEndpoint(endpoint)}
+                                  className="inline-flex items-center gap-1 rounded px-2 py-1 text-xs text-whe-text-secondary hover:text-whe-accent focus:outline-none focus-visible:ring-1 focus-visible:ring-whe-accent disabled:opacity-50"
+                                  aria-label="Test endpoint"
+                                  title="Test"
+                                >
+                                  <TestIcon />
+                                  <span className="hidden lg:inline">Test</span>
+                                </button>
+                              )}
+                              {canReadAttempts && (
+                                <button
+                                  type="button"
+                                  disabled={isToggling || isDeleting}
+                                  onClick={() => setAttemptsEndpoint(endpoint)}
+                                  className="inline-flex items-center gap-1 rounded px-2 py-1 text-xs text-whe-text-secondary hover:text-whe-accent focus:outline-none focus-visible:ring-1 focus-visible:ring-whe-accent disabled:opacity-50"
+                                  aria-label="View attempts"
+                                  title="Attempts"
+                                >
+                                  <ClockIcon />
+                                  <span className="hidden lg:inline">Attempts</span>
+                                </button>
+                              )}
+                              {canWrite && (
+                                <>
+                                  <button
+                                    type="button"
+                                    disabled={isToggling || isDeleting}
+                                    onClick={() => void handleToggle(endpoint)}
+                                    className="rounded px-2 py-1 text-xs text-whe-text-secondary hover:text-whe-text-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-whe-accent disabled:opacity-50"
+                                    aria-label={endpoint.isActive ? "Disable endpoint" : "Enable endpoint"}
+                                  >
+                                    {isToggling ? "…" : endpoint.isActive ? "Disable" : "Enable"}
+                                  </button>
+                                  <button
+                                    type="button"
+                                    disabled={isToggling || isDeleting}
+                                    onClick={() => void handleDelete(endpoint)}
+                                    className="rounded px-2 py-1 text-xs text-whe-danger hover:text-whe-danger focus:outline-none focus-visible:ring-1 focus-visible:ring-whe-danger disabled:opacity-50"
+                                    aria-label="Delete endpoint"
+                                  >
+                                    {isDeleting ? "…" : "Delete"}
+                                  </button>
+                                </>
+                              )}
+                            </div>
+                          </td>
+                        )}
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
             </div>
-          )}
-        </>
+
+            {/* Pagination */}
+            {totalPages > 1 && (
+              <div className="flex items-center justify-between text-sm text-whe-text-secondary">
+                <button
+                  type="button"
+                  disabled={state.page <= 1 || state.loading}
+                  onClick={() => dispatch({ type: "SET_PAGE", page: state.page - 1 })}
+                  className="rounded px-3 py-1.5 hover:bg-whe-bg-3 disabled:opacity-40 focus:outline-none focus-visible:ring-1 focus-visible:ring-whe-accent"
+                >
+                  Previous
+                </button>
+                <span className="text-xs text-whe-text-muted">
+                  Page {state.page} of {totalPages}
+                </span>
+                <button
+                  type="button"
+                  disabled={state.page >= totalPages || state.loading}
+                  onClick={() => dispatch({ type: "SET_PAGE", page: state.page + 1 })}
+                  className="rounded px-3 py-1.5 hover:bg-whe-bg-3 disabled:opacity-40 focus:outline-none focus-visible:ring-1 focus-visible:ring-whe-accent"
+                >
+                  Next
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* Modals — rendered outside the table flow */}
+      {testerEndpoint && (
+        <EndpointTester
+          client={client}
+          endpoint={testerEndpoint}
+          capabilities={capabilities}
+          onClose={() => setTesterEndpoint(null)}
+        />
       )}
-    </div>
+      {attemptsEndpoint && (
+        <AttemptList
+          client={client}
+          endpoint={attemptsEndpoint}
+          capabilities={capabilities}
+          onClose={() => setAttemptsEndpoint(null)}
+        />
+      )}
+    </>
   );
 }

--- a/packages/endpoint-manager/src/components/EndpointTester.tsx
+++ b/packages/endpoint-manager/src/components/EndpointTester.tsx
@@ -1,0 +1,589 @@
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
+import type { JSX } from "react";
+import type {
+  PortalCapability,
+  PortalEndpointSummary,
+  PortalEventTypeListItem,
+  PortalTestResult,
+} from "../types.js";
+import type { PortalClient } from "../api/createPortalClient.js";
+import { PortalError } from "../api/createPortalClient.js";
+
+export interface EndpointTesterProps {
+  client: PortalClient;
+  endpoint: PortalEndpointSummary;
+  capabilities: PortalCapability[];
+  onClose: () => void;
+}
+
+interface TesterState {
+  eventTypeId: string;
+  payloadText: string;
+  payloadError: string | null;
+  customHeaders: { key: string; value: string }[];
+  submitting: boolean;
+  globalError: string | null;
+  result: PortalTestResult | null;
+  eventTypes: PortalEventTypeListItem[];
+  eventTypesLoading: boolean;
+  signedRequestExpanded: boolean;
+  responseBodyExpanded: boolean;
+}
+
+type TesterAction =
+  | { type: "SET_EVENT_TYPE"; id: string }
+  | { type: "SET_PAYLOAD"; text: string; error: string | null }
+  | { type: "ADD_HEADER" }
+  | { type: "UPDATE_HEADER"; index: number; key: string; value: string }
+  | { type: "REMOVE_HEADER"; index: number }
+  | { type: "SUBMIT_START" }
+  | { type: "SUBMIT_SUCCESS"; result: PortalTestResult }
+  | { type: "SUBMIT_ERROR"; message: string }
+  | { type: "EVENT_TYPES_LOADED"; eventTypes: PortalEventTypeListItem[] }
+  | { type: "TOGGLE_SIGNED_REQUEST" }
+  | { type: "TOGGLE_RESPONSE_BODY" };
+
+function testerReducer(state: TesterState, action: TesterAction): TesterState {
+  switch (action.type) {
+    case "SET_EVENT_TYPE":
+      return { ...state, eventTypeId: action.id };
+    case "SET_PAYLOAD":
+      return { ...state, payloadText: action.text, payloadError: action.error };
+    case "ADD_HEADER":
+      return {
+        ...state,
+        customHeaders: [...state.customHeaders, { key: "", value: "" }],
+      };
+    case "UPDATE_HEADER": {
+      const updated = state.customHeaders.map((h, i) =>
+        i === action.index ? { key: action.key, value: action.value } : h,
+      );
+      return { ...state, customHeaders: updated };
+    }
+    case "REMOVE_HEADER":
+      return {
+        ...state,
+        customHeaders: state.customHeaders.filter((_, i) => i !== action.index),
+      };
+    case "SUBMIT_START":
+      return { ...state, submitting: true, globalError: null };
+    case "SUBMIT_SUCCESS":
+      return { ...state, submitting: false, result: action.result, globalError: null };
+    case "SUBMIT_ERROR":
+      return { ...state, submitting: false, globalError: action.message };
+    case "EVENT_TYPES_LOADED":
+      return { ...state, eventTypes: action.eventTypes, eventTypesLoading: false };
+    case "TOGGLE_SIGNED_REQUEST":
+      return { ...state, signedRequestExpanded: !state.signedRequestExpanded };
+    case "TOGGLE_RESPONSE_BODY":
+      return { ...state, responseBodyExpanded: !state.responseBodyExpanded };
+  }
+}
+
+function headersToRecord(headers: { key: string; value: string }[]): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const { key, value } of headers) {
+    const trimmedKey = key.trim();
+    if (trimmedKey) result[trimmedKey] = value;
+  }
+  return result;
+}
+
+function statusColor(code: number): string {
+  if (code >= 200 && code < 300) return "text-whe-success";
+  if (code >= 300 && code < 400) return "text-whe-warning";
+  return "text-whe-danger";
+}
+
+function statusBg(code: number): string {
+  if (code >= 200 && code < 300) return "bg-whe-success-soft border-whe-success/30";
+  if (code >= 300 && code < 400) return "bg-whe-warning-soft border-whe-warning/30";
+  return "bg-whe-danger-soft border-whe-danger/30";
+}
+
+const SIGNATURE_HEADERS = new Set(["webhook-id", "webhook-timestamp", "webhook-signature"]);
+const BODY_COLLAPSE_THRESHOLD = 500;
+
+export function EndpointTester({
+  client,
+  endpoint,
+  capabilities,
+  onClose,
+}: EndpointTesterProps): JSX.Element {
+  const canTest = capabilities.includes("endpoints:test");
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const firstFocusableRef = useRef<HTMLSelectElement | null>(null);
+
+  const [state, dispatch] = useReducer(testerReducer, {
+    eventTypeId: "",
+    payloadText: "{\n  \n}",
+    payloadError: null,
+    customHeaders: [],
+    submitting: false,
+    globalError: null,
+    result: null,
+    eventTypes: [],
+    eventTypesLoading: true,
+    signedRequestExpanded: false,
+    responseBodyExpanded: false,
+  });
+
+  // Track whether we've validated once (to show errors on empty submit attempt).
+  const [submitted, setSubmitted] = useState(false);
+
+  useEffect(() => {
+    client.listEventTypes().then((types) => {
+      dispatch({ type: "EVENT_TYPES_LOADED", eventTypes: types });
+      if (types.length > 0 && types[0]) {
+        dispatch({ type: "SET_EVENT_TYPE", id: types[0].id });
+      }
+    }).catch(() => {
+      dispatch({ type: "EVENT_TYPES_LOADED", eventTypes: [] });
+    });
+  }, [client]);
+
+  // Focus trap and Escape key.
+  useEffect(() => {
+    firstFocusableRef.current?.focus();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (e.key !== "Tab") return;
+
+      const overlay = overlayRef.current;
+      if (!overlay) return;
+      const focusable = overlay.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      );
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (!first || !last) return;
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "";
+    };
+  }, [onClose]);
+
+  const handlePayloadBlur = useCallback(() => {
+    if (!state.payloadText.trim()) return;
+    try {
+      JSON.parse(state.payloadText);
+      dispatch({ type: "SET_PAYLOAD", text: state.payloadText, error: null });
+    } catch {
+      dispatch({ type: "SET_PAYLOAD", text: state.payloadText, error: "Invalid JSON" });
+    }
+  }, [state.payloadText]);
+
+  const handleSubmit = useCallback(async () => {
+    setSubmitted(true);
+
+    // Validate event type.
+    if (!state.eventTypeId) return;
+
+    // Validate payload JSON.
+    let parsedPayload: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(state.payloadText);
+      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+        dispatch({ type: "SET_PAYLOAD", text: state.payloadText, error: "Payload must be a JSON object" });
+        return;
+      }
+      parsedPayload = parsed as Record<string, unknown>;
+    } catch {
+      dispatch({ type: "SET_PAYLOAD", text: state.payloadText, error: "Invalid JSON" });
+      return;
+    }
+
+    dispatch({ type: "SUBMIT_START" });
+
+    const customHeaders = headersToRecord(state.customHeaders);
+
+    try {
+      const result = await client.testEndpoint(endpoint.id, {
+        eventType: state.eventTypeId,
+        payload: parsedPayload,
+        ...(Object.keys(customHeaders).length > 0 ? { customHeaders } : {}),
+      });
+      dispatch({ type: "SUBMIT_SUCCESS", result });
+    } catch (err) {
+      dispatch({
+        type: "SUBMIT_ERROR",
+        message: err instanceof PortalError
+          ? err.message
+          : err instanceof Error
+            ? err.message
+            : "An unexpected error occurred.",
+      });
+    }
+  }, [client, endpoint.id, state.eventTypeId, state.payloadText, state.customHeaders]);
+
+  const isPayloadInvalid = !!state.payloadError || !state.payloadText.trim();
+  const isEventTypeMissing = submitted && !state.eventTypeId;
+  const canSend = !state.submitting && !isPayloadInvalid && !!state.eventTypeId;
+
+  const truncateUrl = (url: string) => url.length > 48 ? url.slice(0, 48) + "…" : url;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        ref={overlayRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="whe-tester-title"
+        className="relative flex w-full max-w-2xl flex-col overflow-hidden rounded-2xl border border-whe-border bg-whe-bg-1 shadow-2xl max-h-[90dvh]"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-whe-border px-6 py-4">
+          <div>
+            <h2 id="whe-tester-title" className="text-base font-semibold text-whe-text-primary">
+              Test endpoint
+            </h2>
+            <p className="mt-0.5 text-xs text-whe-text-muted font-mono">
+              {truncateUrl(endpoint.url)}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md p-1 text-whe-text-muted hover:text-whe-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-whe-accent"
+            aria-label="Close"
+          >
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+              <path d="M12 4L4 12M4 4l8 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="overflow-y-auto px-6 py-5">
+          {/* Capability gate */}
+          {!canTest ? (
+            <div className="rounded-lg border border-whe-warning/30 bg-whe-warning-soft px-4 py-4 text-sm text-whe-warning">
+              <p className="font-medium">Capability required</p>
+              <p className="mt-1 text-xs text-whe-text-secondary">
+                Your portal token does not include the <code className="rounded bg-whe-bg-3 px-1 py-0.5 font-mono text-xs">endpoints:test</code> capability.
+                Contact the application operator to request access.
+              </p>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-5">
+              {/* Global error */}
+              {state.globalError && (
+                <p role="alert" className="rounded-lg bg-whe-danger-soft px-4 py-3 text-sm text-whe-danger">
+                  {state.globalError}
+                </p>
+              )}
+
+              {/* Two-pane: form left, result right (stacked on mobile) */}
+              <div className={state.result ? "grid gap-5 lg:grid-cols-2" : "flex flex-col gap-5"}>
+                {/* Request form */}
+                <div className="flex flex-col gap-4">
+                  {/* Event type */}
+                  <div className="flex flex-col gap-1.5">
+                    <label htmlFor="whe-tester-event" className="text-xs font-medium text-whe-text-secondary">
+                      Event type <span className="ml-0.5 text-whe-danger" aria-hidden="true">*</span>
+                    </label>
+                    {state.eventTypesLoading ? (
+                      <div className="h-9 animate-pulse rounded-lg bg-whe-bg-3" />
+                    ) : (
+                      <select
+                        ref={firstFocusableRef}
+                        id="whe-tester-event"
+                        value={state.eventTypeId}
+                        onChange={(e) => dispatch({ type: "SET_EVENT_TYPE", id: e.target.value })}
+                        className={[
+                          "w-full rounded-lg border bg-whe-bg-3 px-3 py-2 text-sm text-whe-text-primary",
+                          "focus:outline-none focus-visible:ring-2",
+                          isEventTypeMissing
+                            ? "border-whe-danger focus-visible:ring-whe-danger"
+                            : "border-whe-border focus-visible:ring-whe-accent",
+                        ].join(" ")}
+                      >
+                        <option value="">— Select event type —</option>
+                        {state.eventTypes.map((et) => (
+                          <option key={et.id} value={et.id}>
+                            {et.name}
+                          </option>
+                        ))}
+                      </select>
+                    )}
+                    {isEventTypeMissing && (
+                      <p role="alert" className="text-xs text-whe-danger">Event type is required</p>
+                    )}
+                    {state.eventTypes.length === 0 && !state.eventTypesLoading && (
+                      <p className="text-xs text-whe-text-muted">No event types defined for this application.</p>
+                    )}
+                  </div>
+
+                  {/* Payload */}
+                  <div className="flex flex-col gap-1.5">
+                    <label htmlFor="whe-tester-payload" className="text-xs font-medium text-whe-text-secondary">
+                      Payload <span className="ml-0.5 text-whe-danger" aria-hidden="true">*</span>
+                    </label>
+                    <textarea
+                      id="whe-tester-payload"
+                      value={state.payloadText}
+                      onChange={(e) =>
+                        dispatch({ type: "SET_PAYLOAD", text: e.target.value, error: null })
+                      }
+                      onBlur={handlePayloadBlur}
+                      rows={6}
+                      spellCheck={false}
+                      className={[
+                        "w-full rounded-lg border bg-whe-bg-3 px-3 py-2 font-mono text-xs text-whe-text-primary placeholder:text-whe-text-muted",
+                        "resize-y focus:outline-none focus-visible:ring-2",
+                        state.payloadError
+                          ? "border-whe-danger focus-visible:ring-whe-danger"
+                          : "border-whe-border focus-visible:ring-whe-accent",
+                      ].join(" ")}
+                      placeholder='{"key": "value"}'
+                    />
+                    {state.payloadError && (
+                      <p role="alert" className="text-xs text-whe-danger">{state.payloadError}</p>
+                    )}
+                  </div>
+
+                  {/* Custom headers */}
+                  <div className="flex flex-col gap-1.5">
+                    <span className="text-xs font-medium text-whe-text-secondary">Custom headers (optional)</span>
+                    <div className="space-y-2">
+                      {state.customHeaders.map((header, index) => (
+                        <div key={index} className="flex gap-2">
+                          <input
+                            type="text"
+                            value={header.key}
+                            onChange={(e) =>
+                              dispatch({
+                                type: "UPDATE_HEADER",
+                                index,
+                                key: e.target.value,
+                                value: header.value,
+                              })
+                            }
+                            placeholder="Header name"
+                            className="flex-1 rounded-lg border border-whe-border bg-whe-bg-3 px-3 py-2 text-sm text-whe-text-primary placeholder:text-whe-text-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-whe-accent"
+                            aria-label={`Custom header ${index + 1} name`}
+                          />
+                          <input
+                            type="text"
+                            value={header.value}
+                            onChange={(e) =>
+                              dispatch({
+                                type: "UPDATE_HEADER",
+                                index,
+                                key: header.key,
+                                value: e.target.value,
+                              })
+                            }
+                            placeholder="Value"
+                            className="flex-1 rounded-lg border border-whe-border bg-whe-bg-3 px-3 py-2 text-sm text-whe-text-primary placeholder:text-whe-text-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-whe-accent"
+                            aria-label={`Custom header ${index + 1} value`}
+                          />
+                          <button
+                            type="button"
+                            onClick={() => dispatch({ type: "REMOVE_HEADER", index })}
+                            className="shrink-0 rounded px-2 text-whe-text-muted hover:text-whe-danger focus:outline-none focus-visible:ring-1 focus-visible:ring-whe-danger"
+                            aria-label={`Remove custom header ${index + 1}`}
+                          >
+                            ×
+                          </button>
+                        </div>
+                      ))}
+                      <button
+                        type="button"
+                        onClick={() => dispatch({ type: "ADD_HEADER" })}
+                        className="text-xs text-whe-accent hover:opacity-80 focus:outline-none focus-visible:ring-1 focus-visible:ring-whe-accent"
+                      >
+                        + Add header
+                      </button>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Response panel — renders after a successful send */}
+                {state.result && (
+                  <ResponsePanel
+                    result={state.result}
+                    signedRequestExpanded={state.signedRequestExpanded}
+                    responseBodyExpanded={state.responseBodyExpanded}
+                    onToggleSignedRequest={() => dispatch({ type: "TOGGLE_SIGNED_REQUEST" })}
+                    onToggleResponseBody={() => dispatch({ type: "TOGGLE_RESPONSE_BODY" })}
+                  />
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-2 border-t border-whe-border px-6 py-4">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md px-4 py-2 text-sm text-whe-text-secondary hover:text-whe-text-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-whe-accent"
+          >
+            {canTest ? "Cancel" : "Close"}
+          </button>
+          {canTest && (
+            <button
+              type="button"
+              disabled={!canSend}
+              onClick={() => void handleSubmit()}
+              className="rounded-md bg-whe-accent px-4 py-2 text-sm font-medium text-whe-bg-0 hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-whe-accent disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {state.submitting ? "Sending…" : "Send test"}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Internal: Response panel
+// ---------------------------------------------------------------------------
+
+interface ResponsePanelProps {
+  result: PortalTestResult;
+  signedRequestExpanded: boolean;
+  responseBodyExpanded: boolean;
+  onToggleSignedRequest: () => void;
+  onToggleResponseBody: () => void;
+}
+
+function ResponsePanel({
+  result,
+  signedRequestExpanded,
+  responseBodyExpanded,
+  onToggleSignedRequest,
+  onToggleResponseBody,
+}: ResponsePanelProps): JSX.Element {
+  const bodyTooLong = result.responseBody.length > BODY_COLLAPSE_THRESHOLD;
+  const displayBody = !bodyTooLong || responseBodyExpanded
+    ? result.responseBody
+    : result.responseBody.slice(0, BODY_COLLAPSE_THRESHOLD) + "…";
+
+  return (
+    <div className="flex flex-col gap-4 rounded-xl border border-whe-border bg-whe-bg-2 p-4">
+      <p className="text-xs font-semibold uppercase tracking-wide text-whe-text-muted">Response</p>
+
+      {/* Status + latency row */}
+      <div className="flex items-center gap-3">
+        <span
+          className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold ${statusBg(result.statusCode)}`}
+        >
+          <span className={statusColor(result.statusCode)}>{result.statusCode}</span>
+        </span>
+        <span className="text-xs text-whe-text-secondary">
+          {result.latencyMs} ms
+        </span>
+        {result.error && (
+          <span className="text-xs text-whe-danger">{result.error}</span>
+        )}
+      </div>
+
+      {/* Response body */}
+      <div className="flex flex-col gap-1">
+        <p className="text-xs font-medium text-whe-text-secondary">Body</p>
+        {result.responseBody ? (
+          <>
+            <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded-lg bg-whe-bg-3 px-3 py-2 font-mono text-xs text-whe-text-primary">
+              {displayBody}
+            </pre>
+            {bodyTooLong && (
+              <button
+                type="button"
+                onClick={onToggleResponseBody}
+                className="self-start text-xs text-whe-accent hover:opacity-80 focus:outline-none focus-visible:ring-1 focus-visible:ring-whe-accent"
+              >
+                {responseBodyExpanded ? "Show less" : `Show all (${result.responseBody.length} chars)`}
+              </button>
+            )}
+          </>
+        ) : (
+          <p className="text-xs italic text-whe-text-muted">no body</p>
+        )}
+      </div>
+
+      {/* Signed-request preview */}
+      <div className="flex flex-col gap-1">
+        <button
+          type="button"
+          onClick={onToggleSignedRequest}
+          className="flex items-center gap-1.5 text-xs font-medium text-whe-text-secondary hover:text-whe-text-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-whe-accent"
+          aria-expanded={signedRequestExpanded}
+        >
+          <svg
+            width="10"
+            height="10"
+            viewBox="0 0 10 10"
+            fill="none"
+            aria-hidden="true"
+            className={`transition-transform ${signedRequestExpanded ? "rotate-90" : ""}`}
+          >
+            <path d="M3 2l4 3-4 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+          Signed request preview
+        </button>
+        {signedRequestExpanded && (
+          <div className="mt-1 flex flex-col gap-2 rounded-lg border border-whe-border bg-whe-bg-3 px-3 py-3">
+            <div>
+              <p className="mb-1 text-xs font-medium text-whe-text-secondary">URL</p>
+              <p className="break-all font-mono text-xs text-whe-text-primary">{result.request.url}</p>
+            </div>
+            <div>
+              <p className="mb-1 text-xs font-medium text-whe-text-secondary">Headers</p>
+              <div className="space-y-0.5">
+                {Object.entries(result.request.headers).map(([key, value]) => {
+                  const isSignatureHeader = SIGNATURE_HEADERS.has(key.toLowerCase());
+                  return (
+                    <div key={key} className="flex gap-2 font-mono text-xs">
+                      <span
+                        className={`shrink-0 ${isSignatureHeader ? "text-whe-accent font-semibold" : "text-whe-text-muted"}`}
+                      >
+                        {key}:
+                      </span>
+                      <span className="break-all text-whe-text-primary">{value}</span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+            <div>
+              <p className="mb-1 text-xs font-medium text-whe-text-secondary">Body</p>
+              <pre className="overflow-x-auto whitespace-pre-wrap break-words font-mono text-xs text-whe-text-primary">
+                {result.request.body}
+              </pre>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/endpoint-manager/src/index.ts
+++ b/packages/endpoint-manager/src/index.ts
@@ -1,6 +1,8 @@
 export { EndpointManager } from "./EndpointManager.js";
 export { EndpointList } from "./components/EndpointList.js";
 export { EndpointEditor } from "./components/EndpointEditor.js";
+export { EndpointTester } from "./components/EndpointTester.js";
+export { AttemptList } from "./components/AttemptList.js";
 export { createPortalClient, PortalError } from "./api/createPortalClient.js";
 
 export type {
@@ -13,6 +15,8 @@ export type {
   PortalCreateEndpointInput,
   PortalUpdateEndpointInput,
   PortalAttempt,
+  PortalTestResult,
+  PortalTestRequestPreview,
 } from "./types.js";
 
 export type {
@@ -20,6 +24,7 @@ export type {
   PortalClientOptions,
   PortalListResult,
   PortalPagination,
+  PortalTestEndpointInput,
 } from "./api/createPortalClient.js";
 
 export type { EditorMode } from "./components/EndpointEditor.js";

--- a/packages/endpoint-manager/src/types.ts
+++ b/packages/endpoint-manager/src/types.ts
@@ -38,14 +38,44 @@ export interface PortalEventTypeListItem {
   description: string | null;
 }
 
+/**
+ * Single delivery attempt row returned by GET /api/v1/portal/endpoints/{id}/attempts.
+ * Field names mirror PortalAttemptRow on the server (PortalDtos.cs).
+ */
 export interface PortalAttempt {
   id: string;
-  endpointId: string;
+  messageId: string;
+  attemptNumber: number;
+  /** "success" | "failure" — serialised from AttemptStatus enum as camelCase */
   status: string;
-  httpStatus: number | null;
-  latencyMs: number | null;
-  occurredAt: string;
-  responseBody: string | null;
+  /** HTTP status code; null when a network-level error occurred before a response */
+  statusCode: number | null;
+  error: string | null;
+  latencyMs: number;
+  createdAt: string;
+}
+
+/**
+ * Result returned by POST /api/v1/portal/endpoints/{id}/test.
+ * Field names mirror EndpointTestResult on the server (EndpointTestModels.cs).
+ */
+export interface PortalTestResult {
+  success: boolean;
+  statusCode: number;
+  latencyMs: number;
+  responseBody: string;
+  error: string | null;
+  request: PortalTestRequestPreview;
+}
+
+/**
+ * The signed request that was actually sent to the endpoint.
+ * Mirrors EndpointTestRequestPreview on the server.
+ */
+export interface PortalTestRequestPreview {
+  url: string;
+  headers: Record<string, string>;
+  body: string;
 }
 
 export interface PortalCreateEndpointInput {

--- a/packages/endpoint-manager/tsup.config.ts
+++ b/packages/endpoint-manager/tsup.config.ts
@@ -4,7 +4,10 @@ export default defineConfig({
   entry: ["src/index.ts"],
   format: ["esm"],
   dts: true,
-  clean: true,
+  // clean: false — the `clean` npm script handles dist removal so the build
+  // order is always: clean → build:css → tsup. This prevents tsup from wiping
+  // style.css when build:css runs before tsup in some invocations.
+  clean: false,
   sourcemap: true,
   treeshake: true,
   external: ["react", "react-dom"]


### PR DESCRIPTION
## Summary

**Step 9 of the B1 (embeddable customer portal) plan.** Second pair of components for `@webhookengine/endpoint-manager`. Step 8 landed list + editor; this PR completes the customer-facing surface with endpoint testing and per-endpoint delivery history.

## Components

- **`<EndpointTester />`** — modal opened from the EndpointList row's Test action. Form: event-type select + JSON payload textarea (with on-blur validation surfacing inline 'Invalid JSON' + Send disabled while invalid) + custom-headers editor. Two-pane layout once a test has been sent. Response panel: status code color-coded (2xx green / 3xx amber / 4xx-5xx red / network gray), latency, response body (collapsed if >500 chars), AND a **collapsible signed-request preview** showing URL + headers (`webhook-id` / `webhook-timestamp` / `webhook-signature` highlighted) + body — what the receiver actually HMAC-verifies. Capability gating: missing `endpoints:test` renders a graceful banner.
- **`<AttemptList />`** — modal opened from the EndpointList row's Attempts action. Table: When (relative + absolute on hover) / Status badge / HTTP code / Latency / Response excerpt (60 chars; click row to expand). Pagination footer + skeleton loading + empty + error retry states. Capability gating: missing `attempts:read` renders a banner; `listAttempts` is never called.

**Decision:** Attempts is a separate modal from the list, NOT a tab inside `EndpointEditor` — modal-inside-modal a11y is too gnarly.

## Portal client implementations

`testEndpoint` and `listAttempts` stubs from Step 8 replaced with real implementations. Both follow the existing client pattern: Bearer auth, `ApiEnvelope` unwrap, 4xx/5xx → `PortalError` with code+status+fieldErrors, `onError` fires before throw, `onUnauthorized` hooks 401.

## Backend contract divergence — types corrected

The Step 8 `PortalAttempt` type and the Step 9 `PortalTestResult` design intent didn't match what the server actually returns. Agent read the controller + DTOs and realigned:

- **`PortalTestResult`** — design intent had nested `signedRequest`. Server's `EndpointTestResult` is `{ success, statusCode, latencyMs, responseBody, error, request }` — `request` (not `signedRequest`), plus `success` boolean and `error` string. Renamed.
- **`PortalAttempt`** — Step 8's TS type had `httpStatus`, `endpointId`, `occurredAt` fields that don't exist on the server. Server's `PortalAttemptRow` is `{ id, messageId, attemptNumber, status, statusCode (nullable int), error (nullable string), latencyMs, createdAt }`. Realigned. Backwards-incompatible type change but the package is `private: true` and not on npm yet — no consumer impact.

## Tests

- **42 passed / 0 failed** (Step 8 baseline: 23; **+19 net new**).
- `createPortalClient.test.ts` +6: `testEndpoint` happy + 403 + 422; `listAttempts` happy + pagination + empty.
- `EndpointTester.test.tsx` (new, 7): renders form when capability present, capability banner when missing, invalid JSON disables Send, submit fires correct body, response panel renders status+latency+body, signed-request preview is collapsible and contains `webhook-signature`.
- `AttemptList.test.tsx` (new, 7): rows render, status badge color-codes, pagination Prev/Next disabled at boundaries, empty state, capability banner.

## Bundle size

| Asset | Raw | gzip est. |
|---|---|---|
| `dist/index.js` | 85.6 KB | ~14.2 KB |
| `dist/style.css` | 19.0 KB | ~4.3 KB |
| **Total** | | **~18.5 KB gz** |

Step 8 baseline was 12.6 KB gz. **Δ +5.9 KB gz** for two modal components + response panel + attempts table + signed-request preview. Well under the 30 KB gz target.

## Build sequence cleanup applied

Step 8 left a flag: `bun run build` was `tsup && bun run build:css` — fragile to script-order flips. Fixed in this PR:
- `tsup.config.ts`: `clean: false`.
- `package.json` build: `bun run clean && bun run build:css && tsup`.

## Demo harness

Two new mock fetch routes:
- `POST .../endpoints/{id}/test` → realistic `PortalTestResult` with dynamic `webhook-id`/`webhook-timestamp`/`webhook-signature: v1,...`.
- `GET .../endpoints/{id}/attempts` → 7 synthetic attempts (4 Success + 3 Failure, including a network error with `statusCode: null`).

Demo capabilities now `["endpoints:read", "endpoints:write", "endpoints:test", "attempts:read"]` so both new buttons render.

## What does NOT land (Step 10+)

- `publish-portal.yml` workflow + `samples/portal-host/` (Step 10)
- npm publish — `private: true` stays. Step 11 flips the flag and tags `portal-v0.1.0`.

## Reviewer attention

The **500-char hard-coded response-body collapse threshold** in `EndpointTester`. JSON: fine. HTML error pages: low. Two follow-up options: bump to 1000, OR expose `responseCollapseThreshold?: number` on `EndpointManagerProps`. The latter touches the public API surface, so the decision belongs **before Step 11 publish**.

## Test plan

- [x] `bun run lint`, `typecheck`, `build` clean
- [x] `bun run test` → 42 passed / 0 failed
- [x] `bun run dev` boots the demo at `localhost:5173` with both new flows mocked
- [ ] CI green