### PR TITLE
feat(npm+ci): publish-portal.yml workflow + samples/portal-host reference app (B1 Step 10)

### DIFF
--- a/.github/workflows/publish-portal.yml
+++ b/.github/workflows/publish-portal.yml
@@ -1,0 +1,84 @@
+name: Publish Portal Package
+
+on:
+  push:
+    tags:
+      - "portal-v*"
+
+permissions:
+  contents: read
+  id-token: write   # required for npm provenance / sigstore attestation
+
+env:
+  BUN_VERSION: "1.2.x"
+  NODE_VERSION: "20"
+
+jobs:
+  publish:
+    name: Publish @webhookengine/endpoint-manager
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      # setup-node is required alongside setup-bun because `npm publish`
+      # is the canonical npm registry client; bun's npm publish path does not
+      # reliably emit sigstore provenance attestations on GitHub-hosted runners.
+      - name: Setup Node (for npm publish)
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies (workspace root)
+        run: bun install --frozen-lockfile
+
+      - name: Pre-publish guard — typecheck + lint + test
+        working-directory: packages/endpoint-manager
+        run: |
+          bun run typecheck
+          bun run lint
+          bun run test
+
+      - name: Build package
+        working-directory: packages/endpoint-manager
+        run: bun run build
+
+      - name: Verify build artifacts
+        working-directory: packages/endpoint-manager
+        run: |
+          test -f dist/index.js   || (echo "::error::dist/index.js missing";   exit 1)
+          test -f dist/index.d.ts || (echo "::error::dist/index.d.ts missing"; exit 1)
+          test -f dist/style.css  || (echo "::error::dist/style.css missing";  exit 1)
+          ls -la dist/
+
+      - name: Set package version from tag
+        working-directory: packages/endpoint-manager
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#portal-v}"
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+
+      - name: Verify package not marked private before publish
+        working-directory: packages/endpoint-manager
+        run: |
+          PRIVATE=$(node -p "require('./package.json').private || false")
+          if [ "$PRIVATE" = "true" ]; then
+            echo "::error::package.json carries private:true — cannot publish."
+            echo "::error::Flip private:false (or remove the field) on the release branch before pushing portal-v* tags."
+            exit 1
+          fi
+
+      - name: Publish to npm
+        working-directory: packages/endpoint-manager
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+- **npm publish workflow** (`publish-portal.yml`). New `.github/workflows/publish-portal.yml` fires on `portal-v*` tags and publishes `@webhookengine/endpoint-manager` to npmjs.com with sigstore provenance (`--provenance`). Includes a pre-publish guard that fails with a human-readable error if `private:true` is still set in `package.json`, preventing accidental publishes from dev branches.
+- **`samples/portal-host/` reference application.** Standalone Vite + React app demonstrating host-SaaS integration with `<EndpointManager />`. Uses a browser-native Web Crypto HS256 mint (`mint-token.ts`) and an in-memory fetch shim (`mock-fetch.ts`) — no engine instance required to run. Shows prop wiring, CSS custom-property theme overrides, and the server-side token-mint pattern.
+- **`docs/PORTAL.md` Section 5 — Component Usage.** Replaced the "coming soon" placeholder with a full quickstart: reference to `samples/portal-host/`, a server-side `jose` + Express JWT mint snippet, a React-side `<EndpointManager />` embedding snippet, and CSS theme override instructions.
+- **`docs/RELEASE.md` Section 6 — Portal package release.** Documents the `portal-v*` tag scheme, `NPM_TOKEN` secret setup steps, sigstore provenance setup, and the pre-flight checklist to run before pushing a release tag.
+
 ## [0.2.0] - 2026-05-10
 
 The first minor release. Adds an embeddable customer-facing portal: SaaS operators can now hand customers a self-service `<EndpointManager />` React component that runs against a narrowed `/api/v1/portal/*` API surface, scoped per-application via short-lived HS256 JWTs minted by the host SaaS backend. The engine never mints these tokens — it only verifies them — and the per-app signing key is generated, rotated, and revoked from the operator dashboard. No breaking changes to the existing v1 surface; the `v1` route prefix and Standard Webhooks signature header names are preserved.

--- a/bun.lock
+++ b/bun.lock
@@ -31,6 +31,22 @@
         "react-dom": "^19.0.0",
       },
     },
