### PR TITLE
chore(security): suppress whsec_ example/test secret-scanning false positives

### DIFF
--- a/.github/secret_scanning.yml
+++ b/.github/secret_scanning.yml
@@ -1,0 +1,12 @@
+# Exclude paths that legitimately contain example/test signing secrets from
+# secret scanning. WebhookEngine implements the Standard Webhooks spec, whose
+# signing-secret prefix `whsec_` collides with Stripe's webhook-secret pattern,
+# so GitHub flags fabricated `whsec_…` doc examples and test vectors as "Stripe
+# Webhook Signing Secret" false positives. These paths never hold live
+# credentials; `src/**` (where real config/secrets would live) stays scanned.
+paths-ignore:
+  - "docs/**"
+  - "samples/**"
+  - "tests/**"
+  - "**/__tests__/**"
+  - "**/*.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Security
 - **Repository security baseline hardened.** Added a root `SECURITY.md` (supported-versions policy + GitHub private-vulnerability-reporting disclosure flow), which also resolves the dangling `/SECURITY.md` reference in `CODEOWNERS`. Added explicit least-privilege `permissions: contents: read` blocks to `ci.yml` and `release.yml` — previously the two highest-privilege workflows ran with the broad default token (Docker Hub / NuGet auth uses repository secrets, not `GITHUB_TOKEN`, so no write scope is needed; `id-token: write` is deliberately omitted while provenance is disabled). Extended Dependabot to the previously-uncovered `/packages/endpoint-manager` npm workspace (vite, tailwindcss, tsup, vitest, typescript, … now tracked). Added `timeout-minutes` to the CI Backend/Frontend/Docker jobs so a hung Testcontainers run can't consume the 6-hour default.
+- **Secret-scanning false-positive suppression.** Added `.github/secret_scanning.yml` with `paths-ignore` for `docs/**`, `samples/**`, `tests/**`, `**/__tests__/**`, and `**/*.md`. WebhookEngine's Standard Webhooks `whsec_` signing-secret prefix collides with Stripe's webhook-secret pattern, so GitHub flagged fabricated `whsec_…` doc examples and test vectors as "Stripe Webhook Signing Secret" alerts. Those paths never hold live credentials; `src/**` stays scanned. (The two existing alerts were resolved as false-positive.)
 
 ## [0.2.2] - 2026-05-29
 


### PR DESCRIPTION
## Problem

The Security tab showed 2 open **secret-scanning** alerts, both *"Stripe Webhook Signing Secret"*:
- `docs/API.md` — an illustrative `whsec_AbCdEf…` example
- `tests/WebhookEngine.Sdk.Tests/WebhookVerifierTests.cs` — a `whsec_…` test vector

Both are **false positives**. WebhookEngine implements the [Standard Webhooks](https://www.standardwebhooks.com/) spec, whose signing-secret prefix `whsec_` is identical to Stripe's webhook-secret pattern — so GitHub's Stripe partner-scanner flags fabricated `whsec_…` example/test values as leaked Stripe secrets (validity: `unknown`, i.e. never verified against Stripe). They are not live credentials.

## Fix

- The two existing alerts were **resolved as `false_positive`** (Security tab is now clean).
- This PR adds **`.github/secret_scanning.yml`** with `paths-ignore` for `docs/**`, `samples/**`, `tests/**`, `**/__tests__/**`, and `**/*.md` so future example/test `whsec_` values don't re-trigger the same alert. The collision is inherent to the project, so without this it recurs on every new doc/test example.

## Trade-off

`paths-ignore` removes those paths from secret scanning entirely. That's acceptable here: real credentials live in CI secrets / env / `appsettings` under `src/**`, which **stays scanned**; the excluded paths only ever hold fabricated examples. If you'd rather keep full coverage and dismiss the occasional false positive by hand instead, this PR can be dropped.