### PR TITLE
chore(release): prep @webhookengine/endpoint-manager v0.1.0 (B1 Step 11 — final)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - **`samples/portal-host/` reference application.** Standalone Vite + React app demonstrating host-SaaS integration with `<EndpointManager />`. Uses a browser-native Web Crypto HS256 mint (`mint-token.ts`) and an in-memory fetch shim (`mock-fetch.ts`) — no engine instance required to run. Shows prop wiring, CSS custom-property theme overrides, and the server-side token-mint pattern.
 - **`docs/PORTAL.md` Section 5 — Component Usage.** Replaced the "coming soon" placeholder with a full quickstart: reference to `samples/portal-host/`, a server-side `jose` + Express JWT mint snippet, a React-side `<EndpointManager />` embedding snippet, and CSS theme override instructions.
 - **`docs/RELEASE.md` Section 6 — Portal package release.** Documents the `portal-v*` tag scheme, `NPM_TOKEN` secret setup steps, sigstore provenance setup, and the pre-flight checklist to run before pushing a release tag.
+- **`@webhookengine/endpoint-manager` v0.1.0 published to npm.** First public release of the embeddable customer portal React component. Pairs with engine v0.2.0+. See `packages/endpoint-manager/CHANGELOG.md` for the package's own changelog.
 
 ## [0.2.0] - 2026-05-10
 

