### PR TITLE
fix(ci): lockfile-sync commit re-triggers CI via short-lived App token

### DIFF
--- a/.github/workflows/sync-bun-lock.yml
+++ b/.github/workflows/sync-bun-lock.yml
@@ -12,6 +12,16 @@ name: Sync bun.lock for Dependabot
 # to the base repo (needed to push the lockfile back); we still gate on
 # `github.actor == 'dependabot[bot]'` so an external contributor cannot
 # repurpose this surface to push arbitrary commits.
+#
+# The lockfile-sync commit is pushed with a GitHub App installation token
+# (when configured) so that the push re-triggers required CI checks.
+# GitHub deliberately does not trigger new workflow runs from pushes made
+# with GITHUB_TOKEN (recursion guard), which would leave the PR blocked on
+# required status checks. The App token is short-lived (~1 h) and therefore
+# security-equivalent to GITHUB_TOKEN in token lifetime. When the App is not
+# configured (vars.LOCK_BOT_APP_ID is empty) the workflow falls back to
+# GITHUB_TOKEN — the lockfile is still synced, but CI must be re-triggered
+# manually (close/reopen the PR or push an empty commit).
 
 on:
   pull_request_target:
@@ -30,11 +40,19 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
+      - name: Mint GitHub App token
+        id: app-token
+        if: ${{ vars.LOCK_BOT_APP_ID != '' }}
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.LOCK_BOT_APP_ID }}
+          private-key: ${{ secrets.LOCK_BOT_PRIVATE_KEY }}
+
       - name: Checkout PR head
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+- **Dependabot lockfile-sync commit can now re-trigger CI.** `sync-bun-lock.yml` pushed the regenerated `bun.lock` with `GITHUB_TOKEN`, and GitHub deliberately does not let `GITHUB_TOKEN` pushes trigger new workflow runs (recursion guard) — so the sync commit became the PR's HEAD with no CI run on it, leaving the PR blocked on required status checks until a manual close/reopen (as happened on #113). The push now uses a short-lived GitHub App installation token (`actions/create-github-app-token`, gated on the optional `vars.LOCK_BOT_APP_ID`) so the lockfile commit re-triggers the required checks automatically; it falls back to `GITHUB_TOKEN` (manual re-trigger) when the App is not configured. One-time App setup is documented in `docs/RELEASE.md` §1.
+
 ## [0.2.2] - 2026-05-29
 
 Maintenance patch: full dependency refresh across NuGet, npm, Docker base images, and GitHub Actions — plus the CI Bun/lockfile alignment fix. No user-visible behaviour changes, no breaking API changes; the `v1` route prefix and Standard Webhooks signature surface are unchanged.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -28,6 +28,20 @@ Add these secrets:
 | `NUGET_API_KEY` | NuGet.org API key |
 | `NPM_TOKEN` | npm automation token (for portal package — see Section 6) |
 
+### (Optional) Dependabot lockfile auto-sync that re-triggers CI
+
+`sync-bun-lock.yml` regenerates `bun.lock` on Dependabot npm PRs and pushes it back to the PR branch. By default that push uses `GITHUB_TOKEN`, and GitHub **does not** let `GITHUB_TOKEN` pushes trigger new workflow runs (recursion guard) — so the lockfile commit lands with no CI run on it and the PR stays blocked on required checks until you close/reopen it. To make the sync commit re-trigger CI automatically, configure a GitHub App whose short-lived installation token is used for the push:
+
+1. **Settings → Developer settings → GitHub Apps → New GitHub App.** Name it e.g. `webhook-engine-lock-bot`, set any homepage URL, and uncheck Webhook → Active.
+2. **Permissions → Repository permissions → Contents: Read and write.** No other permission is needed.
+3. Create the App, then **Generate a private key** (downloads a `.pem`).
+4. **Install App** on `voyvodka/webhook-engine` (only-this-repo is fine).
+5. In the repo, **Settings → Secrets and variables → Actions**:
+   - **Variables** tab → new variable `LOCK_BOT_APP_ID` = the App's numeric ID.
+   - **Secrets** tab → new secret `LOCK_BOT_PRIVATE_KEY` = the full `.pem` contents.
+
+When both are present the workflow mints a per-run App token (~1 h lifetime, so security-equivalent to `GITHUB_TOKEN`) and the lockfile-sync push re-triggers the required checks. When they are absent the workflow falls back to `GITHUB_TOKEN` and the manual close/reopen is still required.
+
 ## 2) (Optional) Bootstrap labels and milestones
 
 If you use the included scripts:


### PR DESCRIPTION
## Problem

`sync-bun-lock.yml` (the `pull_request_target` workflow that regenerates `bun.lock` on Dependabot npm PRs) pushes the synced lockfile commit with `GITHUB_TOKEN`. GitHub deliberately does **not** let `GITHUB_TOKEN` pushes trigger new workflow runs (recursion guard), so:

- the lockfile-sync commit becomes the PR's HEAD with **no CI run on it**,
- the required status checks (`Frontend (build + lint)`, …) only exist on the parent (Dependabot bump) commit,
- with strict branch protection the PR sits **BLOCKED** until someone manually closes/reopens it.

This was hit live on #113 today (had to close/reopen to unblock).

## Fix

Push the lockfile commit with a **short-lived GitHub App installation token** (`actions/create-github-app-token`) instead. An App token *does* trigger workflows and is minted per-run (~1 h lifetime), so it is security-equivalent to `GITHUB_TOKEN` for this `pull_request_target` job — and strictly safer than a long-lived PAT.

- New `Mint GitHub App token` step, gated on `vars.LOCK_BOT_APP_ID != ''`.
- Checkout token becomes `${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}`.
- **Graceful fallback:** with the App not configured the workflow behaves exactly as today (syncs the lock, manual re-trigger still needed) — so this is safe to merge before the App exists.
- Committer identity unchanged (CI triggering depends on the *push token*, not the commit author).

The `if: github.actor == 'dependabot[bot]'` gate and `contents: write` permission are untouched.

## One-time setup to activate (optional, documented in `docs/RELEASE.md` §1)

Create a GitHub App with **Contents: write**, install it on this repo, then add repo variable `LOCK_BOT_APP_ID` + repo secret `LOCK_BOT_PRIVATE_KEY`. Until then, behaviour is unchanged.