### PR TITLE
fix(ci): align Bun to 1.3.x and repair Dependabot lockfile auto-sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   DOTNET_VERSION: "10.0.x"
-  BUN_VERSION: "1.2.x"
+  BUN_VERSION: "1.3.x"
 
 jobs:
   backend:

--- a/.github/workflows/publish-portal.yml
+++ b/.github/workflows/publish-portal.yml
@@ -10,7 +10,7 @@ permissions:
   id-token: write   # required for npm provenance / sigstore attestation
 
 env:
-  BUN_VERSION: "1.2.x"
+  BUN_VERSION: "1.3.x"
   NODE_VERSION: "20"
 
 jobs:

--- a/.github/workflows/sync-bun-lock.yml
+++ b/.github/workflows/sync-bun-lock.yml
@@ -22,7 +22,7 @@ permissions:
   contents: write
 
 env:
-  BUN_VERSION: "1.2.x"
+  BUN_VERSION: "1.3.x"
 
 jobs:
   sync-lockfile:
@@ -42,7 +42,7 @@ jobs:
           bun-version: ${{ env.BUN_VERSION }}
 
       - name: Regenerate lockfile (workspace root)
-        run: bun install --no-save
+        run: bun install
 
       - name: Commit and push if lockfile changed
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+- **CI Bun version aligned to 1.3.x and the Dependabot lockfile auto-sync repaired.** Three workflows (`ci.yml`, `sync-bun-lock.yml`, `publish-portal.yml`) pinned `BUN_VERSION: "1.2.x"` while the committed `bun.lock` is in the Bun 1.3 text-lockfile format (`configVersion`), the Docker dashboard build runs `oven/bun:1`, and local dev runs 1.3.x. The skew made every grouped Dependabot npm bump fail the `Frontend (build + lint)` job's `tsc --noEmit` under 1.2.x's transitive resolution — a duplicate vite `Plugin` type identity surfacing as `TS2321 Excessive stack depth` / `TS2769` on `vite.config.ts`. Separately, `sync-bun-lock.yml` ran `bun install --no-save`, which never writes `bun.lock`, so the auto-sync step silently no-op'd and every frontend dependency PR landed with a stale lockfile that broke CI's `bun install --frozen-lockfile`. All three pins are now `"1.3.x"` and the sync step drops `--no-save` so the refreshed lockfile is actually committed back to the PR branch.
+
 ## [0.2.1] - 2026-05-11
 
 ### Removed


### PR DESCRIPTION
## Problem

A Bun version skew across the repo broke Dependabot's frontend dependency flow:

- The committed `bun.lock` is in the **Bun 1.3 text-lockfile format** (`configVersion` header field), `docker/Dockerfile` builds the dashboard with `oven/bun:1` (→ 1.3.x), and local dev runs 1.3.x.
- But `ci.yml`, `sync-bun-lock.yml`, and `publish-portal.yml` all pinned `BUN_VERSION: "1.2.x"`.

Two consequences:

1. **Type-check failure on every grouped npm bump.** Under Bun 1.2.x's transitive resolution, the dashboard `tsc --noEmit` fails with a duplicate vite `Plugin` type identity:
   ```
   vite.config.ts(5,16): error TS2321: Excessive stack depth comparing types ... 'UserConfig'.
   vite.config.ts(6,13): error TS2769: No overload matches this call.
       Type 'Plugin<any>[]' is not assignable to type 'PluginOption'.
   ```
   Verified: under Bun **1.2.23** a fresh resolve of PR #113's `package.json` fails `tsc`; under Bun **1.3.8** `lint` + `typecheck` + `build` all pass. On `main`, `bun install --frozen-lockfile` under 1.3.8 passes cleanly (no drift), so the bump is safe for the existing lockfile.

2. **Lockfile auto-sync silently no-op'd.** `sync-bun-lock.yml` ran `bun install --no-save` — `--no-save` suppresses the lockfile write, so the `git diff --quiet bun.lock` guard always saw no change and never committed a refreshed lock. Every Dependabot npm PR then landed with a stale lockfile that broke CI's `bun install --frozen-lockfile`.

## Fix

- Bump `BUN_VERSION` `1.2.x` → `1.3.x` in all three workflows (aligns resolver with the committed lockfile format, Docker, and local dev).
- Drop `--no-save` in `sync-bun-lock.yml` so the refreshed `bun.lock` is actually written and committed back to the PR branch.

The `pull_request_target` security gate on `sync-bun-lock.yml` (`github.actor == 'dependabot[bot]'`, PR-head checkout, `contents: write`) is unchanged. This unblocks PR #113.