--- a/packages/endpoint-manager/CHANGELOG.md
+++ b/packages/endpoint-manager/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog — @webhookengine/endpoint-manager
+
+All notable changes to this package are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The package versions independently from the WebhookEngine engine. The npm
+release tag scheme is `portal-v{major}.{minor}.{patch}` (engine releases use
+`v{major}.{minor}.{patch}`).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-05-11
+
+Initial public release. Pairs with WebhookEngine engine v0.2.0 or later (which exposes the `/api/v1/portal/*` route group the package consumes).
+
+### Added
+- **`<EndpointManager />`** — the headline embeddable React component. Wraps a self-contained portal that authenticates against a host SaaS-minted HS256 JWT and serves a customer-facing endpoint management UI. Props: `baseUrl`, `token`, `appId`, `capabilities`, `theme`, `className`, `onError`, `onUnauthorized`.
+- **`<EndpointList />`** — paginated table of endpoints with status badges, capability-gated `[+ New endpoint]` + per-row Edit/Enable/Disable/Delete/Test/Attempts actions.
+- **`<EndpointEditor />`** — modal-style overlay for create + edit. Fields: URL (HTTPS), description, custom headers (key/value editor), event-type filter (multi-select), secret override (`whsec_` prefix + 32+ char client-side check). Server validation `fieldErrors` route to per-field inline messages. Field narrowing enforced at the DTO level — `transformExpression` / `transformEnabled` / `allowedIpsJson` are dropped on write.
+- **`<EndpointTester />`** — modal opened from the Test row action. JSON payload validation on blur, color-coded response panel (status + latency + body, collapsed if >500 chars), collapsible signed-request preview showing the URL + headers (`webhook-id` / `webhook-timestamp` / `webhook-signature`) + body the receiver actually HMAC-verifies.
+- **`<AttemptList />`** — modal opened from the Attempts row action. Paginated delivery history with relative + absolute timestamps, success / failure status badges, HTTP code, latency, expandable response excerpts.
+- **`createPortalClient()`** — fetch wrapper, **zero runtime dependencies**. `Bearer` auth, `ApiEnvelope` unwrap, 4xx/5xx → `PortalError` with `code` + `status` + `fieldErrors`, 401 hooks `onUnauthorized` for token re-mint flows. Methods: `listEndpoints`, `getEndpoint`, `createEndpoint`, `updateEndpoint`, `deleteEndpoint`, `enableEndpoint`, `disableEndpoint`, `testEndpoint`, `listAttempts`, `listEventTypes`.
+- **`PortalCapability` union and full TypeScript types** for `PortalAppState`, `PortalEndpointSummary`, `PortalEndpointDetail`, `PortalAttempt`, `PortalTestResult`, `PortalListResult<T>`, `PortalError`, `PortalClientOptions`, `EndpointManagerProps`. Re-exported from `./types`.
+- **Tailwind 4 internal compile pipeline.** `dist/style.css` ships pre-compiled with the package. The `@theme` block defines `--color-whe-*` tokens (background, text, border, accent, success, danger, warning) — consumers override at `:root` or `.whe-portal` scope to re-theme without touching component code. The `.whe-portal` wrapper className is the load-bearing scoping mechanism so consumer page styles can't leak in and our utilities can't leak out.
+- **42-test vitest suite** (vitest + happy-dom + `@testing-library/react`) covering the client contract, capability gating, field-narrowing, JSON validation, secret-override entropy floor, signed-request preview, status badge color-coding, and pagination boundaries.
+- **`samples/portal-host/` reference app** in the engine repo demonstrating consumer integration: Vite + mocked fetch + browser-side JWT mint (`mint-token.ts`) — for local exploration only. Production token minting belongs on the host SaaS's own backend.
+
+### Notes
+- **Bundle:** ESM-only, ~14.2 KB gzip JS + ~4.3 KB gzip CSS. Tree-shakable.
+- **Peer dependencies:** `react ^19.0.0`, `react-dom ^19.0.0`. Zero runtime dependencies.
+- **Engine compatibility:** v0.2.0 or later. Earlier engines lack the `/api/v1/portal/*` surface.
+- **JWT requirements:** HS256, signed with the per-app `PortalSigningKey` (rotated from the engine's operator dashboard). Lifetime cap defaults to 15 min on the engine side. The component never sees the signing key — only the bearer token.

--- a/packages/endpoint-manager/README.md
+++ b/packages/endpoint-manager/README.md
@@ -2,17 +2,58 @@
 
 Embeddable React portal for managing webhook endpoints — pairs with a self-hosted WebhookEngine instance.
 
-## Installation
+## Install
 
 ```bash
 npm install @webhookengine/endpoint-manager
+# or
+bun add @webhookengine/endpoint-manager
+# or
+pnpm add @webhookengine/endpoint-manager
 ```
 
-> **Note:** This package is not yet published to npm. Publication happens in B1 Step 11. Until then, workspace consumers can reference it directly via the Bun workspace:
->
-> ```json
-> { "dependencies": { "@webhookengine/endpoint-manager": "workspace:*" } }
-> ```
+Peer dependencies (you provide these): `react ^19`, `react-dom ^19`.
+
+## Quick start
+
+```tsx
+import { EndpointManager } from "@webhookengine/endpoint-manager";
+import "@webhookengine/endpoint-manager/style.css";
+
+export function WebhookSettingsPage() {
+  // Mint this token on YOUR backend — never in the browser.
+  // The signing key (Application.PortalSigningKey from the engine dashboard)
+  // must stay server-side.
+  const token = "<JWT minted by your backend>";
+
+  return (
+    <EndpointManager
+      baseUrl="https://hooks.your-domain.com"
+      token={token}
+      appId="<the application id from the engine dashboard>"
+      capabilities={["endpoints:read", "endpoints:write", "endpoints:test", "attempts:read"]}
+    />
+  );
+}
+```
+
+See [`docs/PORTAL.md`](https://github.com/voyvodka/webhook-engine/blob/main/docs/PORTAL.md) for the full integration model (JWT minting on the host backend, CORS, capability scoping, security model). See [`samples/portal-host/`](https://github.com/voyvodka/webhook-engine/tree/main/samples/portal-host) for a working consumer reference app.
+
+## Theming
+
+The component uses CSS custom properties scoped under `.whe-portal`. Override them at `:root` or on a wrapper element to match your brand:
+
+```css
+:root {
+  --color-whe-background: #ffffff;
+  --color-whe-text: #111827;
+  --color-whe-border: #e5e7eb;
+  --color-whe-accent: #6366f1;
+  --color-whe-success: #16a34a;
+  --color-whe-danger: #dc2626;
+  --color-whe-warning: #d97706;
+}
+```
 
 ## Peer dependencies
 
@@ -22,29 +63,14 @@ Requires React 19 or later:
 npm install react@^19 react-dom@^19
 ```
 
-## Usage
+## Engine compatibility
 
-```tsx
-import { EndpointManager } from "@webhookengine/endpoint-manager";
-
-<EndpointManager
-  baseUrl="https://hooks.example.com"
-  token="<portal-jwt>"
-  appId="<your-app-id>"
-  theme="dark"
-/>
-```
-
-The full component suite (endpoint list, editor, tester, attempt history) ships in **B1 Step 8**. The current version renders a placeholder that confirms the import path is correctly wired — no setup changes will be required when the real UI lands.
-
-## Integration model
-
-Portal JWTs are minted by your WebhookEngine instance (`POST /api/v1/portal/token`). The token encodes the app ID and a `capabilities` claim that controls which UI panels are visible. CORS and allowed-origins configuration lives in the WebhookEngine admin dashboard.
-
-Full integration documentation: [`docs/PORTAL.md`](https://github.com/voyvodka/webhook-engine/blob/main/docs/PORTAL.md)
+Requires WebhookEngine v0.2.0 or later. Earlier engine versions do not expose the `/api/v1/portal/*` route group this package consumes.
 
 ## Links
 
+- Integration guide: [`docs/PORTAL.md`](https://github.com/voyvodka/webhook-engine/blob/main/docs/PORTAL.md)
+- Reference sample: [`samples/portal-host/`](https://github.com/voyvodka/webhook-engine/tree/main/samples/portal-host)
 - GitHub: [voyvodka/webhook-engine](https://github.com/voyvodka/webhook-engine)
 - Landing page: [webhook.sametozkan.com.tr](https://webhook.sametozkan.com.tr)
 - License: MIT

--- a/packages/endpoint-manager/package.json
+++ b/packages/endpoint-manager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@webhookengine/endpoint-manager",
-  "version": "0.0.0",
-  "private": true,
+  "version": "0.1.0",
+  "private": false,
   "type": "module",
   "description": "Embeddable React portal for managing webhook endpoints — pairs with WebhookEngine self-hosted.",
   "license": "MIT",

--- a/samples/portal-host/README.md
+++ b/samples/portal-host/README.md
@@ -33,6 +33,24 @@ seeded with three example endpoints.
 
 ---
 
+## Using the package in your own project
+
+In your own project, install from npm rather than referencing the workspace:
+
+```bash
+npm install @webhookengine/endpoint-manager
+# or
+bun add @webhookengine/endpoint-manager
+# or
+pnpm add @webhookengine/endpoint-manager
+```
+
+This sample's `package.json` references `"@webhookengine/endpoint-manager": "workspace:*"`
+so that local monorepo development works without publishing. That line is
+specific to this repo — do not copy it into your own project.
+
+---
+
 ## mint-token.ts caveat — production warning
 
 `src/mint-token.ts` mints a JWT in the browser using a hard-coded key. This is


### PR DESCRIPTION
## Summary

**Final B1 step.** Flips package metadata for the initial public npm release of `@webhookengine/endpoint-manager`. After this PR merges, the `portal-v0.1.0` tag gets pushed from main; `.github/workflows/publish-portal.yml` then runs `npm publish --access public --provenance` against the `@webhookengine/endpoint-manager` scope.

## What lands

### `packages/endpoint-manager/package.json`
- `private: true → false` (publish-portal.yml's defensive guard would otherwise block the publish)
- `version: 0.0.0 → 0.1.0` (matches the `portal-v0.1.0` tag pattern)
- `name`, `exports`, `peerDependencies`, `files`, `repository.directory` unchanged from Step 7

### `packages/endpoint-manager/CHANGELOG.md` (NEW)
- Keep-a-Changelog format. `[0.1.0]` covers all of Steps 7-10.
- `### Notes` records bundle facts (~14.2 KB gz JS + ~4.3 KB gz CSS, ESM-only, peer deps `react ^19`, zero runtime deps), engine compatibility (`v0.2.0+`), and JWT requirements (HS256, per-app `PortalSigningKey`, 15-min lifetime cap).

### `packages/endpoint-manager/README.md`
- "NOT yet published" banner removed.
- Quickstart opens with the real `npm install @webhookengine/endpoint-manager` + a working `<EndpointManager />` snippet.

### `samples/portal-host/README.md`
- Note that the sample uses `workspace:*` for monorepo dev; consumers use `npm install`.

### Engine `CHANGELOG.md`
- One-line cross-reference under `[Unreleased]` noting the package release for engine release watchers; engine itself unchanged.

## Pre-flight verification (all clean)

- `bun run typecheck` / `lint` / `test` (42/42) / `build` all green
- `dist/` contents: `index.js` (88 KB raw / ~14 KB gz), `index.d.ts` (6.3 KB), `style.css` (19 KB raw / ~4 KB gz)
- NPM_TOKEN repository secret confirmed available
- `@webhookengine` npm scope unregistered → created on first publish

## After this PR merges

```
git tag -a portal-v0.1.0 -m "@webhookengine/endpoint-manager v0.1.0 — initial public release"
git push origin portal-v0.1.0
```

`publish-portal.yml` then runs install + typecheck + lint + test + build + `npm publish --access public --provenance`. ~3-5 min later the package is live on npmjs.com with sigstore attestation. `gh release create portal-v0.1.0` from the CHANGELOG body.