### PR TITLE
fix(api): require authentication on the SignalR delivery hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Removed
 
 ### Security
+- **The real-time delivery hub now requires authentication (cross-tenant leak fix).** `/hubs/deliveries` was mapped with no authorization and `DeliveryHub` carried no `[Authorize]`, while the notifier fans every delivery event out to `Clients.All` — so any anonymous client that could reach the host could open a websocket and receive the system-wide delivery firehose for **all** applications (message IDs, endpoint IDs, per-attempt error strings that leak other tenants' endpoint hostnames, latencies, and circuit-state transitions), defeating the AppId isolation the rest of the system enforces. The hub now requires the dashboard cookie scheme (`[Authorize(AuthenticationSchemes = CookieAuthenticationDefaults.AuthenticationScheme)]` on the hub plus `.RequireAuthorization()` on the `MapHub` mapping so the `/negotiate` endpoint is gated too). The operator dashboard is unaffected — it already connects same-origin with the session cookie. A negotiate-handshake integration test (anonymous → redirect to login, authenticated → `200`) locks the guard in place.
 
 ## [0.3.1] - 2026-06-29
 

--- a/src/WebhookEngine.API/Hubs/DeliveryHub.cs
+++ b/src/WebhookEngine.API/Hubs/DeliveryHub.cs
@@ -1,30 +1,18 @@
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 using WebhookEngine.Core.Enums;
 using WebhookEngine.Core.Interfaces;
 
 namespace WebhookEngine.API.Hubs;
 
-/// <summary>
-/// SignalR hub for real-time delivery status updates.
-/// Dashboard clients connect to receive live delivery events.
-/// </summary>
+// Cookie-only: the event stream spans all applications and carries cross-tenant detail.
+[Authorize(AuthenticationSchemes = CookieAuthenticationDefaults.AuthenticationScheme)]
 public class DeliveryHub : Hub
 {
-    public override async Task OnConnectedAsync()
-    {
-        await base.OnConnectedAsync();
-    }
-
-    public override async Task OnDisconnectedAsync(Exception? exception)
-    {
-        await base.OnDisconnectedAsync(exception);
-    }
 }
 
-/// <summary>
-/// IDeliveryNotifier implementation that pushes events to all connected SignalR clients.
-/// Registered as a singleton in DI so workers can resolve it.
-/// </summary>
+// Singleton IDeliveryNotifier so workers can resolve it; fans events out to all clients.
 public class SignalRDeliveryNotifier : IDeliveryNotifier
 {
     private readonly IHubContext<DeliveryHub> _hubContext;

--- a/src/WebhookEngine.API/Program.cs
+++ b/src/WebhookEngine.API/Program.cs
@@ -372,7 +372,7 @@ app.UseAuthorization();
 app.UseStaticFiles(); // Serve React dashboard from wwwroot
 
 app.MapControllers();
-app.MapHub<DeliveryHub>("/hubs/deliveries");
+app.MapHub<DeliveryHub>("/hubs/deliveries").RequireAuthorization();
 app.MapPrometheusScrapingEndpoint(); // GET /metrics
 
 if (app.Environment.IsDevelopment() || app.Environment.IsStaging())

--- a/tests/WebhookEngine.API.Tests/Integration/DeliveryHubAuthorizationTests.cs
+++ b/tests/WebhookEngine.API.Tests/Integration/DeliveryHubAuthorizationTests.cs
@@ -1,0 +1,111 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using WebhookEngine.API.Auth;
+using WebhookEngine.Core.Entities;
+using WebhookEngine.Infrastructure.Data;
+
+namespace WebhookEngine.API.Tests.Integration;
+
+// Regression guard: DeliveryHub fans cross-tenant events to Clients.All, so its
+// negotiate endpoint must reject anonymous callers (asserted over the plain-HTTP
+// negotiate POST, which the auth pipeline gates before any hub code runs).
+public class DeliveryHubAuthorizationTests : IClassFixture<TestWebApplicationFactory>
+{
+    private const string DashboardEmail = "hub-admin@test.local";
+    private const string DashboardPassword = "P@ssw0rd-123";
+    private const string NegotiatePath = "/hubs/deliveries/negotiate?negotiateVersion=1";
+
+    private readonly TestWebApplicationFactory _factory;
+
+    public DeliveryHubAuthorizationTests(TestWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    // Load-bearing: pre-fix this returned 200 and leaked every tenant's events.
+    // Cookie auth 401s only /api paths; /hubs challenges fall through to a 302 login redirect.
+    [Fact]
+    public async Task DeliveryHub_Negotiate_Without_Cookie_Redirects_To_Login()
+    {
+        await ResetDatabaseAsync();
+        using var client = CreateClient();
+
+        var response = await client.PostAsync(NegotiatePath, new StringContent(string.Empty));
+
+        response.StatusCode.Should().NotBe(
+            HttpStatusCode.OK,
+            "an anonymous client must never complete the negotiate handshake for the cross-tenant delivery hub");
+        response.StatusCode.Should().Be(
+            HttpStatusCode.Redirect,
+            "cookie auth challenges non-/api paths with a 302 to the login page");
+
+        response.Headers.Location.Should().NotBeNull();
+        var location = response.Headers.Location!.ToString();
+        location.Should().Contain("/Account/Login", "the challenge redirects to the dashboard login path");
+        location.Should().Contain("hubs", "the return-url must round-trip the original hub negotiate path");
+    }
+
+    // Positive counterpart: a cookie-authed operator must still negotiate — this stops
+    // anyone from silencing the negative test by breaking auth for everyone.
+    [Fact]
+    public async Task DeliveryHub_Negotiate_With_Cookie_Returns_200_OK()
+    {
+        await ResetDatabaseAsync();
+        using var client = CreateClient();
+        await AuthenticateDashboardAsync(client);
+
+        var response = await client.PostAsync(NegotiatePath, new StringContent(string.Empty));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("connectionId", "a successful negotiate returns a SignalR connection descriptor");
+    }
+
+    // ── Plumbing (mirrors AuditLoggingTests) ───────────────────────────────
+
+    private HttpClient CreateClient()
+    {
+        return _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            HandleCookies = true
+        });
+    }
+
+    private async Task ResetDatabaseAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+        await db.Database.EnsureDeletedAsync();
+        await db.Database.EnsureCreatedAsync();
+    }
+
+    private async Task AuthenticateDashboardAsync(HttpClient client)
+    {
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WebhookDbContext>();
+            if (!await db.DashboardUsers.AnyAsync(u => u.Email == DashboardEmail))
+            {
+                db.DashboardUsers.Add(new DashboardUser
+                {
+                    Email = DashboardEmail,
+                    PasswordHash = PasswordHasher.HashPassword(DashboardPassword),
+                    Role = "admin"
+                });
+                await db.SaveChangesAsync();
+            }
+        }
+
+        var loginResponse = await client.PostAsJsonAsync("/api/v1/auth/login", new
+        {
+            email = DashboardEmail,
+            password = DashboardPassword
+        });
+        loginResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}


