### PR TITLE
chore(release): prepare v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+
+### Security
+
+## [0.3.0] - 2026-06-08
+
+### Added
 - **`WebhookEngine.Sdk` gains `EndpointClient.TestAsync(endpointId, request)`** — the one live `/api/v1/*` route with no SDK coverage. Sends a one-off signed test webhook and returns the live response plus the exact signed request (new models `TestEndpointRequest`, `EndpointTestResult`, `EndpointTestRequestPreview`).
 - **SDK request models gain the fields the API already accepts:** `CreateEventTypeRequest`/`UpdateEventTypeRequest.IdempotencyWindowMinutes`, and `CreateEndpointRequest`/`UpdateEndpointRequest.{AllowedIps, TransformExpression, TransformEnabled}`. Previously SDK callers could not set per-event-type idempotency windows, per-endpoint IP allowlists, or payload-transform expressions at all.
 - **First test coverage for `WebhookEngine.Sdk`** — a new `WebhookEngine.Sdk.Tests` project (32 cases). Covers `WebhookVerifier` constant-time HMAC verification across tolerance, secret-encoding (`whsec_` vs base64), multi-signature, tamper, and missing-field cases, plus a stub-`HttpMessageHandler` contract suite that deserializes real API envelopes through the client (exercising the SDK's own camelCase options) so response-DTO drift fails CI.

--- a/src/WebhookEngine.Sdk/WebhookEngine.Sdk.csproj
+++ b/src/WebhookEngine.Sdk/WebhookEngine.Sdk.csproj
@@ -8,7 +8,7 @@
 
     <!-- NuGet package metadata -->
     <PackageId>WebhookEngine.Sdk</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.3.0</Version>
     <Authors>WebhookEngine</Authors>
     <Description>.NET SDK for WebhookEngine — self-hosted webhook delivery platform. Send webhooks, manage endpoints and event types, retry failed deliveries.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary

- Renames `## [Unreleased]` → `## [0.3.0] - 2026-06-08` in `CHANGELOG.md`
- Inserts a fresh empty `## [Unreleased]` skeleton above it
- Bumps `WebhookEngine.Sdk` `<Version>` from `0.2.0` to `0.3.0` for cosmetic consistency (NuGet version is driven by the git tag via `release.yml`)

## Checklist

- [x] Pre-release local checks all green (build 0 errors/warnings, 312 tests passed, frontend lint + typecheck + build clean)
- [x] CHANGELOG `[Unreleased]` block accurately summarizes all user-visible changes
- [x] SDK `<Version>` aligned to `0.3.0`
- [x] No AI-attribution lines anywhere