### PR TITLE
fix(security): close CodeQL alert #11 (incomplete URL substring sanitization in sample mock-fetch)

### DIFF
--- a/samples/portal-host/src/mock-fetch.ts
+++ b/samples/portal-host/src/mock-fetch.ts
@@ -108,15 +108,28 @@ function notFound(): Response {
 }
 
 const BASE = "https://hooks.example.com";
+const BASE_URL = new URL(BASE);
 
 const originalFetch = globalThis.fetch;
 
 export function installMockFetch(): void {
   globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-    if (!url.startsWith(BASE)) return originalFetch(input, init);
+    // Parse the URL and compare the host explicitly. A naive
+    // url.startsWith(BASE) check would also match
+    // https://hooks.example.com.attacker.com/... — fine for a sample
+    // but the kind of pattern that gets copy-pasted into production code.
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      return originalFetch(input, init);
+    }
+    if (parsed.protocol !== BASE_URL.protocol || parsed.host !== BASE_URL.host) {
+      return originalFetch(input, init);
+    }
 
-    const path = url.slice(BASE.length).split("?")[0];
+    const path = parsed.pathname;
     const method = (init?.method ?? "GET").toUpperCase();
 
     // GET /api/v1/portal/endpoints


### PR DESCRIPTION
## Summary

Closes **CodeQL alert #11** (HIGH severity, `js/incomplete-url-substring-sanitization`) on `samples/portal-host/src/mock-fetch.ts:117`.

The previous shape:
```ts
if (!url.startsWith(BASE)) return originalFetch(input, init);
```

with `BASE = "https://hooks.example.com"`. The `startsWith` check correctly catches paths like `https://hooks.example.com/api/v1/portal/endpoints`, but it ALSO matches `https://hooks.example.com.attacker.com/api/v1/portal/endpoints` — the BASE prefix can be followed by an arbitrary host suffix. Fine for the sample's mock semantics in isolation (the worst case is the mock answers a request that should have gone to the real network), but the kind of pattern that absolutely should not get copy-pasted into production code.

## Fix

Parse the URL and compare protocol + host explicitly via WHATWG URL:
```ts
const BASE_URL = new URL(BASE);
// ...
let parsed: URL;
try {
  parsed = new URL(url);
} catch {
  return originalFetch(input, init);
}
if (parsed.protocol !== BASE_URL.protocol || parsed.host !== BASE_URL.host) {
  return originalFetch(input, init);
}
```

Same intent, no substring trap. Also flipped `path = url.slice(BASE.length).split("?")[0]` → `path = parsed.pathname` which is the same value via a safer route. Route handlers downstream are unchanged.

## Test plan

- [x] No behavior change for the sample's actual use (mocks serve the same routes for the same inputs)
- [ ] CI green
- [ ] CodeQL alert #11 closes after merge