### PR DESCRIPTION
## Summary

`/hubs/deliveries` was mapped with **no authorization** and `DeliveryHub` carried no `[Authorize]`, while `SignalRDeliveryNotifier` fans every delivery event out to `Clients.All`. Any anonymous client that could reach the host could open a websocket and receive the **system-wide delivery firehose for all applications** — message IDs, endpoint IDs, per-attempt error strings (which leak other tenants' endpoint hostnames), latencies, and circuit-state transitions. This defeats the AppId isolation the rest of the system carefully enforces.

Found by a full-codebase security audit; this is the highest-severity finding (an unauthenticated cross-tenant data leak).

## Fix

- `[Authorize(AuthenticationSchemes = CookieAuthenticationDefaults.AuthenticationScheme)]` on `DeliveryHub` (guards hub invocations).
- `.RequireAuthorization()` on `app.MapHub<DeliveryHub>("/hubs/deliveries")` (guards the `/negotiate` endpoint).
- `Clients.All` is **retained by design** — the operator dashboard is a global admin (`DashboardUser.Role = "admin"`, no AppId claim) and is the only consumer. No per-AppId grouping, since there is no customer-facing feed today; that would be scope creep.

## Impact / compatibility

The operator dashboard is unaffected: it connects same-origin (`.withUrl("/hubs/deliveries")`) with the session cookie, which flows on both the negotiate `POST` and the websocket upgrade (`SameSite=Lax`, `Secure=Always` — both satisfied same-origin over HTTPS). Anonymous/expired-session clients now get a redirect to login on negotiate, which the client's existing capped-backoff reconnect + `auth-expired` flow already handles gracefully. The `@webhookengine/endpoint-manager` portal package does not use SignalR, so it is unaffected.

## Tests

New `DeliveryHubAuthorizationTests` (negotiate handshake, real cookie login via `TestWebApplicationFactory`):
- anonymous negotiate → **302 redirect to `/Account/Login`** (the cookie handler returns 401 only for `/api` paths; `/hubs` falls through to the login redirect)
- authenticated negotiate → **200** with a `connectionId`

Mutation-verified: with the guard removed the negative test goes red (the leak reproduces); with the guard restored both pass. Full API suite green (124 tests).