+    "samples/portal-host": {
+      "name": "portal-host-sample",
+      "version": "0.0.0",
+      "dependencies": {
+        "@webhookengine/endpoint-manager": "workspace:*",
+        "react": "^19.2.6",
+        "react-dom": "^19.2.6",
+      },
+      "devDependencies": {
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^5.0.5",
+        "typescript": "6.0.3",
+        "vite": "8.0.11",
+      },
+    },
     "src/dashboard": {
       "name": "webhookengine-dashboard",
       "version": "0.2.0",
@@ -786,6 +802,8 @@
 
     "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
+    "portal-host-sample": ["portal-host-sample@workspace:samples/portal-host"],
+
     "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
 
     "postcss-load-config": ["postcss-load-config@6.0.1", "", { "dependencies": { "lilconfig": "^3.1.1" }, "peerDependencies": { "jiti": ">=1.21.0", "postcss": ">=8.0.9", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["jiti", "postcss", "tsx", "yaml"] }, "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g=="],
@@ -990,6 +1008,10 @@
 
     "codemirror/@codemirror/view": ["@codemirror/view@6.41.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg=="],
 
+    "portal-host-sample/@vitejs/plugin-react": ["@vitejs/plugin-react@5.2.0", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw=="],
+
+    "portal-host-sample/vite": ["vite@8.0.11", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.14", "rolldown": "1.0.0-rc.18", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow=="],
+
     "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.18", "", {}, "sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw=="],
@@ -1003,6 +1025,10 @@
     "webhookengine-dashboard/vite": ["vite@8.0.11", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.14", "rolldown": "1.0.0-rc.18", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow=="],
 
     "whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "portal-host-sample/@vitejs/plugin-react/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
+
+    "portal-host-sample/@vitejs/plugin-react/react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
 
     "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /workspace
 COPY package.json bun.lock ./
 COPY src/dashboard/package.json src/dashboard/package.json
 COPY packages/endpoint-manager/package.json packages/endpoint-manager/package.json
+COPY samples/portal-host/package.json samples/portal-host/package.json
 RUN bun install --frozen-lockfile
 
 COPY src/dashboard src/dashboard

--- a/docs/PORTAL.md
+++ b/docs/PORTAL.md
@@ -10,7 +10,7 @@ This guide covers the embeddable customer portal shipped in v0.2.0. It is writte
 2. [Architecture](#2-architecture)
 3. [Operator Setup](#3-operator-setup)
 4. [Host SaaS Integration](#4-host-sas-integration)
-5. [Component Usage (coming soon)](#5-component-usage-coming-soon)
+5. [Component Usage](#5-component-usage)
 6. [Security Model](#6-security-model)
 7. [Configuration Reference](#7-configuration-reference)
 8. [Limits](#8-limits)
@@ -33,7 +33,7 @@ The customer portal lets SaaS operators embed a self-service endpoint-management
 **What you build:**
 
 - A short-lived JWT minted by your backend and passed to the frontend component.
-- A settings page in your product that renders the `<EndpointManager />` component (shipping in a follow-up tag — see [Section 5](#5-component-usage-coming-soon)).
+- A settings page in your product that renders the `<EndpointManager />` component.
 
 ---
 
@@ -193,22 +193,102 @@ Admin-only fields stripped on portal writes and reads: `transformExpression`, `t
 
 ---
 
-## 5. Component Usage (coming soon)
+## 5. Component Usage
 
-The `@webhookengine/endpoint-manager` React package is tracked under B1 Step 7 of the roadmap and will ship in a follow-up `portal-v0.1.0` tag after v0.2.0. It is not bundled in the engine release.
+The `@webhookengine/endpoint-manager` npm package ships the `<EndpointManager />` React component. It pairs with the `/api/v1/portal/*` engine surface described above.
 
-When it ships, usage will look roughly like:
+> The package is not yet on npm. Step 11 of the B1 roadmap pushes the first `portal-v0.1.0` tag that triggers the publish workflow. Until then, install via the Bun workspace: `"@webhookengine/endpoint-manager": "workspace:*"`.
+
+### 5.1 Quickstart — reference sample
+
+`samples/portal-host/` is the canonical consumer-side reference. Run it locally with no engine instance required:
+
+```bash
+cd samples/portal-host
+bun install
+bun run dev
+# Opens http://localhost:5173
+```
+
+The sample installs a fetch shim (`mock-fetch.ts`) that serves in-memory data so you can explore the full component UI without any Docker setup.
+
+### 5.2 Server-side token mint (Node.js + Express)
+
+Your host SaaS backend exposes an internal route that mints the JWT and returns it to the browser. The signing key **never leaves your server**.
+
+```js
+import express from 'express'
+import { SignJWT } from 'jose'
+
+const router = express.Router()
+
+// POST /internal/portal-token
+// Called by your frontend after the customer's session is verified.
+router.post('/internal/portal-token', requireSession, async (req, res) => {
+  const { customerId } = req.session
+
+  // Look up the WebhookEngine appId for this customer from your own DB.
+  const appId = await db.customers.getWebhookAppId(customerId)
+
+  // The signing key comes from your secrets manager, keyed per appId.
+  const signingKey = await secrets.get(`PORTAL_KEY_${appId}`)
+
+  const secret = new TextEncoder().encode(signingKey)
+  const now = Math.floor(Date.now() / 1000)
+
+  const token = await new SignJWT({ sub: appId, appId, cap: ['endpoints:read', 'endpoints:write', 'endpoints:test', 'attempts:read'] })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt(now)
+    .setNotBefore(now)
+    .setExpirationTime(now + 10 * 60)   // 10 minutes
+    .sign(secret)
+
+  res.json({ token, expiresAt: new Date((now + 600) * 1000).toISOString() })
+})
+```
+
+### 5.3 React-side embedding
 
 ```tsx
 import { EndpointManager } from '@webhookengine/endpoint-manager'
+import '@webhookengine/endpoint-manager/style.css'
+import { useEffect, useState } from 'react'
 
-<EndpointManager
-  apiBase="https://webhooks.yourproduct.com"
-  token={portalToken}
-/>
+export function WebhookSettingsPage() {
+  const [token, setToken] = useState<string | null>(null)
+
+  useEffect(() => {
+    // Fetch the short-lived JWT from your OWN backend.
+    fetch('/internal/portal-token', { method: 'POST' })
+      .then(r => r.json())
+      .then(({ token }) => setToken(token))
+  }, [])
+
+  if (!token) return <p>Loading…</p>
+
+  return (
+    <EndpointManager
+      baseUrl="https://hooks.yourproduct.com"
+      token={token}
+      appId={APP_ID}
+      capabilities={['endpoints:read', 'endpoints:write', 'endpoints:test', 'attempts:read']}
+    />
+  )
+}
 ```
 
-Watch the [GitHub roadmap](https://github.com/voyvodka/webhook-engine/blob/main/docs/ROADMAP.md) for the `portal-v0.1.0` tag.
+### 5.4 Theme overrides
+
+The component exposes CSS custom properties so you can match your brand without forking the package. Declare them in your host page's `:root` or a wrapping selector:
+
+```css
+:root {
+  --color-whe-accent: #7c3aed;          /* primary interactive colour */
+  --color-whe-accent-soft: rgb(124 58 237 / 0.15); /* hover / focus tint */
+}
+```
+
+See `samples/portal-host/src/styles.css` for a working example and `packages/endpoint-manager/src/styles.css` for the full token list.
 
 ---
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -4,14 +4,16 @@ This guide explains how to publish:
 
 1. Docker image to Docker Hub
 2. .NET SDK package to NuGet
+3. `@webhookengine/endpoint-manager` npm package
 
-Both are automated by `.github/workflows/release.yml` and triggered by version tags (`v*`).
+Docker and the .NET SDK are automated by `.github/workflows/release.yml` and triggered by `v*` tags. The npm package is automated by `.github/workflows/publish-portal.yml` and triggered by `portal-v*` tags.
 
 ## Prerequisites
 
 - GitHub repository with Actions enabled
 - Docker Hub account and repository (`voyvodka/webhook-engine` by default)
 - NuGet.org account with API key
+- npmjs.com account with automation token (for the portal package)
 
 ## 1) Configure GitHub Secrets
 
@@ -24,6 +26,7 @@ Add these secrets:
 | `DOCKERHUB_USERNAME` | Docker Hub username |
 | `DOCKERHUB_TOKEN` | Docker Hub access token |
 | `NUGET_API_KEY` | NuGet.org API key |
+| `NPM_TOKEN` | npm automation token (for portal package — see Section 6) |
 
 ## 2) (Optional) Bootstrap labels and milestones
 
@@ -99,6 +102,80 @@ dotnet build
 
 This verifies `/health`, `/metrics`, dashboard login/session, overview, timeline, and dev-traffic endpoint behavior.
 
+## 6) Portal package release — @webhookengine/endpoint-manager
+
+The portal npm package follows an **independent SemVer** track from the engine. The engine can ship `v0.2.x` while the portal package stays at `v0.1.x`, and vice versa. A `portal-v*` tag never triggers the Docker or NuGet jobs, and a `v*` engine tag never triggers the npm publish.
+
+### 6.1 Tag pattern
+
+```
+portal-v{major}.{minor}.{patch}
+portal-v0.1.0
+portal-v0.1.1-beta.1   # pre-release
+```
+
+The workflow strips the `portal-v` prefix to extract the npm version: `portal-v0.1.0` → `0.1.0`.
+
+### 6.2 NPM_TOKEN secret setup
+
+1. Log in to [npmjs.com](https://www.npmjs.com).
+2. Go to **Settings → Access Tokens → Generate New Token → Automation**.
+   - Choose **Automation** (not Publish) so the token works in CI without 2FA prompts.
+3. Copy the generated token (shown only once).
+4. In the GitHub repository go to **Settings → Secrets and variables → Actions → New repository secret**.
+5. Name: `NPM_TOKEN`, value: the token you copied.
+
+The `publish-portal.yml` workflow consumes it as `NODE_AUTH_TOKEN` — this is the conventional env var name that `actions/setup-node` wires to the npm registry automatically.
+
+### 6.3 Provenance / sigstore
+
+The workflow passes `--provenance` to `npm publish`. This attaches a sigstore attestation to the package so consumers can verify its build provenance via `npm audit signatures`. The `id-token: write` permission in the workflow grants the GitHub Actions OIDC token that sigstore requires. No additional setup is needed beyond the permission already declared in the workflow file.
+
+### 6.4 Pre-flight checklist before pushing a portal-v* tag
+
+Run these steps on the release branch before tagging:
+
+1. **Bump the version** in `packages/endpoint-manager/package.json` to match the intended tag. The workflow also runs `npm version` defensively, but having a clean source-of-truth value in `package.json` keeps git history readable.
+
+2. **Set `private: false`** (or remove the `private` field entirely). The package defaults to `private: true` during development to prevent accidental publishes. The workflow has an explicit guard that fails with a clear error message if `private: true` is still set when a `portal-v*` tag is pushed.
+
+3. **Update `packages/endpoint-manager/CHANGELOG.md`** with the release notes for this version (created at Step 11 of the B1 roadmap).
+
+4. **Verify the build artifacts** locally:
+
+   ```bash
+   cd packages/endpoint-manager
+   bun run build
+   ls -la dist/
+   # Must contain: index.js  index.d.ts  style.css
+   ```
+
+5. **Run the pre-publish guard** locally:
+
+   ```bash
+   bun run typecheck
+   bun run lint
+   bun run test
+   ```
+
+6. Push the branch, open a PR, and let CI green before tagging.
+
+7. After the PR merges to `main`, create and push the tag:
+
+   ```bash
+   git tag portal-v0.1.0
+   git push origin portal-v0.1.0
+   ```
+
+### 6.5 Verify the npm publish
+
+```bash
+npm info @webhookengine/endpoint-manager
+npm install @webhookengine/endpoint-manager@0.1.0
+```
+
+Check the package page on npmjs.com for the provenance badge (a green shield icon next to the version number).
+
 ## Troubleshooting
 
 ### Docker publish failed
@@ -111,8 +188,17 @@ This verifies `/health`, `/metrics`, dashboard login/session, overview, timeline
 - Verify `NUGET_API_KEY` is valid and not expired
 - Confirm package ID/version is correct in `WebhookEngine.Sdk.csproj`
 
+### npm publish failed — private:true error
+
+The workflow guard caught `private: true` in `packages/endpoint-manager/package.json`. Set `"private": false` (or remove the field) on the release branch and re-push the tag.
+
+### npm publish failed — authentication error
+
+Verify `NPM_TOKEN` secret is set and the token has not expired. Automation tokens do not expire by default but can be revoked manually on npmjs.com.
+
 ### Workflow did not trigger
 
-- Ensure tag starts with `v`
+- Engine workflow: ensure tag starts with `v` (not `portal-v`)
+- Portal workflow: ensure tag starts with `portal-v`
 - Confirm tag was pushed to origin
 - Check Actions is enabled for the repository

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "workspaces": [
     "src/dashboard",
-    "packages/*"
+    "packages/*",
+    "samples/portal-host"
   ]
 }

--- a/samples/portal-host/.gitignore
+++ b/samples/portal-host/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+*.log

--- a/samples/portal-host/README.md
+++ b/samples/portal-host/README.md
@@ -1,0 +1,58 @@
+# portal-host sample
+
+A minimal Vite + React app that shows what a SaaS host's integration with
+`@webhookengine/endpoint-manager` looks like from the outside.
+
+The sample is self-contained: it mocks the fetch layer so you do not need a
+running WebhookEngine instance to explore the component.
+
+---
+
+## What this shows
+
+- How to embed `<EndpointManager />` in a host SaaS settings page.
+- How to pass `baseUrl`, `token`, `appId`, and `capabilities` props.
+- How to override the component's CSS custom properties at the page level to
+  match your brand (see `src/styles.css` and the `:root` block in `index.html`).
+- Where portal-token minting belongs (server side, not browser side — see the
+  caveat below).
+
+---
+
+## Run it locally
+
+```bash
+cd samples/portal-host
+bun install
+bun run dev
+```
+
+Opens on <http://localhost:5173>. The mock fetch intercepts all calls to
+`https://hooks.example.com/api/v1/portal/*` and serves an in-memory state
+seeded with three example endpoints.
+
+---
+
+## mint-token.ts caveat — production warning
+
+`src/mint-token.ts` mints a JWT in the browser using a hard-coded key. This is
+acceptable in a local sample because the mock-fetch shim never validates the
+signature and the key is public in the repo.
+
+**In production this pattern is forbidden.** The signing key would be visible to
+every visitor who opens DevTools. JWT minting MUST live on your host SaaS
+backend — the only place that is allowed to hold the per-app
+`PORTAL_SIGNING_KEY`. Your frontend should call your own
+`POST /internal/portal-token` endpoint and receive back only the short-lived JWT.
+
+See [docs/PORTAL.md — Section 4](../../docs/PORTAL.md#4-host-sas-integration) for
+the full server-side integration model, including a `jose`-based Node.js example.
+
+---
+
+## Further reading
+
+- [docs/PORTAL.md](../../docs/PORTAL.md) — full integration model, security
+  model, configuration reference, and limits.
+- [packages/endpoint-manager/README.md](../../packages/endpoint-manager/README.md)
+  — component API, props, CSS custom properties.

--- a/samples/portal-host/index.html
+++ b/samples/portal-host/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Acme SaaS — Webhook settings (portal-host sample)</title>
+    <style>
+      /*
+       * Host-brand theme override: demonstrate that the component's CSS
+       * custom properties can be overridden at the page level without
+       * touching the @webhookengine/endpoint-manager package.
+       *
+       * Full token list: see packages/endpoint-manager/src/styles.css
+       */
+      :root {
+        --color-whe-accent: #7c3aed;
+        --color-whe-accent-soft: rgb(124 58 237 / 0.15);
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/samples/portal-host/package.json
+++ b/samples/portal-host/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "portal-host-sample",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@webhookengine/endpoint-manager": "workspace:*",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.0.5",
+    "typescript": "6.0.3",
+    "vite": "8.0.11"
+  }
+}

--- a/samples/portal-host/src/App.tsx
+++ b/samples/portal-host/src/App.tsx
@@ -1,0 +1,58 @@
+import { EndpointManager } from "@webhookengine/endpoint-manager";
+import { useEffect, useState } from "react";
+import { installMockFetch } from "./mock-fetch.js";
+import { mintPortalToken } from "./mint-token.js";
+
+// Install the fetch shim before any component renders.
+// In a real host SaaS app this line is removed — the real engine handles requests.
+installMockFetch();
+
+// This UUID identifies the customer's WebhookEngine Application.
+// In production it comes from your SaaS database (the row that maps a
+// customer account to its WebhookEngine appId).
+const SAMPLE_APP_ID = "00000000-0000-0000-0000-0000000000aa";
+
+export function App() {
+  const [token, setToken] = useState<string | null>(null);
+
+  useEffect(() => {
+    // In production this fetch goes to your SaaS backend's own
+    // POST /internal/portal-token endpoint, which is the only place
+    // that holds the per-app PORTAL_SIGNING_KEY. The browser never
+    // sees the signing key; it only receives the short-lived JWT.
+    void mintPortalToken(SAMPLE_APP_ID, [
+      "endpoints:read",
+      "endpoints:write",
+      "endpoints:test",
+      "attempts:read",
+    ]).then(setToken);
+  }, []);
+
+  return (
+    <main className="page">
+      <header>
+        <h1>Acme SaaS — Webhook settings</h1>
+        <p>
+          This page lives in the host SaaS app. The portal below is the
+          embedded <code>@webhookengine/endpoint-manager</code> component.
+        </p>
+      </header>
+
+      {token ? (
+        <EndpointManager
+          baseUrl="https://hooks.example.com"
+          token={token}
+          appId={SAMPLE_APP_ID}
+          capabilities={[
+            "endpoints:read",
+            "endpoints:write",
+            "endpoints:test",
+            "attempts:read",
+          ]}
+        />
+      ) : (
+        <p className="loading">Loading portal token…</p>
+      )}
+    </main>
+  );
+}

--- a/samples/portal-host/src/css.d.ts
+++ b/samples/portal-host/src/css.d.ts
@@ -1,0 +1,6 @@
+// Vite handles CSS imports at bundle time; this declaration tells TypeScript
+// that side-effect CSS imports are valid without emitting any module shape.
+declare module "*.css" {
+  const _: string;
+  export default _;
+}

--- a/samples/portal-host/src/main.tsx
+++ b/samples/portal-host/src/main.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App.js";
+import "@webhookengine/endpoint-manager/style.css";
+import "./styles.css";
+
+const container = document.getElementById("root");
+if (!container) throw new Error("Root element #root not found");
+
+const root = createRoot(container);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/samples/portal-host/src/mint-token.ts
+++ b/samples/portal-host/src/mint-token.ts
@@ -1,0 +1,63 @@
+/**
+ * Browser-side JWT mint for the portal-host sample.
+ *
+ * DEMO ONLY — do not copy this into production.
+ *
+ * In production, JWT minting MUST happen on your host SaaS backend — the only
+ * place that is allowed to hold the per-app PORTAL_SIGNING_KEY. Putting the
+ * signing key in browser code exposes it to every visitor and defeats the
+ * entire security model.
+ *
+ * This file exists solely to make the sample self-contained (no server needed).
+ * The mock-fetch.ts shim never validates the signature so the hard-coded key
+ * here is purely cosmetic.
+ */
+
+const FAKE_SIGNING_KEY = "demo-only-not-for-production-use!!!!!!!!!!!!!!!!";
+
+function base64url(obj: unknown): string {
+  return btoa(JSON.stringify(obj))
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+export async function mintPortalToken(
+  appId: string,
+  capabilities: string[],
+): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+
+  const header = { alg: "HS256", typ: "JWT" };
+  const payload = {
+    sub: appId,
+    appId,
+    cap: capabilities,
+    iat: now,
+    nbf: now,
+    exp: now + 600, // 10 minutes — well within the engine's 15-minute cap
+  };
+
+  const signingInput = `${base64url(header)}.${base64url(payload)}`;
+
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(FAKE_SIGNING_KEY),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+
+  const sigBytes = new Uint8Array(
+    await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(signingInput)),
+  );
+
+  // Use reduce instead of spread so the pattern stays safe to copy-paste
+  // for larger payloads — spreading a long Uint8Array can blow the call stack.
+  const sigB64 = btoa(sigBytes.reduce((s, b) => s + String.fromCharCode(b), ""))
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+
+  return `${signingInput}.${sigB64}`;
+}

--- a/samples/portal-host/src/mock-fetch.ts
+++ b/samples/portal-host/src/mock-fetch.ts
@@ -1,0 +1,231 @@
+/**
+ * In-memory fetch shim for the portal-host sample.
+ *
+ * Intercepts calls to https://hooks.example.com/api/v1/portal/* and serves
+ * synthetic data so the sample runs without a running WebhookEngine instance.
+ *
+ * The real engine is the source of truth for the API contract. This file
+ * demonstrates what calling code looks like, not faithful API reproduction.
+ */
+
+import type {
+  PortalAttempt,
+  PortalEndpointDetail,
+  PortalEndpointSummary,
+  PortalEventTypeListItem,
+  PortalTestResult,
+} from "@webhookengine/endpoint-manager";
+
+function uuid(): string {
+  return crypto.randomUUID();
+}
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+const EVENT_TYPES: PortalEventTypeListItem[] = [
+  { id: uuid(), name: "order.created", description: "A new order was placed" },
+  { id: uuid(), name: "order.shipped", description: "An order was shipped" },
+  { id: uuid(), name: "refund.issued", description: "A refund was issued to the customer" },
+];
+
+type StoredEndpoint = PortalEndpointDetail & { isActive: boolean };
+
+const store = new Map<string, StoredEndpoint>([
+  [
+    "ep-0001",
+    {
+      id: "ep-0001",
+      url: "https://api.acme.example/webhooks/orders",
+      description: "Order lifecycle events",
+      isActive: true,
+      hasSecretOverride: false,
+      filterEventTypes: ["order.created", "order.shipped"],
+      customHeaders: {},
+      createdAt: "2026-04-01T10:00:00.000Z",
+      updatedAt: "2026-04-01T10:00:00.000Z",
+    },
+  ],
+  [
+    "ep-0002",
+    {
+      id: "ep-0002",
+      url: "https://api.acme.example/webhooks/refunds",
+      description: "Refund notifications",
+      isActive: true,
+      hasSecretOverride: true,
+      filterEventTypes: ["refund.issued"],
+      customHeaders: { "X-Source": "webhookengine" },
+      createdAt: "2026-04-15T09:30:00.000Z",
+      updatedAt: "2026-04-20T14:00:00.000Z",
+    },
+  ],
+  [
+    "ep-0003",
+    {
+      id: "ep-0003",
+      url: "https://legacy.acme.example/hook",
+      description: null,
+      isActive: false,
+      hasSecretOverride: false,
+      filterEventTypes: [],
+      customHeaders: {},
+      createdAt: "2026-03-10T08:00:00.000Z",
+      updatedAt: "2026-04-25T11:15:00.000Z",
+    },
+  ],
+]);
+
+function toSummary(ep: StoredEndpoint): PortalEndpointSummary {
+  return {
+    id: ep.id,
+    url: ep.url,
+    description: ep.description,
+    isActive: ep.isActive,
+    hasSecretOverride: ep.hasSecretOverride,
+    filterEventTypes: ep.filterEventTypes,
+    createdAt: ep.createdAt,
+  };
+}
+
+function ok(data: unknown, extra?: Record<string, unknown>): Response {
+  return new Response(JSON.stringify({ data, ...extra }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function noContent(): Response {
+  return new Response(null, { status: 204 });
+}
+
+function notFound(): Response {
+  return new Response(
+    JSON.stringify({ error: { code: "PORTAL_NOT_FOUND", message: "Not found" } }),
+    { status: 404, headers: { "content-type": "application/json" } },
+  );
+}
+
+const BASE = "https://hooks.example.com";
+
+const originalFetch = globalThis.fetch;
+
+export function installMockFetch(): void {
+  globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    if (!url.startsWith(BASE)) return originalFetch(input, init);
+
+    const path = url.slice(BASE.length).split("?")[0];
+    const method = (init?.method ?? "GET").toUpperCase();
+
+    // GET /api/v1/portal/endpoints
+    if (method === "GET" && path === "/api/v1/portal/endpoints") {
+      const items = [...store.values()].map(toSummary);
+      return ok(items, { meta: { pagination: { page: 1, pageSize: 20, total: items.length } } });
+    }
+
+    // GET /api/v1/portal/event-types
+    if (method === "GET" && path === "/api/v1/portal/event-types") {
+      return ok(EVENT_TYPES);
+    }
+
+    // POST /api/v1/portal/endpoints
+    if (method === "POST" && path === "/api/v1/portal/endpoints") {
+      const body = JSON.parse((init?.body as string) ?? "{}") as Partial<PortalEndpointDetail>;
+      const id = uuid();
+      const ep: StoredEndpoint = {
+        id,
+        url: body.url ?? "",
+        description: body.description ?? null,
+        isActive: true,
+        hasSecretOverride: false,
+        filterEventTypes: body.filterEventTypes ?? [],
+        customHeaders: body.customHeaders ?? {},
+        createdAt: now(),
+        updatedAt: now(),
+      };
+      store.set(id, ep);
+      return ok(ep);
+    }
+
+    const endpointMatch = path.match(/^\/api\/v1\/portal\/endpoints\/([^/]+)(\/.*)?$/);
+    if (endpointMatch) {
+      const [, id, sub] = endpointMatch as [string, string, string | undefined];
+      const ep = store.get(id);
+
+      if (!ep) return notFound();
+
+      // GET /api/v1/portal/endpoints/{id}
+      if (method === "GET" && !sub) return ok(ep);
+
+      // PUT /api/v1/portal/endpoints/{id}
+      if (method === "PUT" && !sub) {
+        const body = JSON.parse((init?.body as string) ?? "{}") as Partial<PortalEndpointDetail>;
+        const updated: StoredEndpoint = { ...ep, ...body, id, updatedAt: now() };
+        store.set(id, updated);
+        return ok(updated);
+      }
+
+      // DELETE /api/v1/portal/endpoints/{id}
+      if (method === "DELETE" && !sub) {
+        store.delete(id);
+        return noContent();
+      }
+
+      // POST /api/v1/portal/endpoints/{id}/enable
+      if (method === "POST" && sub === "/enable") {
+        store.set(id, { ...ep, isActive: true, updatedAt: now() });
+        return noContent();
+      }
+
+      // POST /api/v1/portal/endpoints/{id}/disable
+      if (method === "POST" && sub === "/disable") {
+        store.set(id, { ...ep, isActive: false, updatedAt: now() });
+        return noContent();
+      }
+
+      // POST /api/v1/portal/endpoints/{id}/test
+      if (method === "POST" && sub === "/test") {
+        const result: PortalTestResult = {
+          success: true,
+          statusCode: 200,
+          latencyMs: 42,
+          responseBody: '{"received":true}',
+          error: null,
+          request: {
+            url: ep.url,
+            headers: {
+              "webhook-id": uuid(),
+              "webhook-timestamp": String(Math.floor(Date.now() / 1000)),
+              "webhook-signature": "v1,dGVzdC1zaWduYXR1cmU=",
+              "content-type": "application/json",
+            },
+            body: '{"eventType":"order.created","payload":{}}',
+          },
+        };
+        return ok(result);
+      }
+
+      // GET /api/v1/portal/endpoints/{id}/attempts
+      if (method === "GET" && sub === "/attempts") {
+        const attempts: PortalAttempt[] = Array.from({ length: 5 }, (_, i) => ({
+          id: uuid(),
+          messageId: uuid(),
+          attemptNumber: i + 1,
+          status: i === 4 ? "failure" : "success",
+          statusCode: i === 4 ? 500 : 200,
+          error: i === 4 ? "Internal Server Error" : null,
+          latencyMs: 30 + i * 10,
+          createdAt: new Date(Date.now() - (5 - i) * 3_600_000).toISOString(),
+        }));
+        return ok(attempts, { meta: { pagination: { page: 1, pageSize: 50, total: 5 } } });
+      }
+    }
+
+    return new Response(JSON.stringify({ error: { code: "NOT_FOUND", message: "Mock: route not matched" } }), {
+      status: 404,
+      headers: { "content-type": "application/json" },
+    });
+  };
+}

--- a/samples/portal-host/src/styles.css
+++ b/samples/portal-host/src/styles.css
@@ -1,0 +1,46 @@
+:root {
+  /* Host SaaS theme override — lighter accent + brand colour.
+   * These custom properties are declared in the host page, not inside
+   * the @webhookengine/endpoint-manager package, so they safely override
+   * the component's defaults without touching the package itself. */
+  --color-whe-accent: #7c3aed;
+  --color-whe-accent-soft: rgb(124 58 237 / 0.15);
+}
+
+body {
+  margin: 0;
+  background: #0a0a0c;
+  color: #e5e5e5;
+  font-family: ui-sans-serif, system-ui, sans-serif;
+}
+
+.page {
+  max-width: 960px;
+  margin: 2rem auto;
+  padding: 0 1.5rem;
+}
+
+.page header {
+  margin-bottom: 2rem;
+}
+
+.page h1 {
+  font-size: 1.5rem;
+  margin: 0 0 0.5rem;
+}
+
+.page p {
+  color: #a1a1aa;
+  margin: 0;
+}
+
+.page code {
+  background: #18181b;
+  padding: 0.1rem 0.35rem;
+  border-radius: 0.25rem;
+  font-size: 0.85em;
+}
+
+.loading {
+  margin-top: 2rem;
+}

--- a/samples/portal-host/tsconfig.json
+++ b/samples/portal-host/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": false,
+    "noEmit": true
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/samples/portal-host/vite.config.ts
+++ b/samples/portal-host/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary

**Step 10 of the B1 (embeddable customer portal) plan.** Lays down the npm publish pipeline + a working consumer-side reference app. **NO npm publish actually fires** — `package.json` keeps `private: true` until Step 11.

## `publish-portal.yml` workflow

- **Trigger:** `push` tag pattern `portal-v*` — independent SemVer from the engine's `v*` tags.
- **Permissions:** `contents: read` + `id-token: write` (the latter required for npm provenance / sigstore attestation).
- **Steps:** checkout (full depth) → setup-bun (1.2.x) → setup-node (20 LTS, registry-url npmjs) → `bun install --frozen-lockfile` from workspace root → typecheck + lint + test pre-publish guard → `bun run build` → verify `dist/index.js` + `dist/index.d.ts` + `dist/style.css` all present → `npm version --no-git-tag-version --allow-same-version` (sets package version from tag) → defensive `private: true` guard → `npm publish --access public --provenance`.

The `private: true` guard is **load-bearing**: if a future maintainer pushes `portal-v*` from a branch that still carries `private: true`, the workflow surfaces a clear error message instead of `npm publish` failing with the cryptic "private packages cannot be published".

`setup-node` runs alongside `setup-bun` because `npm publish` is the canonical npm registry client; bun's npm publish path doesn't yet reliably emit provenance attestations on GitHub-hosted runners. Right tool per step.

## `samples/portal-host/` reference app

Vite app demonstrating consumer integration. 13 files (index.html, package.json, tsconfig, vite.config, README, .gitignore, plus `src/{main.tsx, App.tsx, mint-token.ts, mock-fetch.ts, styles.css, css.d.ts}`).

- `@webhookengine/endpoint-manager` imported as `workspace:*` — resolves locally during development, will switch to npm version after Step 11 publish.
- Mocked fetch (in-memory state) so the sample boots **without a running engine**. 3 endpoints + event types + attempts + test responses out of the box.
- Hand-rolled HS256 JWT mint using `crypto.subtle` (zero runtime deps). The README is **explicit that mint-token.ts is DEMO ONLY** — in production it MUST live on the host SaaS's own backend, the only place where the per-app `PORTAL_SIGNING_KEY` is allowed to live.
- `:root` CSS variable overrides demonstrating package theme customization (`--color-whe-accent` purple instead of default cyan).

Sample registered in the root `package.json` workspaces array so `workspace:*` resolves the package from the monorepo. `bun.lock` regenerated.

### Sample mint-token.ts hardening

Replaced `btoa(String.fromCharCode(...sigBytes))` spread with `btoa(sigBytes.reduce(...))`. The spread is fine for a 32-byte HMAC-SHA-256 signature but copy-paste-unsafe for larger payloads where the spread can overflow the call stack. The `reduce` variant stays safe at any size.

## Documentation

- **`docs/PORTAL.md`** — Section 5 ("Component Usage") replaced with a real Quickstart pointing at `samples/portal-host/` as the canonical example, plus inline snippets for the host SaaS server-side mint helper (Express + jose) and the React-side `<EndpointManager />` usage that fetches the token from the host backend.
- **`docs/RELEASE.md`** — new Section 6 "Portal package release" covering: `portal-v*` tag scheme + independent SemVer from the engine, NPM_TOKEN secret setup (5-step npmjs automation token + GitHub repository secret flow), provenance / sigstore via `id-token: write`, and the pre-flight checklist before pushing a `portal-v*` tag (version bump, `private: false`, CHANGELOG entry, dist verification).

## CI choice — sample is NOT in CI

Matches the existing `samples/` precedent (`Sample.Sender`, `Sample.Receiver`, `signature-verification` all run-it-yourself smoke samples). The `frontend` job in CI already exercises `packages/endpoint-manager` (typecheck + lint + build); adding the sample would only validate Vite resolving the workspace dep, which `bun install` validates implicitly.

## What does NOT land (Step 11)

- **npm publish.** `private: true` stays on `packages/endpoint-manager/package.json`. Step 11 is the release-prep PR that flips the flag, bumps the package to 0.1.0, creates `packages/endpoint-manager/CHANGELOG.md`, then pushes the `portal-v0.1.0` tag.

## Bundle / test count delta

**Unchanged from Step 9** — this PR adds NO test files and NO new components inside the package. **42/42 tests still pass.**

## Test plan

- [x] `cd samples/portal-host && bun install && bun run build` — succeeds, 21 modules transformed
- [x] `cd samples/portal-host && bunx tsc --noEmit` — clean
- [x] `bun run dev` boots the demo at localhost:5173 with mocked engine
- [x] All 42 package tests still pass
- [ ] CI green